### PR TITLE
Address review round 2: write-corruption, log batching, config cleanup

### DIFF
--- a/launcher/config.py
+++ b/launcher/config.py
@@ -46,7 +46,8 @@ def save(data):
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
         os.replace(tmp, path)
-    except OSError:
+    except Exception:
+        # clean up the temp file on any failure (e.g. non-serializable value)
         try:
             os.remove(tmp)
         except OSError:

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -312,12 +312,15 @@ class LauncherApp:
         self.out_queue.put((key, line + "\n"))
 
     def _drain_logs(self):
+        updates = {}
         try:
             for _ in range(500):  # cap per tick so a log flood can't freeze the GUI
                 key, line = self.out_queue.get_nowait()
-                self._append_log(key, line)
+                updates.setdefault(key, []).append(line)
         except queue.Empty:
             pass
+        for key, lines in updates.items():  # one widget update per server per tick
+            self._append_log(key, "".join(lines))
         self.root.after(150, self._drain_logs)
 
     def _append_log(self, key, text):

--- a/udpbd_server/selftest.py
+++ b/udpbd_server/selftest.py
@@ -94,6 +94,16 @@ def _fuzz(c, expected_sectors):
     print("  FUZZ  ok: server survived malformed packets")
 
 
+def _truncated_rdma(c, img, start):
+    # a WRITE_RDMA that claims 2 sectors (1024 B) but carries only 100 B must be
+    # dropped, not partially written -- otherwise it corrupts the region/alignment
+    c.sendto(U.pack_header(U.CMD_WRITE, 9, 0) + struct.pack("<IH", start, 2), SRV)
+    c.sendto(U.pack_header(U.CMD_WRITE_RDMA, 9, 0) + U.pack_block_type(7, 2)
+             + b"\xAB" * 100, SRV)
+    _read(c, img, start, 2)  # region must read back as the original, untouched data
+    print("  TRUNC ok: truncated WRITE_RDMA dropped, no corruption")
+
+
 def main():
     with tempfile.TemporaryDirectory(prefix="udpbd_") as tmp:
         path = os.path.join(tmp, "test.img")
@@ -120,6 +130,7 @@ def main():
                 img2 = f.read()
             _read(c, img2, 200, 5)
             _fuzz(c, size // 512)
+            _truncated_rdma(c, img, 400)  # untouched region -> still matches original
             _optimizer()
             print("ALL UDPBD TESTS PASSED")
         finally:

--- a/udpbd_server/udpbd_server.py
+++ b/udpbd_server/udpbd_server.py
@@ -203,6 +203,12 @@ class UdpbdServer:
         _, cmdid, _ = unpack_header(datagram)
         block_shift, block_count = unpack_block_type(datagram)
         size = block_count * (1 << (block_shift + 2))
+        if len(datagram) < 6 + size:
+            # truncated payload: drop it rather than write a short, misaligned block
+            # (which would corrupt every following write in the sequence)
+            if self.verbose:
+                print("Dropping truncated WRITE_RDMA from {}".format(addr[0]))
+            return
         self.bd.write(datagram[6:6 + size])
         self._write_left -= size
         if self._write_left <= 0:


### PR DESCRIPTION
Second round of Gemini feedback (on #2). All verified by the UDPBD self-test (now with a truncated-write check) and GUI/config spot-checks.

| Area | Change | Severity |
|------|--------|----------|
| `udpbd_server.py` | Validate the **full** declared `WRITE_RDMA` payload length; drop truncated packets instead of writing a short, misaligned block that corrupts the rest of the write sequence | security-high |
| `gui.py` | Batch drained log lines per server → one Text-widget update per server per tick (the per-line update defeated the 500/tick cap under a flood) | high |
| `config.py` | Clean up the temp file on **any** exception (e.g. a non-serializable value), not just `OSError` | medium |

`selftest.py` gains a `TRUNC` check: it sends a `WRITE_RDMA` claiming 2 sectors but carrying 100 bytes and confirms the region reads back unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)