### PR TITLE
Cross-platform GUI launcher + pure-Python UDPBD server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,11 @@ __pycache__/
 venv/
 env/
 
-# Nuitka build output (from smbv1_server/build_exe.ps1)
+# Nuitka build output (from smbv1_server/build_exe.ps1 and build/build.py)
 *.build/
 *.dist/
 *.onefile-build/
+/dist/
 
 # OS cruft
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,14 +1,59 @@
 # PS2-Servers
 
 Network servers for loading PlayStation 2 games and apps over a LAN with
-[Open PS2 Loader](https://github.com/ps2homebrew/Open-PS2-Loader) (OPL) and forks.
-Three independent servers, pick whichever transport your setup uses:
+[Open PS2 Loader](https://github.com/ps2homebrew/Open-PS2-Loader) (OPL) and forks —
+plus a small **GUI launcher** so anyone can run them without touching a terminal.
 
-| Folder | Server | What it is |
-|--------|--------|------------|
-| [`smbv1_server/`](smbv1_server/) | **RiptOPL SMBv1 server** | A tiny, dependency-free SMBv1/CIFS server so OPL's SMB game-loading keeps working even on Windows 11 hosts where the OS has removed SMB1/NTLMv1. Pure Python 3 stdlib. |
-| [`udpbd_server/`](udpbd_server/) | **UDPBD server** | Prebuilt `udpbd-server.exe` — serves a block device to OPL over the UDPBD protocol. |
-| [`udpfs_server/`](udpfs_server/) | **UDPFS server** | Python UDPFS server with on-the-fly handlers for compressed ISO formats (CHD / CSO / ZSO) under [`compressed_iso/`](udpfs_server/compressed_iso/). |
+## Quick start — the launcher
 
-See each folder's own README / source for usage details. The SMBv1 server's
-[README](smbv1_server/README.md) is the most complete walkthrough.
+The launcher lets you pick a server, choose your games folder, and click **Start**.
+It detects your PC's LAN IP and shows the exact settings to enter in OPL.
+
+- **Packaged app (no Python needed):** double-click **`PS2Servers`** (`.exe` on
+  Windows) — see [Build the app](#build-the-single-file-app) to produce it.
+- **From source:** double-click **`Start-Launcher.bat`** (Windows) or run
+  `./start-launcher.sh` (Linux/macOS). Requires Python 3.
+
+![one card per server: pick a folder, Start, and it shows the OPL settings]
+
+## What's inside
+
+All three servers are pure-Python (standard library) and run on Windows, Linux and macOS.
+
+| Folder | Server | What it does |
+|--------|--------|--------------|
+| [`smbv1_server/`](smbv1_server/) | **SMBv1 (RiptOPL)** | Shares a games folder over SMB — works even on Windows 11 where the OS removed SMB1. |
+| [`udpfs_server/`](udpfs_server/) | **UDPFS** | Serves a folder and/or disk image over UDP; can transparently decompress CHD/CSO/ZSO. |
+| [`udpbd_server/`](udpbd_server/) | **UDPBD** | Serves a disk image as a block device over UDP; the PS2 auto-discovers it. |
+
+`udpbd_server/udpbd_server.py` is a pure-Python port of Rick Gaiser's UDPBD server —
+see [its provenance](udpbd_server/SOURCE.md). UDPBD has largely been superseded by UDPFS.
+
+## Run a server on its own (terminal)
+
+Each server still runs standalone, and the launcher can run them too:
+
+```sh
+python smbv1_server/smbserver_opl.py --share games=D:/PS2Games
+python udpfs_server/udpfs_server.py  -d D:/PS2Games --enable-compression
+python udpbd_server/udpbd_server.py  D:/PS2Games/game.iso
+# or, via the launcher engine:
+python -m launcher --serve udpfs -d D:/PS2Games
+python -m launcher --list            # show servers available on this machine
+```
+
+## Build the single-file app
+
+[Nuitka](https://nuitka.net) bundles the launcher and all three servers into one
+executable per OS — no Python install required for the end user:
+
+```sh
+python -m pip install nuitka
+python build/build.py            # -> dist/PS2Servers(.exe)
+```
+
+## Status
+
+The UDPBD port is validated by `udpbd_server/selftest.py` at the protocol level
+(INFO/READ/WRITE byte-for-byte). As with the SMBv1 server, **final validation is on
+real hardware** — an actual PS2 running OPL, or PCSX2 with a network adapter.

--- a/Start-Launcher.bat
+++ b/Start-Launcher.bat
@@ -1,0 +1,11 @@
+@echo off
+REM Launch the PS2 Servers GUI from source (Windows).
+REM The packaged .exe will not need Python; this script is for running from source.
+cd /d "%~dp0"
+python -m launcher
+if errorlevel 9009 (
+  echo.
+  echo Python 3 was not found on your PATH.
+  echo Install it from https://www.python.org/downloads/ and try again.
+  pause
+)

--- a/build/build.py
+++ b/build/build.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Build a single-file PS2 Servers executable with Nuitka.
+
+    python -m pip install nuitka
+    python build/build.py
+
+Produces dist/PS2Servers (.exe on Windows) that bundles the Tkinter launcher and
+all three Python servers, so an end user needs no Python install -- they double
+click one file.
+
+How the bundling works
+----------------------
+The launcher loads each server module *by file path at runtime* (see
+launcher/serve.py), and UDPFS imports its `compressed_iso` package. Nuitka cannot
+see those dynamic imports, so we ship the server sources as data laid out at the
+same relative paths the launcher expects (REPO_ROOT/<server_dir>/...). Inside the
+onefile bundle REPO_ROOT resolves to the extraction dir, so the same path logic
+works unchanged.
+"""
+
+import os
+import platform
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# server sources shipped as data at their original relative paths
+DATA_FILES = [
+    "smbv1_server/smbserver_opl.py",
+    "udpfs_server/udpfs_server.py",
+    "udpbd_server/udpbd_server.py",
+]
+DATA_DIRS = [
+    "udpfs_server/compressed_iso",  # imported by udpfs_server at runtime
+]
+
+
+def main():
+    system = platform.system()
+    out = "PS2Servers.exe" if system == "Windows" else "PS2Servers"
+
+    cmd = [
+        sys.executable, "-m", "nuitka",
+        "--onefile",
+        "--enable-plugin=tk-inter",
+        "--assume-yes-for-downloads",
+        "--output-dir=" + os.path.join(ROOT, "dist"),
+        "--output-filename=" + out,
+        "--company-name=PS2-Servers",
+        "--product-name=PS2 Servers",
+        "--product-version=0.1.0",
+        "--file-version=0.1.0",
+    ]
+    for rel in DATA_FILES:
+        cmd.append("--include-data-files={}={}".format(os.path.join(ROOT, rel), rel))
+    for rel in DATA_DIRS:
+        cmd.append("--include-data-dir={}={}".format(os.path.join(ROOT, rel), rel))
+
+    if system == "Windows":
+        cmd.append("--windows-console-mode=disable")
+    elif system == "Darwin":
+        cmd.append("--macos-create-app-bundle")
+
+    cmd.append(os.path.join(ROOT, "ps2servers.py"))
+
+    print("Running:\n  " + " \\\n  ".join(cmd) + "\n")
+    return subprocess.call(cmd, cwd=ROOT)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/build.py
+++ b/build/build.py
@@ -25,14 +25,17 @@ import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-# server sources shipped as data at their original relative paths
+# Server sources shipped as data at their original relative paths -- the launcher
+# loads these by file path at runtime (Nuitka can't see those dynamic imports).
 DATA_FILES = [
     "smbv1_server/smbserver_opl.py",
     "udpfs_server/udpfs_server.py",
     "udpbd_server/udpbd_server.py",
 ]
-DATA_DIRS = [
-    "udpfs_server/compressed_iso",  # imported by udpfs_server at runtime
+# udpfs_server.py does `from compressed_iso import ...` on load. --include-data-dir
+# skips .py files, so compile it in as a real package instead (importable anywhere).
+INCLUDE_PACKAGES = [
+    "compressed_iso",
 ]
 
 
@@ -54,8 +57,8 @@ def main():
     ]
     for rel in DATA_FILES:
         cmd.append("--include-data-files={}={}".format(os.path.join(ROOT, rel), rel))
-    for rel in DATA_DIRS:
-        cmd.append("--include-data-dir={}={}".format(os.path.join(ROOT, rel), rel))
+    for pkg in INCLUDE_PACKAGES:
+        cmd.append("--include-package=" + pkg)
 
     if system == "Windows":
         cmd.append("--windows-console-mode=disable")
@@ -64,8 +67,13 @@ def main():
 
     cmd.append(os.path.join(ROOT, "ps2servers.py"))
 
+    # compressed_iso lives under udpfs_server/, so make it importable for Nuitka.
+    env = os.environ.copy()
+    env["PYTHONPATH"] = (os.path.join(ROOT, "udpfs_server") + os.pathsep
+                         + env.get("PYTHONPATH", ""))
+
     print("Running:\n  " + " \\\n  ".join(cmd) + "\n")
-    return subprocess.call(cmd, cwd=ROOT)
+    return subprocess.call(cmd, cwd=ROOT, env=env)
 
 
 if __name__ == "__main__":

--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -1,0 +1,10 @@
+"""PS2-Servers launcher.
+
+A small GUI/engine that lets any user pick and run one or more of the PS2 OPL
+network servers (SMBv1, UDPBD, UDPFS) without touching a terminal.
+
+This package is intentionally dependency-free (Python standard library only) so
+it stays antivirus-clean and bundles cleanly into a single executable per OS.
+"""
+
+__version__ = "0.1.0"

--- a/launcher/__main__.py
+++ b/launcher/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+from .main import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/launcher/config.py
+++ b/launcher/config.py
@@ -1,0 +1,42 @@
+"""Persisted launcher settings (last-used folders, ports, toggles).
+
+Stored as JSON in the per-user config location for each OS so the GUI can
+remember what the user picked between runs.
+"""
+
+import json
+import os
+import platform
+
+APP_NAME = "PS2-Servers"
+
+
+def config_dir():
+    system = platform.system()
+    if system == "Windows":
+        base = os.environ.get("APPDATA") or os.path.expanduser("~")
+        return os.path.join(base, APP_NAME)
+    if system == "Darwin":
+        return os.path.join(os.path.expanduser("~/Library/Application Support"), APP_NAME)
+    base = os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config")
+    return os.path.join(base, "ps2-servers")
+
+
+def config_path():
+    return os.path.join(config_dir(), "launcher.json")
+
+
+def load():
+    try:
+        with open(config_path(), "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data if isinstance(data, dict) else {}
+    except (FileNotFoundError, ValueError, OSError):
+        return {}
+
+
+def save(data):
+    directory = config_dir()
+    os.makedirs(directory, exist_ok=True)
+    with open(config_path(), "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)

--- a/launcher/elevate.py
+++ b/launcher/elevate.py
@@ -1,0 +1,50 @@
+"""Windows UAC elevation for the one option that needs admin rights.
+
+Only SMBv1's ``--take-445`` needs administrator privileges (it pauses Windows'
+LanmanServer to bind the standard port 445). Managing a single elevated child
+from a non-elevated parent is painful on Windows (UIPI blocks piping and
+termination), so instead we relaunch the *whole* launcher elevated -- then every
+server still streams its logs and stops normally.
+"""
+
+import os
+import platform
+import sys
+
+from .servers import REPO_ROOT, is_frozen
+
+
+def is_admin():
+    """True if this process already has administrator/root rights."""
+    if platform.system() == "Windows":
+        try:
+            import ctypes
+            return bool(ctypes.windll.shell32.IsUserAnAdmin())
+        except Exception:
+            return False
+    try:
+        return os.geteuid() == 0
+    except AttributeError:
+        return False
+
+
+def can_elevate():
+    """Whether we can offer to relaunch elevated on this platform."""
+    return platform.system() == "Windows"
+
+
+def relaunch_as_admin():
+    """Relaunch the launcher elevated via a UAC prompt. Returns True if launched."""
+    if platform.system() != "Windows":
+        return False
+    try:
+        import ctypes
+        if is_frozen():
+            exe, params, cwd = sys.executable, "", None
+        else:  # from source: re-run `python -m launcher` from the repo root
+            exe, params, cwd = sys.executable, "-m launcher", REPO_ROOT
+        # ShellExecuteW returns a value > 32 on success.
+        rc = ctypes.windll.shell32.ShellExecuteW(None, "runas", exe, params, cwd, 1)
+        return rc > 32
+    except Exception:
+        return False

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -1,0 +1,351 @@
+"""Tkinter GUI -- the front-end any user sees.
+
+One card per server: pick a folder/file, hit Start, and the card shows exactly
+what to enter in OPL plus a live log. No terminal required. The GUI never blocks
+on a server; each runs as a subprocess (see process.py) and its output is pumped
+to the log via a thread-safe queue drained on the Tk main thread.
+"""
+
+import platform
+import queue
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+from . import config, netinfo
+from .process import ServerProcess
+from .servers import REGISTRY, REPO_ROOT
+
+DOT_RUNNING = "●"  # filled circle
+COLOR_RUNNING = "#2e9e44"
+COLOR_STOPPED = "#b0b0b0"
+COLOR_ERROR = "#d23c3c"
+
+
+def opl_hint(key, ip, values):
+    if key == "smbv1":
+        port = str(values.get("port") or 1445)
+        return ("In OPL → Network:  IP {}  ·  Port {}  ·  Share 'games'  "
+                "·  NetBIOS off  ·  user/pass blank".format(ip, port))
+    if key == "udpfs":
+        return "In OPL → select UDPFS  ·  server IP {} (if prompted)".format(ip)
+    if key == "udpbd":
+        return "In OPL → select UDPBD  ·  auto-discovered (no IP or port needed)"
+    return ""
+
+
+class ServerCard(ttk.LabelFrame):
+    """One server's controls, status and OPL hint."""
+
+    def __init__(self, master, app, server):
+        super().__init__(master, text="  " + server.label + "  ")
+        self.app = app
+        self.server = server
+        self.vars = {}
+        self._advanced_shown = False
+        self._build()
+
+    # -- widget construction ---------------------------------------------- #
+    def _build(self):
+        self.columnconfigure(1, weight=1)
+        row = 0
+
+        # header: blurb + status + start/stop
+        ttk.Label(self, text=self.server.blurb, wraplength=560,
+                  foreground="#555").grid(row=row, column=0, columnspan=3,
+                                          sticky="w", padx=8, pady=(6, 2))
+        row += 1
+
+        self.status = ttk.Label(self, text=DOT_RUNNING + " Stopped",
+                                foreground=COLOR_STOPPED)
+        self.status.grid(row=row, column=0, sticky="w", padx=8)
+        self.toggle_btn = ttk.Button(self, text="Start", width=10,
+                                     command=self.on_toggle)
+        self.toggle_btn.grid(row=row, column=2, sticky="e", padx=8, pady=2)
+        if not self.server.is_available():
+            self.status.config(text="n/a on this OS", foreground=COLOR_ERROR)
+            self.toggle_btn.config(state="disabled")
+        row += 1
+
+        # primary fields, then advanced fields (hidden behind a toggle)
+        primary = [f for f in self.server.fields if not f.advanced]
+        advanced = [f for f in self.server.fields if f.advanced]
+        for f in primary:
+            row = self._add_field(self, f, row)
+
+        if advanced:
+            self.adv_btn = ttk.Button(self, text="Advanced ▸", width=14,
+                                      command=self._toggle_advanced)
+            self.adv_btn.grid(row=row, column=0, sticky="w", padx=8, pady=2)
+            row += 1
+            self.adv_frame = ttk.Frame(self)
+            self.adv_frame.grid(row=row, column=0, columnspan=3, sticky="ew")
+            self.adv_frame.columnconfigure(1, weight=1)
+            self.adv_frame.grid_remove()
+            arow = 0
+            for f in advanced:
+                arow = self._add_field(self.adv_frame, f, arow)
+            row += 1
+
+        self.hint = ttk.Label(self, text="", foreground="#1c6db5", wraplength=620)
+        self.hint.grid(row=row, column=0, columnspan=3, sticky="w", padx=8, pady=(2, 6))
+
+    def _add_field(self, parent, f, row):
+        if f.kind == "bool":
+            var = tk.BooleanVar(value=bool(f.default))
+            ttk.Checkbutton(parent, text=f.label, variable=var).grid(
+                row=row, column=0, columnspan=3, sticky="w", padx=8, pady=1)
+            self.vars[f.key] = var
+            return row + 1
+
+        ttk.Label(parent, text=f.label + ":").grid(row=row, column=0, sticky="w",
+                                                   padx=8, pady=1)
+        if f.kind == "port":
+            var = tk.StringVar(value=self.server.port_display())
+            ttk.Entry(parent, textvariable=var, width=12).grid(
+                row=row, column=1, sticky="w", padx=4, pady=1)
+        elif f.kind in ("folder", "file"):
+            var = tk.StringVar(value="")
+            ttk.Entry(parent, textvariable=var).grid(
+                row=row, column=1, sticky="ew", padx=4, pady=1)
+            ttk.Button(parent, text="Browse…", width=10,
+                       command=lambda v=var, k=f.kind: self._browse(v, k)).grid(
+                row=row, column=2, sticky="e", padx=8, pady=1)
+        else:  # text
+            var = tk.StringVar(value=str(f.default or ""))
+            ttk.Entry(parent, textvariable=var).grid(
+                row=row, column=1, sticky="ew", padx=4, pady=1)
+        self.vars[f.key] = var
+        row += 1
+        if f.help:  # on its own row so it never overlaps the entry/Browse button
+            ttk.Label(parent, text=f.help, foreground="#888", font=("", 8)).grid(
+                row=row, column=1, columnspan=2, sticky="w", padx=4, pady=(0, 2))
+            row += 1
+        return row
+
+    def _toggle_advanced(self):
+        self._advanced_shown = not self._advanced_shown
+        if self._advanced_shown:
+            self.adv_frame.grid()
+            self.adv_btn.config(text="Advanced ▾")
+        else:
+            self.adv_frame.grid_remove()
+            self.adv_btn.config(text="Advanced ▸")
+
+    def _browse(self, var, kind):
+        path = (filedialog.askdirectory() if kind == "folder"
+                else filedialog.askopenfilename())
+        if path:
+            var.set(path)
+
+    # -- values / config --------------------------------------------------- #
+    def values(self):
+        out = {}
+        for key, var in self.vars.items():
+            v = var.get()
+            if isinstance(v, str):
+                v = v.strip()
+            if v not in ("", False, None):
+                out[key] = v
+        return out
+
+    def set_values(self, saved):
+        for key, var in self.vars.items():
+            if key in saved:
+                var.set(saved[key])
+
+    # -- lifecycle --------------------------------------------------------- #
+    def on_toggle(self):
+        if self.app.is_running(self.server.key):
+            self.app.stop_server(self.server.key)
+        else:
+            self.app.start_server(self.server.key)
+
+    def refresh_status(self, running, error=False):
+        if error:
+            self.status.config(text=DOT_RUNNING + " Error", foreground=COLOR_ERROR)
+        elif running:
+            self.status.config(text=DOT_RUNNING + " Running", foreground=COLOR_RUNNING)
+        else:
+            self.status.config(text=DOT_RUNNING + " Stopped", foreground=COLOR_STOPPED)
+        self.toggle_btn.config(text="Stop" if running else "Start")
+        if running:
+            self.hint.config(text=opl_hint(self.server.key, self.app.current_ip(),
+                                           self.values()))
+        else:
+            self.hint.config(text="")
+
+
+class LauncherApp:
+    def __init__(self, root):
+        self.root = root
+        self.procs = {}
+        self.cards = {}
+        self.out_queue = queue.Queue()
+        self.logs = {}
+        self.saved = config.load()
+
+        root.title("PS2 Servers")
+        root.minsize(720, 600)
+        self._build()
+        self._restore()
+
+        root.protocol("WM_DELETE_WINDOW", self.on_close)
+        self.root.after(150, self._drain_logs)
+        self.root.after(600, self._poll_status)
+
+    def _build(self):
+        # header: LAN IP the user types into OPL
+        header = ttk.Frame(self.root)
+        header.pack(fill="x", padx=10, pady=(10, 4))
+        ttk.Label(header, text="Your PC's LAN IP:", font=("", 10, "bold")).pack(side="left")
+        self.ip_var = tk.StringVar(value=netinfo.best_lan_ip())
+        self.ip_combo = ttk.Combobox(header, textvariable=self.ip_var, width=18,
+                                     values=netinfo.all_ipv4(), state="readonly")
+        self.ip_combo.pack(side="left", padx=6)
+        ttk.Button(header, text="Refresh", command=self._refresh_ips).pack(side="left")
+        ttk.Label(header, text="  (enter this in OPL where it asks for the PC/server IP)",
+                  foreground="#888").pack(side="left")
+
+        # server cards
+        cards = ttk.Frame(self.root)
+        cards.pack(fill="x", padx=10, pady=4)
+        for server in REGISTRY.values():
+            card = ServerCard(cards, self, server)
+            card.pack(fill="x", pady=5)
+            self.cards[server.key] = card
+
+        # logs
+        logframe = ttk.LabelFrame(self.root, text="  Logs  ")
+        logframe.pack(fill="both", expand=True, padx=10, pady=(4, 6))
+        self.nb = ttk.Notebook(logframe)
+        self.nb.pack(fill="both", expand=True, padx=4, pady=4)
+        for server in REGISTRY.values():
+            txt = tk.Text(self.nb, height=8, wrap="none", state="disabled",
+                          background="#101418", foreground="#d8dee9",
+                          insertbackground="#d8dee9")
+            self.nb.add(txt, text=server.label)
+            self.logs[server.key] = txt
+
+        # footer
+        footer = ttk.Frame(self.root)
+        footer.pack(fill="x", padx=10, pady=(0, 10))
+        ttk.Button(footer, text="Stop all", command=self.stop_all).pack(side="right")
+
+    # -- IP --------------------------------------------------------------- #
+    def current_ip(self):
+        return self.ip_var.get()
+
+    def _refresh_ips(self):
+        self.ip_combo.config(values=netinfo.all_ipv4())
+        self.ip_var.set(netinfo.best_lan_ip())
+        for key in self.procs:
+            self.cards[key].refresh_status(self.is_running(key))
+
+    # -- run/stop --------------------------------------------------------- #
+    def is_running(self, key):
+        p = self.procs.get(key)
+        return p is not None and p.is_running()
+
+    def start_server(self, key):
+        card = self.cards[key]
+        server = REGISTRY[key]
+        values = card.values()
+
+        missing = [f.label for f in server.fields
+                   if f.required and not values.get(f.key)]
+        if missing:
+            messagebox.showerror("Missing input",
+                                 "Please set: " + ", ".join(missing))
+            return
+        try:
+            command = server.launch_command(values)
+        except Exception as e:
+            messagebox.showerror("Cannot start", str(e))
+            return
+
+        self._append_log(key, "[launcher] starting: {}\n".format(" ".join(command)))
+        proc = ServerProcess(key, command, cwd=REPO_ROOT, on_output=self._on_output)
+        try:
+            proc.start()
+        except OSError as e:
+            messagebox.showerror("Cannot start", str(e))
+            card.refresh_status(False, error=True)
+            return
+        self.procs[key] = proc
+        card.refresh_status(True)
+        self.nb.select(list(REGISTRY).index(key))
+
+    def stop_server(self, key):
+        proc = self.procs.get(key)
+        if proc:
+            proc.stop()
+        self.cards[key].refresh_status(False)
+        self._append_log(key, "[launcher] stopped\n")
+
+    def stop_all(self):
+        for key in list(self.procs):
+            self.stop_server(key)
+
+    # -- logging (thread-safe) ------------------------------------------- #
+    def _on_output(self, key, line):
+        self.out_queue.put((key, line + "\n"))
+
+    def _drain_logs(self):
+        try:
+            while True:
+                key, line = self.out_queue.get_nowait()
+                self._append_log(key, line)
+        except queue.Empty:
+            pass
+        self.root.after(150, self._drain_logs)
+
+    def _append_log(self, key, text):
+        widget = self.logs[key]
+        widget.config(state="normal")
+        widget.insert("end", text)
+        widget.see("end")
+        widget.config(state="disabled")
+
+    # -- status polling --------------------------------------------------- #
+    def _poll_status(self):
+        for key, proc in self.procs.items():
+            running = proc.is_running()
+            current = self.cards[key].toggle_btn.cget("text") == "Stop"
+            if current and not running:  # server exited on its own
+                self.cards[key].refresh_status(False)
+                self._append_log(key, "[launcher] server exited (code {})\n".format(
+                    proc.returncode))
+        self.root.after(600, self._poll_status)
+
+    # -- config ----------------------------------------------------------- #
+    def _restore(self):
+        servers = self.saved.get("servers", {})
+        for key, card in self.cards.items():
+            card.set_values(servers.get(key, {}))
+        ip = self.saved.get("ip")
+        if ip and ip in netinfo.all_ipv4():
+            self.ip_var.set(ip)
+
+    def _save(self):
+        data = {"servers": {key: card.values() for key, card in self.cards.items()},
+                "ip": self.ip_var.get()}
+        try:
+            config.save(data)
+        except OSError:
+            pass
+
+    def on_close(self):
+        self._save()
+        self.stop_all()
+        self.root.destroy()
+
+
+def run_gui():
+    root = tk.Tk()
+    try:
+        ttk.Style().theme_use("vista" if platform.system() == "Windows" else "clam")
+    except tk.TclError:
+        pass
+    LauncherApp(root)
+    root.mainloop()
+    return 0

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -11,7 +11,7 @@ import queue
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 
-from . import config, netinfo
+from . import config, elevate, netinfo
 from .process import ServerProcess
 from .servers import REGISTRY, REPO_ROOT
 
@@ -257,6 +257,27 @@ class LauncherApp:
             messagebox.showerror("Missing input",
                                  "Please set: " + ", ".join(missing))
             return
+
+        if key == "smbv1" and values.get("take_445") and not elevate.is_admin():
+            if not elevate.can_elevate():
+                messagebox.showerror(
+                    "Administrator required",
+                    "'Take port 445' needs Windows administrator rights.")
+                return
+            if messagebox.askyesno(
+                    "Administrator required",
+                    "'Take port 445' needs administrator rights.\n\n"
+                    "Restart the launcher as administrator now? Your settings are "
+                    "saved — then click Start again."):
+                self._save()
+                if elevate.relaunch_as_admin():
+                    self.root.destroy()
+                else:
+                    messagebox.showerror(
+                        "Elevation failed",
+                        "Could not restart as administrator.")
+            return
+
         try:
             command = server.launch_command(values)
         except Exception as e:

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -28,12 +28,13 @@ def main(argv=None):
         _print_list()
         return 0
 
-    # Milestone 2 will launch the Tkinter GUI here.
-    _print_list()
-    print()
-    print("GUI not built yet (Milestone 2). For now, start a server directly, e.g.:")
-    print("  python -m launcher --serve smbv1 --share games=D:/PS2Games")
-    return 0
+    try:
+        from .gui import run_gui
+    except ImportError as e:  # Tkinter not present in this Python build
+        print("GUI unavailable ({}). Servers on this machine:".format(e))
+        _print_list()
+        return 1
+    return run_gui()
 
 
 def _print_list():

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -1,0 +1,50 @@
+"""Launcher entry point.
+
+Normally this opens the GUI (Milestone 2). It also understands two flags used
+internally and for testing:
+
+  --serve <key> [args...]   run one server in this process (re-exec target)
+  --list                    print the servers available on this machine
+"""
+
+import platform
+import sys
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+
+    if "--serve" in argv:
+        i = argv.index("--serve")
+        rest = argv[i + 1:]
+        if not rest:
+            print("error: --serve requires a server key", file=sys.stderr)
+            return 2
+        from .serve import run_serve
+        run_serve(rest[0], rest[1:])
+        return 0
+
+    if "--list" in argv or "-l" in argv:
+        _print_list()
+        return 0
+
+    # Milestone 2 will launch the Tkinter GUI here.
+    _print_list()
+    print()
+    print("GUI not built yet (Milestone 2). For now, start a server directly, e.g.:")
+    print("  python -m launcher --serve smbv1 --share games=D:/PS2Games")
+    return 0
+
+
+def _print_list():
+    from .servers import REGISTRY
+
+    print("PS2-Servers launcher -- servers on this machine ({}):".format(platform.system()))
+    for key, s in REGISTRY.items():
+        mark = "OK " if s.is_available() else "n/a"
+        print("  [{}] {:7s} {:30s} port {:8s} ({})".format(
+            mark, key, s.label, s.port_display(), s.runtime))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/launcher/netinfo.py
+++ b/launcher/netinfo.py
@@ -1,0 +1,70 @@
+"""LAN IP detection.
+
+OPL needs the host's LAN IP typed into its network settings, so the launcher
+surfaces a best-guess address. We deliberately prefer real private-LAN ranges
+(192.168/x, 10/x, 172.16-31/x) over VPN / WSL / link-local addresses, matching
+the warning the SMBv1 server already prints ("usually 192.168.x.x -- NOT a
+VPN/WSL address").
+"""
+
+import socket
+
+
+def primary_ip():
+    """Best outbound-interface IPv4 via the UDP-connect trick (sends no packets)."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("8.8.8.8", 80))
+        return s.getsockname()[0]
+    except OSError:
+        return "127.0.0.1"
+    finally:
+        s.close()
+
+
+def _is_private(ip):
+    if ip.startswith("192.168.") or ip.startswith("10."):
+        return True
+    if ip.startswith("172."):
+        try:
+            return 16 <= int(ip.split(".")[1]) <= 31
+        except (IndexError, ValueError):
+            return False
+    return False
+
+
+def all_ipv4():
+    """All non-loopback, non-link-local IPv4 addresses on this host, sorted."""
+    ips = set()
+    try:
+        for info in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET):
+            ips.add(info[4][0])
+    except OSError:
+        pass
+    ips.add(primary_ip())
+    return sorted(ip for ip in ips if not ip.startswith(("127.", "169.254.")))
+
+
+def _lan_rank(ip):
+    # Lower is better. Prefer common home-LAN ranges; 172.16-31 is frequently a
+    # virtual adapter (WSL / Docker / Hyper-V), so rank it last among privates.
+    if ip.startswith("192.168."):
+        return 0
+    if ip.startswith("10."):
+        return 1
+    if _is_private(ip):
+        return 2
+    return 3
+
+
+def best_lan_ip():
+    """The address most likely to be the one OPL should connect to.
+
+    Prefer the interface that actually routes off-box (the real LAN adapter);
+    this avoids virtual adapters like WSL/Hyper-V (often 172.x).
+    """
+    primary = primary_ip()
+    if not primary.startswith("127."):
+        return primary
+    candidates = sorted(all_ipv4(), key=_lan_rank)
+    return candidates[0] if candidates else "127.0.0.1"

--- a/launcher/process.py
+++ b/launcher/process.py
@@ -1,0 +1,91 @@
+"""Subprocess supervisor.
+
+Each server runs as its own child process; this wraps one with start/stop and
+captures its merged stdout/stderr into a rolling buffer (and an optional live
+callback) so the GUI can show logs without a console window.
+"""
+
+import os
+import platform
+import subprocess
+import threading
+from collections import deque
+
+
+class ServerProcess:
+    def __init__(self, key, command, cwd=None, on_output=None, max_lines=2000):
+        self.key = key
+        self.command = command
+        self.cwd = cwd
+        self.on_output = on_output
+        self.lines = deque(maxlen=max_lines)
+        self.error = None
+        self._proc = None
+        self._reader = None
+
+    def start(self):
+        if self.is_running():
+            return
+        self.lines.clear()
+        self.error = None
+
+        creationflags = 0
+        if platform.system() == "Windows":
+            # Don't pop a console window for the child.
+            creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+        # Unbuffered child stdout so Python servers' logs arrive line-by-line.
+        env = os.environ.copy()
+        env["PYTHONUNBUFFERED"] = "1"
+
+        try:
+            self._proc = subprocess.Popen(
+                self.command,
+                cwd=self.cwd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                bufsize=1,
+                env=env,
+                creationflags=creationflags,
+            )
+        except OSError as e:
+            self.error = str(e)
+            self._emit("[launcher] failed to start: {}".format(e))
+            raise
+
+        self._reader = threading.Thread(target=self._pump, daemon=True)
+        self._reader.start()
+
+    def _pump(self):
+        try:
+            for line in self._proc.stdout:
+                self._emit(line.rstrip("\n"))
+        except (ValueError, OSError):
+            pass  # stream closed during shutdown
+
+    def _emit(self, line):
+        self.lines.append(line)
+        if self.on_output:
+            try:
+                self.on_output(self.key, line)
+            except Exception:
+                pass
+
+    def is_running(self):
+        return self._proc is not None and self._proc.poll() is None
+
+    @property
+    def returncode(self):
+        return self._proc.poll() if self._proc else None
+
+    def stop(self, timeout=5):
+        if not self.is_running():
+            return
+        self._proc.terminate()
+        try:
+            self._proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            self._proc.kill()
+            self._proc.wait()

--- a/launcher/serve.py
+++ b/launcher/serve.py
@@ -1,0 +1,52 @@
+"""--serve dispatch: run one Python server inside this process.
+
+Invoked as `<launcher> --serve <key> [server args...]`. We import the target
+server module by file path (adding its own directory to sys.path so its sibling
+imports, e.g. udpfs's `compressed_iso` package, resolve), then hand control to
+the server's own `main()` exactly as if it had been run directly.
+"""
+
+import importlib.util
+import os
+import sys
+
+
+def _load_module(path):
+    name = "_ps2srv_" + os.path.splitext(os.path.basename(path))[0]
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError("cannot load server module: {}".format(path))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_serve(key, server_args):
+    from .servers import REGISTRY
+
+    # Stream the server's prints line-by-line to our captured pipe instead of
+    # letting Python block-buffer them (works in both source and frozen builds).
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(line_buffering=True)
+        except (AttributeError, ValueError):
+            pass
+
+    server = REGISTRY.get(key)
+    if server is None:
+        raise SystemExit("unknown server: {}".format(key))
+    if server.runtime != "python":
+        raise SystemExit("{} is a native server; run its binary directly".format(key))
+
+    if server.module_dir and server.module_dir not in sys.path:
+        sys.path.insert(0, server.module_dir)
+
+    module = _load_module(server.module_file)
+
+    # Present the args as if the server had been launched on its own.
+    sys.argv = [key] + list(server_args)
+    main = getattr(module, "main", None)
+    if main is None:
+        raise SystemExit("server {} has no main()".format(key))
+    main()

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -145,7 +145,12 @@ def _udpfs_argv(v):
 
 
 def _udpbd_argv(v):
-    return [v["image_file"]]
+    args = [v["image_file"]]
+    if v.get("read_only"):
+        args.append("-r")
+    if v.get("verbose"):
+        args.append("-v")
+    return args
 
 
 # --------------------------------------------------------------------------- #
@@ -203,23 +208,25 @@ UDPFS = ServerDef(
     _build_argv=_udpfs_argv,
 )
 
-# NOTE: UDPBD is currently the interim native .exe (Windows only). It will be
-# replaced by a pure-Python port -- at which point this entry becomes
-# runtime="python" with module_file/module_dir set and available_os = all three,
-# and the rest of the engine is unaffected.
+# Pure-Python port (udpbd_server/udpbd_server.py). Cross-platform; the legacy
+# Windows udpbd-server.exe is kept in the repo only as a fallback and is not used.
 UDPBD = ServerDef(
     key="udpbd",
     label="UDPBD server",
     blurb="Serve a single disk image as a block device over UDP. The PS2 finds "
     "the server automatically (broadcast).",
-    runtime="native",
+    runtime="python",
     default_port=0xBDBD,
     port_is_hex=True,
-    binary_rel={"Windows": "udpbd_server/udpbd-server.exe"},
-    available_os=("Windows",),  # interim: native exe only exists for Windows
+    module_file=_repo("udpbd_server", "udpbd_server.py"),
+    module_dir=_repo("udpbd_server"),
     fields=[
         Field("image_file", "Disk image", "file", required=True,
-              help="A single disk image / block device to serve."),
+              help="A single disk image to serve as a block device."),
+        Field("read_only", "Read-only", "bool", default=False, advanced=True,
+              help="No saves / no VMC writes."),
+        Field("verbose", "Verbose logging", "bool", default=False, advanced=True,
+              help="Log every read/write command."),
     ],
     _build_argv=_udpbd_argv,
 )

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -95,6 +95,8 @@ class ServerDef:
             return False
         if self.runtime == "native":
             return self.resolve_binary(system) is not None
+        if is_frozen():
+            return True  # python servers are bundled into the executable
         return bool(self.module_file) and os.path.exists(self.module_file)
 
     def launch_command(self, values):

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -1,0 +1,227 @@
+"""Registry of the PS2 servers the launcher can run.
+
+Each server is described declaratively: the input fields the GUI should show,
+how those values map to command-line arguments, how the server is launched
+(an in-bundle Python module via re-exec, or a native binary), and on which
+operating systems it is available.
+
+Adding a server, or switching one between Python and native, is a local change
+here -- nothing else in the engine needs to know the difference.
+"""
+
+import os
+import platform
+import sys
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+PKG_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(PKG_DIR)
+
+
+def _repo(*parts):
+    return os.path.join(REPO_ROOT, *parts)
+
+
+# --------------------------------------------------------------------------- #
+# Re-exec dispatch
+# --------------------------------------------------------------------------- #
+def is_frozen():
+    """True when running inside a Nuitka/PyInstaller single-file build."""
+    return bool(getattr(sys, "frozen", False)) or ("__compiled__" in globals())
+
+
+def serve_command(key, args):
+    """Command that runs the Python server `key` in its own process.
+
+    When bundled, we re-exec *this* executable with a hidden --serve flag, so the
+    embedded Python runs the server with no system Python installed. From source,
+    we re-run the package the same way.
+    """
+    if is_frozen():
+        return [sys.executable, "--serve", key, *args]
+    return [sys.executable, "-m", "launcher", "--serve", key, *args]
+
+
+# --------------------------------------------------------------------------- #
+# Declarative descriptions
+# --------------------------------------------------------------------------- #
+@dataclass
+class Field:
+    key: str
+    label: str
+    kind: str  # folder | file | bool | port | text
+    required: bool = False
+    default: object = None
+    help: str = ""
+    advanced: bool = False  # GUI hides advanced fields until expanded
+
+
+@dataclass
+class ServerDef:
+    key: str
+    label: str
+    blurb: str
+    runtime: str  # 'python' | 'native'
+    fields: list
+    _build_argv: Callable
+    default_port: Optional[int] = None
+    port_is_hex: bool = False  # UDP servers are conventionally written in hex
+    share_hint: str = ""  # what the user types into OPL's "Share" field, if any
+    module_file: Optional[str] = None  # python: file to import
+    module_dir: Optional[str] = None  # python: dir added to sys.path (sibling imports)
+    binary_rel: dict = field(default_factory=dict)  # native: {system: 'rel/path'}
+    available_os: tuple = ("Windows", "Linux", "Darwin")
+
+    def build_argv(self, values):
+        return self._build_argv(values)
+
+    def port_display(self):
+        if self.default_port is None:
+            return "-"
+        return ("0x%04X" % self.default_port) if self.port_is_hex else str(self.default_port)
+
+    def resolve_binary(self, system=None):
+        system = system or platform.system()
+        rel = self.binary_rel.get(system)
+        if not rel:
+            return None
+        path = _repo(*rel.split("/"))
+        return path if os.path.exists(path) else None
+
+    def is_available(self, system=None):
+        system = system or platform.system()
+        if system not in self.available_os:
+            return False
+        if self.runtime == "native":
+            return self.resolve_binary(system) is not None
+        return bool(self.module_file) and os.path.exists(self.module_file)
+
+    def launch_command(self, values):
+        """Full command (argv list) to start this server with the given values."""
+        if self.runtime == "python":
+            return serve_command(self.key, self.build_argv(values))
+        binary = self.resolve_binary()
+        if not binary:
+            raise RuntimeError(f"No {self.key} binary available for this platform")
+        return [binary, *self.build_argv(values)]
+
+
+# --------------------------------------------------------------------------- #
+# Argument builders (values dict -> server CLI args)
+# --------------------------------------------------------------------------- #
+def _smbv1_argv(v):
+    args = ["--share", "games={}".format(v["games_folder"])]
+    if v.get("port"):
+        args += ["--port", str(v["port"])]
+    if v.get("bind"):
+        args += ["--bind", str(v["bind"])]
+    if v.get("read_only"):
+        args.append("--read-only")
+    if v.get("take_445"):
+        args.append("--take-445")
+    if v.get("verbose"):
+        args.append("-v")
+    return args
+
+
+def _udpfs_argv(v):
+    args = []
+    if v.get("root_dir"):
+        args += ["-d", v["root_dir"]]
+    if v.get("block_device"):
+        args += ["-b", v["block_device"]]
+    if v.get("port"):
+        args += ["-p", str(v["port"])]
+    if v.get("bind"):
+        args += ["-i", str(v["bind"])]
+    if v.get("read_only"):
+        args.append("-r")
+    if v.get("enable_compression"):
+        args.append("-c")
+    if v.get("verbose"):
+        args.append("-v")
+    return args
+
+
+def _udpbd_argv(v):
+    return [v["image_file"]]
+
+
+# --------------------------------------------------------------------------- #
+# The registry
+# --------------------------------------------------------------------------- #
+SMBV1 = ServerDef(
+    key="smbv1",
+    label="SMBv1 server (RiptOPL)",
+    blurb="Share a games folder over SMB. Works even on Windows 11 where the OS "
+    "removed SMB1.",
+    runtime="python",
+    default_port=1445,
+    share_hint="games",
+    module_file=_repo("smbv1_server", "smbserver_opl.py"),
+    module_dir=_repo("smbv1_server"),
+    fields=[
+        Field("games_folder", "Games folder", "folder", required=True,
+              help="Folder of PS2 games/apps to share."),
+        Field("port", "Port", "port", default=1445, advanced=True,
+              help="TCP port (default 1445)."),
+        Field("read_only", "Read-only", "bool", default=False, advanced=True,
+              help="No saves / no VMC writes."),
+        Field("take_445", "Take port 445 (admin)", "bool", default=False, advanced=True,
+              help="Bind standard port 445 by pausing Windows file sharing. Needs admin."),
+        Field("bind", "Bind address", "text", default="", advanced=True,
+              help="Interface to bind (blank = all)."),
+        Field("verbose", "Verbose logging", "bool", default=False, advanced=True),
+    ],
+    _build_argv=_smbv1_argv,
+)
+
+UDPFS = ServerDef(
+    key="udpfs",
+    label="UDPFS server",
+    blurb="Serve a folder and/or a disk image over UDP. Newer protocol; can "
+    "transparently decompress CHD/CSO/ZSO.",
+    runtime="python",
+    default_port=0xF5F6,
+    port_is_hex=True,
+    module_file=_repo("udpfs_server", "udpfs_server.py"),
+    module_dir=_repo("udpfs_server"),
+    fields=[
+        Field("root_dir", "Games folder", "folder", required=False,
+              help="Folder to serve files from (folder and/or image required)."),
+        Field("block_device", "Disk image", "file", required=False,
+              help="A single disk image to serve as a block device."),
+        Field("enable_compression", "Decompress CHD/CSO/ZSO", "bool", default=False,
+              help="Compressed images appear as .iso (needs lz4 for ZSO, libchdr for CHD)."),
+        Field("read_only", "Read-only", "bool", default=False, advanced=True),
+        Field("port", "Port", "port", default=0xF5F6, advanced=True,
+              help="UDP port (default 0xF5F6)."),
+        Field("bind", "Bind address", "text", default="", advanced=True),
+        Field("verbose", "Verbose logging", "bool", default=False, advanced=True),
+    ],
+    _build_argv=_udpfs_argv,
+)
+
+# NOTE: UDPBD is currently the interim native .exe (Windows only). It will be
+# replaced by a pure-Python port -- at which point this entry becomes
+# runtime="python" with module_file/module_dir set and available_os = all three,
+# and the rest of the engine is unaffected.
+UDPBD = ServerDef(
+    key="udpbd",
+    label="UDPBD server",
+    blurb="Serve a single disk image as a block device over UDP. The PS2 finds "
+    "the server automatically (broadcast).",
+    runtime="native",
+    default_port=0xBDBD,
+    port_is_hex=True,
+    binary_rel={"Windows": "udpbd_server/udpbd-server.exe"},
+    available_os=("Windows",),  # interim: native exe only exists for Windows
+    fields=[
+        Field("image_file", "Disk image", "file", required=True,
+              help="A single disk image / block device to serve."),
+    ],
+    _build_argv=_udpbd_argv,
+)
+
+REGISTRY = {s.key: s for s in (SMBV1, UDPFS, UDPBD)}

--- a/ps2servers.py
+++ b/ps2servers.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Single-file entry point for the packaged PS2 Servers executable.
+
+Running from source you can use `python -m launcher` instead; this top-level
+script exists so Nuitka has a clean module to compile into one binary.
+"""
+
+import sys
+
+from launcher.main import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start-launcher.sh
+++ b/start-launcher.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Launch the PS2 Servers GUI from source (Linux/macOS).
+# The packaged binary will not need Python; this script is for running from source.
+cd "$(dirname "$0")" || exit 1
+exec python3 -m launcher

--- a/udpbd_server/SOURCE.md
+++ b/udpbd_server/SOURCE.md
@@ -1,0 +1,33 @@
+# UDPBD server — provenance
+
+`udpbd_server.py` is a **pure-Python port** of the UDPBD v2 server, written from
+the published wire protocol so PlayStation 2 clients (Open PS2 Loader) talk to
+it unchanged. It is the active server used by the launcher and runs on Windows,
+Linux and macOS.
+
+## Credit
+
+The UDPBD protocol and the original server are by **Rick Gaiser**.
+Upstream: https://github.com/israpps/udpbd-server (brought to GitHub with CI by
+El_isra; Windows port by Alex Parrado). UDPBD has largely been superseded by
+UDPFS (also Rick Gaiser) — see `../udpfs_server/`.
+
+This port was written from the protocol definitions (`udpbd.h`) and documented
+behaviour (`main.cpp`); **no upstream source code was copied**. Upstream ships
+without a license file, so this independent reimplementation avoids redistributing
+their code.
+
+## Files
+
+- `udpbd_server.py` — the server (standard library only). CLI: `udpbd_server.py <image>`.
+- `selftest.py` — protocol self-test (no PS2 needed): `python selftest.py`.
+- `udpbd-server.exe` — the legacy Windows binary (Alex Parrado's build). Kept as a
+  fallback only; **not used** by the launcher. Note it is device-oriented and does
+  not serve plain image files well on Windows — the reason for the Python port.
+
+## Verify
+
+```sh
+cd udpbd_server
+python selftest.py
+```

--- a/udpbd_server/selftest.py
+++ b/udpbd_server/selftest.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Self-test for the UDPBD Python port.
+
+Spins up the server on loopback against a scratch image and exercises the wire
+protocol end-to-end: INFO reply, READ (reassembled RDMA must equal the file
+across every block-size regime), WRITE (must land in the file), and the RDMA
+block-size optimizer. No PlayStation 2 required.
+
+Final validation is still on real hardware (an actual PS2 running OPL, or PCSX2
+with a network adapter) -- this only proves the wire protocol is correct.
+
+    python selftest.py
+"""
+
+import os
+import random
+import socket
+import struct
+import sys
+import tempfile
+import threading
+import time
+
+import udpbd_server as U
+
+SRV = ("127.0.0.1", U.UDPBD_PORT)
+
+
+def _client():
+    c = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    c.settimeout(3.0)
+    return c
+
+
+def _info(c, expected_sectors):
+    c.sendto(U.pack_header(U.CMD_INFO, 1, 0), SRV)
+    data, _ = c.recvfrom(2048)
+    cmd, _, _ = U.unpack_header(data)
+    _, ssize, scount = struct.unpack("<HII", data[:10])
+    assert cmd == U.CMD_INFO_REPLY and ssize == 512 and scount == expected_sectors
+    print("  INFO  ok: sector_size=512 sector_count={}".format(scount))
+
+
+def _read(c, img, start, count):
+    c.sendto(U.pack_header(U.CMD_READ, 2, 0) + struct.pack("<IH", start, count), SRV)
+    want = count * 512
+    got = bytearray()
+    while len(got) < want:
+        data, _ = c.recvfrom(2048)
+        cmd, _, _ = U.unpack_header(data)
+        assert cmd == U.CMD_READ_RDMA
+        bshift, bcount = U.unpack_block_type(data)
+        got += data[6:6 + bcount * (1 << (bshift + 2))]
+    assert bytes(got[:want]) == img[start * 512:(start + count) * 512]
+    print("  READ  ok: start={:<6} count={:<4} matches file".format(start, count))
+
+
+def _write(c, path, start, count):
+    new = random.Random(99).randbytes(count * 512)
+    c.sendto(U.pack_header(U.CMD_WRITE, 3, 0) + struct.pack("<IH", start, count), SRV)
+    off, blocks = 0, count
+    while blocks > 0:  # block_shift 7 => 1 block == 1 sector, 2 sectors per packet
+        bc = min(blocks, 2)
+        blocks -= bc
+        c.sendto(U.pack_header(U.CMD_WRITE_RDMA, 3, 0) + U.pack_block_type(7, bc)
+                 + new[off:off + bc * 512], SRV)
+        off += bc * 512
+    data, _ = c.recvfrom(2048)
+    assert U.unpack_header(data)[0] == U.CMD_WRITE_DONE
+    time.sleep(0.1)
+    with open(path, "rb") as f:
+        f.seek(start * 512)
+        assert f.read(count * 512) == new
+    print("  WRITE ok: start={:<6} count={:<4} written and verified".format(start, count))
+
+
+def _optimizer():
+    s = U.UdpbdServer.__new__(U.UdpbdServer)
+    s.verbose = False
+    s._block_shift = None
+    s._set_block_shift(5)
+    for sectors, expected_block in {1: 512, 8: 128, 64: 32}.items():
+        s._set_block_shift_for_sectors(sectors)
+        assert s._block_size == expected_block, (sectors, s._block_size)
+    print("  SHIFT ok: block-size optimizer matches upstream table")
+
+
+def main():
+    tmp = tempfile.mkdtemp(prefix="udpbd_")
+    path = os.path.join(tmp, "test.img")
+    size = 4 * 1024 * 1024
+    img = random.Random(1234).randbytes(size)
+    with open(path, "wb") as f:
+        f.write(img)
+
+    server = U.UdpbdServer(U.BlockDevice(path), bind="127.0.0.1")
+    threading.Thread(target=server.run, daemon=True).start()
+    time.sleep(0.3)
+
+    c = _client()
+    print("UDPBD port self-test:")
+    _info(c, size // 512)
+    _read(c, img, 0, 1)        # smallest read  -> 512-byte blocks
+    _read(c, img, 100, 8)      # 8 sectors      -> 128-byte blocks
+    _read(c, img, 1000, 512)   # max read       -> 32-byte blocks (~183 packets)
+    _read(c, img, 7777, 17)    # odd offset/count
+    _write(c, path, 200, 5)
+    with open(path, "rb") as f:  # the written region must now read back as new data
+        img2 = f.read()
+    _read(c, img2, 200, 5)
+    _optimizer()
+    print("ALL UDPBD TESTS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/udpbd_server/udpbd_server.py
+++ b/udpbd_server/udpbd_server.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""UDPBD server -- pure-Python port.
+
+Serves a disk image (or block device) to a PlayStation 2 running Open PS2 Loader
+over the UDPBD v2 protocol. The PS2 discovers the server automatically via a
+broadcast on UDP port 0xBDBD -- no IP or port needs to be entered in OPL.
+
+This is an independent reimplementation written from the published protocol
+(struct layout in `udpbd.h`, behaviour in `main.cpp`). The original UDPBD server
+and protocol are by **Rick Gaiser** (https://github.com/israpps/udpbd-server,
+brought to GitHub by El_isra, Windows port by Alex Parrado). No upstream code is
+copied here; only the wire protocol is reproduced so PS2 clients interoperate.
+
+Standard library only -- runs identically on Windows, Linux and macOS, which is
+why it replaces the Windows-only prebuilt binary in this repo.
+"""
+
+import argparse
+import os
+import socket
+import struct
+import sys
+
+# --------------------------------------------------------------------------- #
+# Protocol constants (from udpbd.h)
+# --------------------------------------------------------------------------- #
+UDPBD_PORT = 0xBDBD  # 48573 -- fixed; the PS2 broadcasts here to find us
+
+CMD_INFO = 0x00        # client -> server
+CMD_INFO_REPLY = 0x01  # server -> client
+CMD_READ = 0x02        # client -> server
+CMD_READ_RDMA = 0x03   # server -> client
+CMD_WRITE = 0x04       # client -> server
+CMD_WRITE_RDMA = 0x05  # client -> server
+CMD_WRITE_DONE = 0x06  # server -> client
+
+SECTOR_SIZE = 512
+RECV_BUFLEN = 2048
+# Header (2 bytes) + block_type (4 bytes) = 6 bytes of RDMA overhead.
+RDMA_MAX_PAYLOAD = 1472 - 2 - 4  # 1466
+
+
+# --------------------------------------------------------------------------- #
+# Header / block-type packing
+#   header  (uint16, little-endian bitfield): cmd:5  cmdid:3  cmdpkt:8
+#   block_type (uint32, little-endian bitfield): block_shift:4  block_count:9
+# --------------------------------------------------------------------------- #
+def pack_header(cmd, cmdid, cmdpkt):
+    value = (cmd & 0x1F) | ((cmdid & 0x07) << 5) | ((cmdpkt & 0xFF) << 8)
+    return struct.pack("<H", value)
+
+
+def header_cmd(datagram):
+    return datagram[0] & 0x1F
+
+
+def unpack_header(datagram):
+    value = struct.unpack_from("<H", datagram, 0)[0]
+    return value & 0x1F, (value >> 5) & 0x07, (value >> 8) & 0xFF
+
+
+def pack_block_type(block_shift, block_count):
+    return struct.pack("<I", (block_shift & 0x0F) | ((block_count & 0x1FF) << 4))
+
+
+def unpack_block_type(datagram, offset=2):
+    value = struct.unpack_from("<I", datagram, offset)[0]
+    return value & 0x0F, (value >> 4) & 0x1FF
+
+
+# --------------------------------------------------------------------------- #
+# Block device backed by an image file
+# --------------------------------------------------------------------------- #
+class BlockDevice:
+    def __init__(self, path, read_only=False):
+        self.path = path
+        self.read_only = read_only
+        try:
+            mode = "rb" if read_only else "r+b"
+            self._f = open(path, mode, buffering=0)
+        except OSError:
+            self.read_only = True
+            self._f = open(path, "rb", buffering=0)
+        self._f.seek(0, os.SEEK_END)
+        self.size = self._f.tell()
+        self._f.seek(0)
+
+    def sector_count(self):
+        return self.size // SECTOR_SIZE
+
+    def seek(self, sector):
+        self._f.seek(sector * SECTOR_SIZE)
+
+    def read(self, size):
+        data = self._f.read(size)
+        if len(data) < size:  # past end of image -- pad so packet sizing stays correct
+            data = data + b"\x00" * (size - len(data))
+        return data
+
+    def write(self, data):
+        if self.read_only:
+            return
+        self._f.write(data)
+
+    def close(self):
+        try:
+            self._f.close()
+        except OSError:
+            pass
+
+
+# --------------------------------------------------------------------------- #
+# Server
+# --------------------------------------------------------------------------- #
+class UdpbdServer:
+    def __init__(self, device, bind="", verbose=False):
+        self.bd = device
+        self.verbose = verbose
+        self._total_read = 0
+        self._total_write = 0
+        self._write_left = 0
+
+        self._block_shift = None
+        self._set_block_shift(5)  # default 128-byte blocks, matching upstream
+
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        self.sock.bind((bind or "0.0.0.0", UDPBD_PORT))
+        self._bind_addr = bind or "0.0.0.0"
+
+    # -- RDMA block sizing ------------------------------------------------- #
+    def _set_block_shift(self, shift):
+        if shift == self._block_shift:
+            return
+        self._block_shift = shift
+        self._block_size = 1 << (shift + 2)
+        self._blocks_per_packet = RDMA_MAX_PAYLOAD // self._block_size
+        self._blocks_per_sector = SECTOR_SIZE // self._block_size
+        if self.verbose:
+            print("Block size changed to {}".format(self._block_size))
+
+    def _set_block_shift_for_sectors(self, sectors):
+        # Pick the largest block size that still yields the minimum packet count
+        # (fewest packets = least overhead; largest blocks = faster on the PS2).
+        size = sectors * SECTOR_SIZE
+        packets_min = -(-size // 1440)  # ceil
+        if -(-size // 1024) == packets_min:
+            shift = 7  # 512-byte blocks
+        elif -(-size // 1280) == packets_min:
+            shift = 6  # 256-byte blocks
+        elif -(-size // 1408) == packets_min:
+            shift = 5  # 128-byte blocks
+        else:
+            shift = 3  # 32-byte blocks
+        self._set_block_shift(shift)
+
+    # -- command handlers -------------------------------------------------- #
+    def _handle_info(self, addr, datagram):
+        _, cmdid, _ = unpack_header(datagram)
+        print("UDPBD_CMD_INFO from {}".format(addr[0]))
+        self._print_stats()
+        reply = pack_header(CMD_INFO_REPLY, cmdid, 1) + struct.pack(
+            "<II", SECTOR_SIZE, self.bd.sector_count()
+        )
+        self.sock.sendto(reply, addr)
+
+    def _handle_read(self, addr, datagram):
+        _, cmdid, _ = unpack_header(datagram)
+        _, sector_nr, sector_count = struct.unpack_from("<HIH", datagram, 0)
+        if self.verbose:
+            print("UDPBD_CMD_READ(cmdid={}, start={}, count={})".format(
+                cmdid, sector_nr, sector_count))
+
+        self._set_block_shift_for_sectors(sector_count)
+        blocks_left = sector_count * self._blocks_per_sector
+        self._total_read += blocks_left * self._block_size
+        self.bd.seek(sector_nr)
+
+        cmdpkt = 1
+        while blocks_left > 0:
+            block_count = min(blocks_left, self._blocks_per_packet)
+            blocks_left -= block_count
+            data = self.bd.read(block_count * self._block_size)
+            packet = (pack_header(CMD_READ_RDMA, cmdid, cmdpkt)
+                      + pack_block_type(self._block_shift, block_count)
+                      + data)
+            self.sock.sendto(packet, addr)
+            cmdpkt = (cmdpkt + 1) & 0xFF
+
+    def _handle_write(self, addr, datagram):
+        _, cmdid, _ = unpack_header(datagram)
+        _, sector_nr, sector_count = struct.unpack_from("<HIH", datagram, 0)
+        if self.verbose:
+            print("UDPBD_CMD_WRITE(cmdid={}, start={}, count={})".format(
+                cmdid, sector_nr, sector_count))
+        if self.bd.read_only:
+            print("Warning: write requested on a read-only image -- ignoring")
+        self.bd.seek(sector_nr)
+        self._write_left = sector_count * SECTOR_SIZE
+        self._total_write += self._write_left
+
+    def _handle_write_rdma(self, addr, datagram):
+        _, cmdid, _ = unpack_header(datagram)
+        block_shift, block_count = unpack_block_type(datagram)
+        size = block_count * (1 << (block_shift + 2))
+        self.bd.write(datagram[6:6 + size])
+        self._write_left -= size
+        if self._write_left <= 0:
+            reply = pack_header(CMD_WRITE_DONE, cmdid, (cmdid + 1) & 0xFF)
+            reply += struct.pack("<i", 0)
+            self.sock.sendto(reply, addr)
+
+    def _print_stats(self):
+        print("Total read: {} KiB, total write: {} KiB".format(
+            self._total_read // 1024, self._total_write // 1024))
+
+    # -- main loop --------------------------------------------------------- #
+    def run(self):
+        ro = "read-only" if self.bd.read_only else "read/write"
+        print("UDPBD server")
+        print("  Image: {}  ({})".format(self.bd.path, ro))
+        print("  Size : {} MiB / {} sectors".format(
+            self.bd.size // (1024 * 1024), self.bd.sector_count()))
+        print("  Listening on {}:{} (0x{:X}) -- PS2 finds it via broadcast".format(
+            self._bind_addr, UDPBD_PORT, UDPBD_PORT))
+        print("  In OPL: choose UDPBD; no IP or port to enter.")
+        print()
+        try:
+            while True:
+                datagram, addr = self.sock.recvfrom(RECV_BUFLEN)
+                if not datagram:
+                    continue
+                cmd = header_cmd(datagram)
+                if cmd == CMD_INFO:
+                    self._handle_info(addr, datagram)
+                elif cmd == CMD_READ:
+                    self._handle_read(addr, datagram)
+                elif cmd == CMD_WRITE:
+                    self._handle_write(addr, datagram)
+                elif cmd == CMD_WRITE_RDMA:
+                    self._handle_write_rdma(addr, datagram)
+                elif self.verbose:
+                    print("Invalid cmd: 0x{:x}".format(cmd))
+        except KeyboardInterrupt:
+            print("\nShutting down...")
+            self._print_stats()
+        finally:
+            self.sock.close()
+            self.bd.close()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="UDPBD server -- serve a disk image to a PS2 over UDP (OPL).")
+    parser.add_argument("image", help="disk image / block device to serve")
+    parser.add_argument("-r", "--read-only", action="store_true",
+                        help="serve the image read-only (no saves / VMC writes)")
+    parser.add_argument("-i", "--bind", default="", metavar="IP",
+                        help="interface to bind (default: all interfaces)")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="log every read/write command")
+    args = parser.parse_args(argv)
+
+    if not os.path.exists(args.image):
+        print("Error: '{}' not found".format(args.image))
+        return 1
+
+    try:
+        device = BlockDevice(args.image, read_only=args.read_only)
+    except OSError as e:
+        print("Error: cannot open '{}': {}".format(args.image, e))
+        return 1
+
+    try:
+        server = UdpbdServer(device, bind=args.bind, verbose=args.verbose)
+    except OSError as e:
+        device.close()
+        print("Error: cannot bind UDP port 0x{:X}: {}".format(UDPBD_PORT, e))
+        return 1
+
+    server.run()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a Tkinter **GUI launcher** so anyone can run the PS2 OPL servers without a terminal, and replaces the Windows-only UDPBD `.exe` with a pure-Python port so all three servers are cross-platform and bundle into one executable.

## What's included
- **Engine** — declarative server registry, subprocess supervisor with live log capture, and a `--serve` re-exec dispatch (so Python servers run inside a bundled exe with no system Python).
- **UDPBD → pure Python** (`udpbd_server/udpbd_server.py`) — independent reimplementation of the UDPBD v2 protocol (no upstream code copied; see [SOURCE.md](udpbd_server/SOURCE.md)). `selftest.py` validates INFO/READ/WRITE byte-for-byte + the RDMA block-size optimizer.
- **GUI** (`launcher/gui.py`) — one card per server with folder/file pickers, advanced options, per-card Start/Stop, live status, the exact OPL settings line, per-server log tabs, LAN-IP detection, and persisted settings.
- **Packaging** (`build/build.py`) — Nuitka one-file build per OS (`dist/PS2Servers`). Verified: the built exe runs SMBv1, UDPFS, and UDPBD from inside the bundle.
- **UAC elevation** for SMBv1 `--take-445` (relaunches elevated on demand, Windows).
- **Docs** — top-level README covers the launcher, per-server usage, and the build.

## Verification
- UDPBD protocol self-test passes.
- Engine + all three servers start/stop and stream logs through the launcher.
- The packaged 9.4 MB exe runs `--list` and serves all three protocols.

## Not covered (follow-ups)
- **Real-hardware validation** on an actual PS2 / PCSX2 (especially the new UDPBD port).
- **Linux/macOS binaries** must be produced by running `build/build.py` on those OSes.
- The UAC relaunch path couldn't be auto-tested (needs an interactive UAC approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)