### PR TITLE
CI: build Windows/Linux/macOS release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Build release binaries
+
+# Builds the single-file launcher on each OS natively (no cross-compiling) and,
+# when triggered by a version tag like v0.1.0, attaches the binaries to the
+# matching GitHub Release. Use the manual "Run workflow" button to test-build
+# without publishing.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            asset: PS2Servers-windows-x64.exe
+            built: dist/PS2Servers.exe
+          - os: ubuntu-latest
+            asset: PS2Servers-linux-x64
+            built: dist/PS2Servers
+          - os: macos-latest
+            asset: PS2Servers-macos-arm64
+            built: dist/PS2Servers
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Tk (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y python3-tk tk-dev
+
+      - name: Install Nuitka
+        run: python -m pip install --upgrade pip nuitka
+
+      - name: Build single-file binary
+        run: python build/build.py
+
+      - name: Stage artifact
+        shell: bash
+        run: |
+          mkdir -p out
+          cp "${{ matrix.built }}" "out/${{ matrix.asset }}"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: out/${{ matrix.asset }}
+
+      - name: Attach to release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: out/${{ matrix.asset }}

--- a/build/build.py
+++ b/build/build.py
@@ -62,8 +62,8 @@ def main():
 
     if system == "Windows":
         cmd.append("--windows-console-mode=disable")
-    elif system == "Darwin":
-        cmd.append("--macos-create-app-bundle")
+    # Linux/macOS produce a plain one-file binary (dist/PS2Servers) -- simplest
+    # to attach to a release. (A signed macOS .app bundle could come later.)
 
     cmd.append(os.path.join(ROOT, "ps2servers.py"))
 


### PR DESCRIPTION
Adds `.github/workflows/release.yml` — GitHub Actions builds the single-file launcher **natively** on Windows, Linux, and macOS runners (Nuitka can't cross-compile), and attaches all three binaries to the GitHub Release when a `v*` tag is pushed. The manual "Run workflow" button test-builds without publishing.

`build/build.py` now emits a plain one-file binary on macOS too (instead of a `.app` bundle) so each OS yields a single downloadable asset:
- `PS2Servers-windows-x64.exe`
- `PS2Servers-linux-x64`
- `PS2Servers-macos-arm64`

Plan after merge: trigger a manual run to verify all three compile, then push a `v0.1.0` tag to publish the release with the binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)