### PR TITLE
UDPBD: handle block-device write errors gracefully

### DIFF
--- a/udpbd_server/selftest.py
+++ b/udpbd_server/selftest.py
@@ -114,6 +114,29 @@ def _unsolicited_rdma(c, img, start):
     print("  STRAY ok: unsolicited WRITE_RDMA ignored, no corruption")
 
 
+def _write_error(c, server, start):
+    # a block-device write failure (disk full / I/O error) must reply -1 and not
+    # crash the server
+    original = server.bd.write
+
+    def _boom(_data):
+        raise OSError("simulated write failure")
+
+    server.bd.write = _boom
+    try:
+        c.sendto(U.pack_header(U.CMD_WRITE, 11, 0) + struct.pack("<IH", start, 1), SRV)
+        c.sendto(U.pack_header(U.CMD_WRITE_RDMA, 11, 0) + U.pack_block_type(7, 1)
+                 + b"\x00" * 512, SRV)
+        data, _ = c.recvfrom(2048)
+        cmd, _, _ = U.unpack_header(data)
+        result = struct.unpack_from("<i", data, 2)[0]
+        assert cmd == U.CMD_WRITE_DONE and result == -1, (cmd, result)
+    finally:
+        server.bd.write = original
+    _info(c, server.bd.sector_count())  # server still answers -> it stayed alive
+    print("  WERR  ok: write error replied -1, server stayed alive")
+
+
 def main():
     with tempfile.TemporaryDirectory(prefix="udpbd_") as tmp:
         path = os.path.join(tmp, "test.img")
@@ -142,6 +165,7 @@ def main():
             _read(c, img2, 200, 5)
             _fuzz(c, size // 512)
             _truncated_rdma(c, img, 400)  # untouched region -> still matches original
+            _write_error(c, server, 700)  # write OSError -> reply -1, no crash
             _optimizer()
             print("ALL UDPBD TESTS PASSED")
         finally:

--- a/udpbd_server/udpbd_server.py
+++ b/udpbd_server/udpbd_server.py
@@ -217,7 +217,17 @@ class UdpbdServer:
                 print("Dropping truncated WRITE_RDMA from {}".format(addr[0]))
             return
         size = min(size, self._write_left)  # never write past the requested region
-        self.bd.write(datagram[6:6 + size])
+        try:
+            self.bd.write(datagram[6:6 + size])
+        except OSError as e:
+            # disk full / I/O error / permission: abort the write and tell the
+            # client it failed, rather than letting the exception kill the server
+            if self.verbose:
+                print("Write error from {}: {}".format(addr[0], e))
+            self._write_left = 0
+            reply = pack_header(CMD_WRITE_DONE, cmdid, (cmdid + 1) & 0xFF)
+            self.sock.sendto(reply + struct.pack("<i", -1), addr)
+            return
         self._write_left -= size
         if self._write_left <= 0:
             # signal failure on a read-only image instead of faking success, so the
@@ -263,10 +273,11 @@ class UdpbdServer:
                     elif self.verbose:
                         print("Ignoring bad/short packet (cmd 0x{:x}) from {}".format(
                             cmd, addr[0]))
-                except (struct.error, IndexError) as e:
-                    # never let a malformed packet (fuzzing / port scan) kill the server
+                except (struct.error, IndexError, OSError) as e:
+                    # never let a malformed packet (fuzzing / port scan) or an I/O
+                    # error on read/send kill the server
                     if self.verbose:
-                        print("Bad packet from {}: {}".format(addr[0], e))
+                        print("Error handling packet from {}: {}".format(addr[0], e))
         except KeyboardInterrupt:
             print("\nShutting down...")
             self._print_stats()


### PR DESCRIPTION
Addresses Gemini's feedback on #5.

**Applied:** `bd.write()` raising `OSError` (disk full / I/O error / permission) previously propagated uncaught and crashed the server. Now `_handle_write_rdma` replies `CMD_WRITE_DONE` failure (`-1`) and aborts the sequence; the dispatch handler also catches `OSError` so a read/send error can't crash the loop. `selftest.py` gains a `WERR` check.

**Not applied — moving `stop_all()` before `relaunch_as_admin()`:** the suggested race doesn't exist here (the elevated instance doesn't auto-start servers / bind ports), and the change would regress the UAC-decline path — `stop_all()` would kill the user's running servers even when elevation is declined and we stay put. The current order only stops servers once relaunch actually succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)