### PR TITLE
macOS .app bundle + proactive review hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,10 @@ jobs:
         include:
           - os: windows-latest
             asset: PS2Servers-windows-x64.exe
-            built: dist/PS2Servers.exe
           - os: ubuntu-latest
             asset: PS2Servers-linux-x64
-            built: dist/PS2Servers
           - os: macos-latest
-            asset: PS2Servers-macos-arm64
-            built: dist/PS2Servers
+            asset: PS2Servers-macos-arm64.zip
     steps:
       - uses: actions/checkout@v4
 
@@ -51,7 +48,12 @@ jobs:
         shell: bash
         run: |
           mkdir -p out
-          cp "${{ matrix.built }}" "out/${{ matrix.asset }}"
+          case "$RUNNER_OS" in
+            Windows) cp dist/PS2Servers.exe "out/${{ matrix.asset }}" ;;
+            Linux)   cp dist/PS2Servers "out/${{ matrix.asset }}" ;;
+            macOS)   app=$(ls -d dist/*.app | head -1)
+                     ( cd dist && zip -r -y "../out/${{ matrix.asset }}" "$(basename "$app")" ) ;;
+          esac
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/build/build.py
+++ b/build/build.py
@@ -45,7 +45,6 @@ def main():
 
     cmd = [
         sys.executable, "-m", "nuitka",
-        "--onefile",
         "--enable-plugin=tk-inter",
         "--assume-yes-for-downloads",
         "--output-dir=" + os.path.join(ROOT, "dist"),
@@ -60,10 +59,16 @@ def main():
     for pkg in INCLUDE_PACKAGES:
         cmd.append("--include-package=" + pkg)
 
+    if system == "Darwin":
+        # a Tkinter GUI needs a .app bundle on macOS, or its window opens in the
+        # background with no dock / menu-bar presence. CI zips the .app for release.
+        cmd += ["--standalone", "--macos-create-app-bundle",
+                "--macos-app-name=PS2 Servers"]
+    else:
+        cmd.append("--onefile")
+
     if system == "Windows":
         cmd.append("--windows-console-mode=disable")
-    # Linux/macOS produce a plain one-file binary (dist/PS2Servers) -- simplest
-    # to attach to a release. (A signed macOS .app bundle could come later.)
 
     cmd.append(os.path.join(ROOT, "ps2servers.py"))
 

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -271,6 +271,7 @@ class LauncherApp:
                     "saved — then click Start again."):
                 self._save()
                 if elevate.relaunch_as_admin():
+                    self.stop_all()  # free ports before the elevated instance starts
                     self.root.destroy()
                 else:
                     messagebox.showerror(
@@ -363,6 +364,9 @@ class LauncherApp:
 
     def on_close(self):
         self._save()
+        # hide first so the (up to a few seconds of) child termination doesn't
+        # look like a frozen window
+        self.root.withdraw()
         self.stop_all()
         self.root.destroy()
 

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -21,8 +21,7 @@ def main(argv=None):
             print("error: --serve requires a server key", file=sys.stderr)
             return 2
         from .serve import run_serve
-        run_serve(rest[0], rest[1:])
-        return 0
+        return run_serve(rest[0], rest[1:]) or 0
 
     if "--list" in argv or "-l" in argv:
         _print_list()

--- a/launcher/process.py
+++ b/launcher/process.py
@@ -64,6 +64,13 @@ class ServerProcess:
                 self._emit(line.rstrip("\n"))
         except (ValueError, OSError):
             pass  # stream closed during shutdown
+        finally:
+            # close the pipe on EOF too (a server that exits on its own never
+            # reaches stop(), which early-returns once the process is gone)
+            try:
+                self._proc.stdout.close()
+            except OSError:
+                pass
 
     def _emit(self, line):
         self.lines.append(line)

--- a/launcher/serve.py
+++ b/launcher/serve.py
@@ -49,4 +49,4 @@ def run_serve(key, server_args):
     main = getattr(module, "main", None)
     if main is None:
         raise SystemExit("server {} has no main()".format(key))
-    main()
+    return main()  # propagate the server's exit code (e.g. 1 on bind/open failure)

--- a/udpbd_server/selftest.py
+++ b/udpbd_server/selftest.py
@@ -104,6 +104,16 @@ def _truncated_rdma(c, img, start):
     print("  TRUNC ok: truncated WRITE_RDMA dropped, no corruption")
 
 
+def _unsolicited_rdma(c, img, start):
+    # a WRITE_RDMA with NO preceding CMD_WRITE must be ignored -- otherwise it
+    # writes at the stale file offset left by the previous read, corrupting it
+    _read(c, img, start, 1)  # leaves the file pointer at sector start+1
+    c.sendto(U.pack_header(U.CMD_WRITE_RDMA, 8, 0) + U.pack_block_type(7, 1)
+             + b"\xCD" * 512, SRV)
+    _read(c, img, start, 2)  # sectors start..start+1 must be unchanged
+    print("  STRAY ok: unsolicited WRITE_RDMA ignored, no corruption")
+
+
 def main():
     with tempfile.TemporaryDirectory(prefix="udpbd_") as tmp:
         path = os.path.join(tmp, "test.img")
@@ -125,6 +135,7 @@ def main():
             _read(c, img, 100, 8)      # 8 sectors      -> 128-byte blocks
             _read(c, img, 1000, 512)   # max read       -> 32-byte blocks (~183 packets)
             _read(c, img, 7777, 17)    # odd offset/count
+            _unsolicited_rdma(c, img, 600)  # no write in progress -> must be ignored
             _write(c, path, 200, 5)
             with open(path, "rb") as f:  # the written region must read back as new data
                 img2 = f.read()

--- a/udpbd_server/udpbd_server.py
+++ b/udpbd_server/udpbd_server.py
@@ -201,6 +201,13 @@ class UdpbdServer:
 
     def _handle_write_rdma(self, addr, datagram):
         _, cmdid, _ = unpack_header(datagram)
+        if self._write_left <= 0:
+            # no CMD_WRITE handshake in progress: a stray / duplicate / unsolicited
+            # RDMA would otherwise be written at the *current* file offset (wherever
+            # the last read/write left it) -- an arbitrary sector. Drop it.
+            if self.verbose:
+                print("Dropping unsolicited WRITE_RDMA from {}".format(addr[0]))
+            return
         block_shift, block_count = unpack_block_type(datagram)
         size = block_count * (1 << (block_shift + 2))
         if len(datagram) < 6 + size:
@@ -209,11 +216,15 @@ class UdpbdServer:
             if self.verbose:
                 print("Dropping truncated WRITE_RDMA from {}".format(addr[0]))
             return
+        size = min(size, self._write_left)  # never write past the requested region
         self.bd.write(datagram[6:6 + size])
         self._write_left -= size
         if self._write_left <= 0:
+            # signal failure on a read-only image instead of faking success, so the
+            # PS2 client doesn't believe a save committed when nothing was written
+            result = -1 if self.bd.read_only else 0
             reply = pack_header(CMD_WRITE_DONE, cmdid, (cmdid + 1) & 0xFF)
-            reply += struct.pack("<i", 0)
+            reply += struct.pack("<i", result)
             self.sock.sendto(reply, addr)
 
     def _print_stats(self):


### PR DESCRIPTION
Two things: the macOS feedback from #3, plus a proactive multi-agent review of the launcher + UDPBD port to get ahead of further findings before cutting v0.1.1.

## macOS (#3 feedback)
A Tkinter GUI run as a bare binary on macOS opens backgrounded with no dock/menu presence. So `build.py` now builds a **`.app` bundle** on macOS (`--standalone --macos-create-app-bundle`), and CI zips it into `PS2Servers-macos-arm64.zip`.

## Proactive review fixes (6 confirmed, adversarially verified)
| # | Issue | Sev |
|---|-------|-----|
| 1 | UDPBD honored `WRITE_RDMA` with no `CMD_WRITE` handshake → write at a stale offset = **arbitrary-sector corruption**. Now gated + clamped to the requested region. | med (security) |
| 2 | Re-exec'd server's exit code was discarded → a failed server reported **exit 0**. Now propagated. | med |
| 3 | Relaunch-as-admin orphaned running servers → **port-in-use** on the elevated instance. Now stops them first. | med |
| 4 | stdout pipe fd leaked when a server self-exited. Now closed on EOF. | low |
| 5 | Read-only write faked success (`CMD_WRITE_DONE` status 0) → **silent save loss**. Now replies failure. | low |
| 6 | `on_close` blocked the Tk thread → window looked frozen. Now withdraws first. | low |

Verified: full UDPBD self-test passes (now incl. `STRAY` unsolicited-write and `TRUNC` truncated-write checks), a missing image now exits 1, and the GUI constructs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)