### PR TITLE
CI: add Intel (x86_64) macOS build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
             asset: PS2Servers-linux-x64
           - os: macos-latest
             asset: PS2Servers-macos-arm64.zip
+          - os: macos-13
+            asset: PS2Servers-macos-x64.zip
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Adds a `macos-13` matrix entry so releases include `PS2Servers-macos-x64.zip` (Intel) alongside the Apple-Silicon `PS2Servers-macos-arm64.zip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)