### PR TITLE
CI: cross-build Intel macOS on the Apple-Silicon runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Build release binaries
 
-# Builds the single-file launcher on each OS natively (no cross-compiling) and,
-# when triggered by a version tag like v0.1.0, attaches the binaries to the
-# matching GitHub Release. Use the manual "Run workflow" button to test-build
-# without publishing.
+# Builds the single-file launcher for each platform and, when triggered by a
+# version tag like v0.1.0, attaches the binaries to the matching GitHub Release.
+# Use the manual "Run workflow" button to test-build without publishing.
+#
+# Both macOS builds run on the fast-scheduling Apple-Silicon runner: the arm64
+# one natively, and the Intel (x86_64) one cross-built with a universal2 Python
+# (the free Intel macos-13 runners are being retired and queue for hours).
 on:
   push:
     tags:
@@ -15,7 +18,7 @@ permissions:
 
 jobs:
   build:
-    name: Build (${{ matrix.os }})
+    name: Build ${{ matrix.asset }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -27,14 +30,28 @@ jobs:
             asset: PS2Servers-linux-x64
           - os: macos-latest
             asset: PS2Servers-macos-arm64.zip
-          - os: macos-13
+          - os: macos-latest
             asset: PS2Servers-macos-x64.zip
+            macos_arch: x86_64
     steps:
       - uses: actions/checkout@v4
 
+      # Most jobs use setup-python. The macOS x86_64 cross-build instead needs a
+      # universal2 interpreter (with universal Tcl/Tk) so Nuitka has the x86_64
+      # slice of every linked library.
       - uses: actions/setup-python@v5
+        if: matrix.macos_arch != 'x86_64'
         with:
           python-version: "3.12"
+
+      - name: Install universal2 Python (macOS x86_64 cross-build)
+        if: matrix.macos_arch == 'x86_64'
+        run: |
+          curl -sSLO https://www.python.org/ftp/python/3.12.7/python-3.12.7-macos11.pkg
+          sudo installer -pkg python-3.12.7-macos11.pkg -target /
+          PYBIN=/Library/Frameworks/Python.framework/Versions/3.12/bin
+          sudo ln -sf "$PYBIN/python3" "$PYBIN/python"
+          echo "$PYBIN" >> "$GITHUB_PATH"
 
       - name: Install Tk (Linux)
         if: runner.os == 'Linux'
@@ -44,6 +61,8 @@ jobs:
         run: python -m pip install --upgrade pip nuitka
 
       - name: Build single-file binary
+        env:
+          MACOS_TARGET_ARCH: ${{ matrix.macos_arch }}
         run: python build/build.py
 
       - name: Stage artifact

--- a/build/build.py
+++ b/build/build.py
@@ -64,6 +64,11 @@ def main():
         # background with no dock / menu-bar presence. CI zips the .app for release.
         cmd += ["--standalone", "--macos-create-app-bundle",
                 "--macos-app-name=PS2 Servers"]
+        # optional cross-build target (e.g. x86_64 on an arm64 runner). Needs a
+        # universal2 Python so Nuitka has the target-arch slice of every lib.
+        arch = os.environ.get("MACOS_TARGET_ARCH")
+        if arch:
+            cmd.append("--macos-target-arch=" + arch)
     else:
         cmd.append("--onefile")
 


### PR DESCRIPTION
The free Intel `macos-13` runners are being retired and were queuing for 2+ hours. Build the x86_64 macOS binary on the fast `macos-latest` (arm64) runner instead, via a universal2 Python (python.org, bundles universal Tcl/Tk) + Nuitka `--macos-target-arch=x86_64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)