### PR TITLE
Address review feedback: robustness & safety hardening

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -68,9 +68,11 @@ def main():
     cmd.append(os.path.join(ROOT, "ps2servers.py"))
 
     # compressed_iso lives under udpfs_server/, so make it importable for Nuitka.
+    # Avoid a trailing os.pathsep (an empty entry means CWD, which can shadow imports).
     env = os.environ.copy()
-    env["PYTHONPATH"] = (os.path.join(ROOT, "udpfs_server") + os.pathsep
-                         + env.get("PYTHONPATH", ""))
+    extra = os.path.join(ROOT, "udpfs_server")
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = extra + os.pathsep + existing if existing else extra
 
     print("Running:\n  " + " \\\n  ".join(cmd) + "\n")
     return subprocess.call(cmd, cwd=ROOT, env=env)

--- a/launcher/config.py
+++ b/launcher/config.py
@@ -38,5 +38,17 @@ def load():
 def save(data):
     directory = config_dir()
     os.makedirs(directory, exist_ok=True)
-    with open(config_path(), "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
+    path = config_path()
+    tmp = path + ".tmp"
+    # write to a temp file then atomically replace, so a crash mid-write can't
+    # leave a truncated/corrupt config behind
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -132,8 +132,8 @@ class ServerCard(ttk.LabelFrame):
             self.adv_btn.config(text="Advanced ▸")
 
     def _browse(self, var, kind):
-        path = (filedialog.askdirectory() if kind == "folder"
-                else filedialog.askopenfilename())
+        path = (filedialog.askdirectory(parent=self) if kind == "folder"
+                else filedialog.askopenfilename(parent=self))
         if path:
             var.set(path)
 
@@ -313,7 +313,7 @@ class LauncherApp:
 
     def _drain_logs(self):
         try:
-            while True:
+            for _ in range(500):  # cap per tick so a log flood can't freeze the GUI
                 key, line = self.out_queue.get_nowait()
                 self._append_log(key, line)
         except queue.Empty:
@@ -324,6 +324,9 @@ class LauncherApp:
         widget = self.logs[key]
         widget.config(state="normal")
         widget.insert("end", text)
+        lines = int(widget.index("end-1c").split(".")[0])
+        if lines > 2000:  # keep the log bounded so memory/redraw stay cheap
+            widget.delete("1.0", "{}.0".format(lines - 2000))
         widget.see("end")
         widget.config(state="disabled")
 

--- a/launcher/process.py
+++ b/launcher/process.py
@@ -89,3 +89,10 @@ class ServerProcess:
         except subprocess.TimeoutExpired:
             self._proc.kill()
             self._proc.wait()
+        finally:
+            # release the pipe fd and unblock the reader thread
+            if self._proc.stdout:
+                try:
+                    self._proc.stdout.close()
+                except OSError:
+                    pass

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -128,6 +128,8 @@ def _smbv1_argv(v):
 
 
 def _udpfs_argv(v):
+    if not v.get("root_dir") and not v.get("block_device"):
+        raise ValueError("UDPFS needs a Games folder and/or a Disk image.")
     args = []
     if v.get("root_dir"):
         args += ["-d", v["root_dir"]]

--- a/udpbd_server/selftest.py
+++ b/udpbd_server/selftest.py
@@ -85,31 +85,47 @@ def _optimizer():
     print("  SHIFT ok: block-size optimizer matches upstream table")
 
 
+def _fuzz(c, expected_sectors):
+    # malformed / short packets (fuzzing, port scans) must never crash the server
+    for bad in (b"\x00", b"\x02", b"\x02\x00\x00", b"\x05\x00\x00\x00\x00",
+                random.Random(7).randbytes(5), b"\x04\x00\x01\x00\x00\x00\x00"):
+        c.sendto(bad, SRV)
+    _info(c, expected_sectors)  # still answers -> it survived the garbage
+    print("  FUZZ  ok: server survived malformed packets")
+
+
 def main():
-    tmp = tempfile.mkdtemp(prefix="udpbd_")
-    path = os.path.join(tmp, "test.img")
-    size = 4 * 1024 * 1024
-    img = random.Random(1234).randbytes(size)
-    with open(path, "wb") as f:
-        f.write(img)
+    with tempfile.TemporaryDirectory(prefix="udpbd_") as tmp:
+        path = os.path.join(tmp, "test.img")
+        size = 4 * 1024 * 1024
+        img = random.Random(1234).randbytes(size)
+        with open(path, "wb") as f:
+            f.write(img)
 
-    server = U.UdpbdServer(U.BlockDevice(path), bind="127.0.0.1")
-    threading.Thread(target=server.run, daemon=True).start()
-    time.sleep(0.3)
+        server = U.UdpbdServer(U.BlockDevice(path), bind="127.0.0.1")
+        thread = threading.Thread(target=server.run, daemon=True)
+        thread.start()
+        time.sleep(0.3)
 
-    c = _client()
-    print("UDPBD port self-test:")
-    _info(c, size // 512)
-    _read(c, img, 0, 1)        # smallest read  -> 512-byte blocks
-    _read(c, img, 100, 8)      # 8 sectors      -> 128-byte blocks
-    _read(c, img, 1000, 512)   # max read       -> 32-byte blocks (~183 packets)
-    _read(c, img, 7777, 17)    # odd offset/count
-    _write(c, path, 200, 5)
-    with open(path, "rb") as f:  # the written region must now read back as new data
-        img2 = f.read()
-    _read(c, img2, 200, 5)
-    _optimizer()
-    print("ALL UDPBD TESTS PASSED")
+        c = _client()
+        try:
+            print("UDPBD port self-test:")
+            _info(c, size // 512)
+            _read(c, img, 0, 1)        # smallest read  -> 512-byte blocks
+            _read(c, img, 100, 8)      # 8 sectors      -> 128-byte blocks
+            _read(c, img, 1000, 512)   # max read       -> 32-byte blocks (~183 packets)
+            _read(c, img, 7777, 17)    # odd offset/count
+            _write(c, path, 200, 5)
+            with open(path, "rb") as f:  # the written region must read back as new data
+                img2 = f.read()
+            _read(c, img2, 200, 5)
+            _fuzz(c, size // 512)
+            _optimizer()
+            print("ALL UDPBD TESTS PASSED")
+        finally:
+            c.close()
+            server.sock.close()       # unblocks recvfrom -> run() closes the image
+            thread.join(timeout=1.0)  # ensure the image handle is freed before cleanup
     return 0
 
 

--- a/udpbd_server/udpbd_server.py
+++ b/udpbd_server/udpbd_server.py
@@ -227,20 +227,29 @@ class UdpbdServer:
         print()
         try:
             while True:
-                datagram, addr = self.sock.recvfrom(RECV_BUFLEN)
-                if not datagram:
+                try:
+                    datagram, addr = self.sock.recvfrom(RECV_BUFLEN)
+                except OSError:
+                    break  # socket closed -> shut down
+                if len(datagram) < 2:  # smaller than the header: ignore
                     continue
-                cmd = header_cmd(datagram)
-                if cmd == CMD_INFO:
-                    self._handle_info(addr, datagram)
-                elif cmd == CMD_READ:
-                    self._handle_read(addr, datagram)
-                elif cmd == CMD_WRITE:
-                    self._handle_write(addr, datagram)
-                elif cmd == CMD_WRITE_RDMA:
-                    self._handle_write_rdma(addr, datagram)
-                elif self.verbose:
-                    print("Invalid cmd: 0x{:x}".format(cmd))
+                try:
+                    cmd = header_cmd(datagram)
+                    if cmd == CMD_INFO:
+                        self._handle_info(addr, datagram)
+                    elif cmd == CMD_READ and len(datagram) >= 8:
+                        self._handle_read(addr, datagram)
+                    elif cmd == CMD_WRITE and len(datagram) >= 8:
+                        self._handle_write(addr, datagram)
+                    elif cmd == CMD_WRITE_RDMA and len(datagram) >= 6:
+                        self._handle_write_rdma(addr, datagram)
+                    elif self.verbose:
+                        print("Ignoring bad/short packet (cmd 0x{:x}) from {}".format(
+                            cmd, addr[0]))
+                except (struct.error, IndexError) as e:
+                    # never let a malformed packet (fuzzing / port scan) kill the server
+                    if self.verbose:
+                        print("Bad packet from {}: {}".format(addr[0], e))
         except KeyboardInterrupt:
             print("\nShutting down...")
             self._print_stats()


### PR DESCRIPTION
Applies the Gemini Code Assist review feedback from #1. All changes verified (UDPBD self-test incl. a new fuzz check, GUI log truncation/drain cap, UDPFS validation, atomic config round-trip).

| Area | Change | Severity |
|------|--------|----------|
| `udpbd_server.py` | Validate packet lengths + guard dispatch against `struct.error`; clean shutdown on socket close | security-high |
| `gui.py` | Cap log drain at 500 lines/tick (no GUI freeze on flood) | high |
| `gui.py` | Bound each log widget to ~2000 lines (no memory/redraw blowup) | medium |
| `gui.py` | Parent file dialogs to the window | medium |
| `process.py` | Close child stdout pipe on stop (no fd leak; unblocks reader) | medium |
| `config.py` | Atomic save (temp + `os.replace`) — no corruption on crash | medium |
| `servers.py` | UDPFS raises a friendly error when neither folder nor image is set | medium |
| `build.py` | Avoid trailing `PYTHONPATH` separator (empty entry == CWD) | medium |
| `selftest.py` | `TemporaryDirectory` + socket close so it cleans up after itself | medium |

Also added a fuzz check to `selftest.py` that sends malformed/short packets and confirms the UDPBD server stays alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)