### PR TITLE
Fix: packaged exe couldn't start servers (re-exec target)

### DIFF
--- a/launcher/main.py
+++ b/launcher/main.py
@@ -1,10 +1,12 @@
 """Launcher entry point.
 
-Normally this opens the GUI (Milestone 2). It also understands two flags used
-internally and for testing:
+Normally this opens the GUI. It also understands a few flags used internally and
+for testing:
 
-  --serve <key> [args...]   run one server in this process (re-exec target)
+  --serve <key> [args...]   run one server in this process (the re-exec target)
   --list                    print the servers available on this machine
+  --selfcheck               verify the re-exec path can actually start a server
+                            (used to confirm the packaged build works)
 """
 
 import platform
@@ -27,6 +29,9 @@ def main(argv=None):
         _print_list()
         return 0
 
+    if "--selfcheck" in argv:
+        return _selfcheck()
+
     try:
         from .gui import run_gui
     except ImportError as e:  # Tkinter not present in this Python build
@@ -34,6 +39,42 @@ def main(argv=None):
         _print_list()
         return 1
     return run_gui()
+
+
+def _selfcheck():
+    """Verify the re-exec path works in this build: build the command the GUI
+    uses to start a server and confirm it actually launches."""
+    import os
+    import subprocess
+    import tempfile
+    import time
+    from .servers import frozen_self_exe, is_frozen, serve_command
+
+    print("is_frozen:", is_frozen())
+    print("sys.executable:", sys.executable)
+    print("sys.argv[0]:", sys.argv[0])
+    print("NUITKA_ONEFILE_BINARY:", os.environ.get("NUITKA_ONEFILE_BINARY"))
+    print("frozen_self_exe:", frozen_self_exe())
+
+    img = os.path.join(tempfile.mkdtemp(prefix="ps2chk_"), "a.img")
+    with open(img, "wb") as f:
+        f.write(b"\0" * 65536)
+    cmd = serve_command("udpbd", [img])
+    print("serve_command:", cmd)
+    try:
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT, text=True)
+    except OSError as e:
+        print("SPAWN FAILED:", e)
+        return 1
+    time.sleep(3)
+    alive = proc.poll() is None
+    print("server alive:", alive)
+    if not alive:
+        print("output:", (proc.stdout.read() or "")[:500])
+    proc.terminate()
+    print("RESULT:", "PASS" if alive else "FAIL")
+    return 0 if alive else 1
 
 
 def _print_list():

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -31,15 +31,32 @@ def is_frozen():
     return bool(getattr(sys, "frozen", False)) or ("__compiled__" in globals())
 
 
+def frozen_self_exe():
+    """Path of the executable to re-launch when frozen.
+
+    In a Nuitka *onefile* build, sys.executable is the temporary EXTRACTED inner
+    binary, which cannot be relaunched -- re-running the app means launching the
+    ORIGINAL onefile exe the user started. Nuitka exposes it via the
+    NUITKA_ONEFILE_BINARY env var; sys.argv[0] is the next-best source.
+    """
+    for candidate in (os.environ.get("NUITKA_ONEFILE_BINARY"),
+                      getattr(sys, "argv", [None])[0]):
+        if candidate:
+            path = os.path.abspath(candidate)
+            if os.path.exists(path):
+                return path
+    return sys.executable
+
+
 def serve_command(key, args):
     """Command that runs the Python server `key` in its own process.
 
-    When bundled, we re-exec *this* executable with a hidden --serve flag, so the
-    embedded Python runs the server with no system Python installed. From source,
-    we re-run the package the same way.
+    When bundled, we re-exec the original onefile exe with a hidden --serve flag,
+    so the embedded Python runs the server with no system Python installed. From
+    source, we re-run the package the same way.
     """
     if is_frozen():
-        return [sys.executable, "--serve", key, *args]
+        return [frozen_self_exe(), "--serve", key, *args]
     return [sys.executable, "-m", "launcher", "--serve", key, *args]
 
 


### PR DESCRIPTION
**Critical:** in the released v0.1.1/v0.1.2 exes, clicking **Start** failed with `[WinError 2] The system cannot find the file specified` — no server could launch from the packaged app.

**Cause:** the GUI starts each bundled Python server by re-executing the app with `--serve`. In a Nuitka **onefile** build, `sys.executable` is the temporary extracted inner binary (an unspawnable temp `python.exe`), not the real `PS2Servers.exe`. The earlier CLI smoke-test invoked `--serve` on the real exe directly, so it masked this.

**Fix:** `frozen_self_exe()` resolves the original onefile binary via `NUITKA_ONEFILE_BINARY` (Nuitka's env var) then `sys.argv[0]`, and the re-exec uses that. Source mode unchanged. The Linux onefile build had the same issue and is fixed by the same change; macOS uses standalone (`.app`), which was unaffected.

**Verified:** new `--selfcheck` mode builds the exact start command and spawns a server from inside the packaged exe → `RESULT: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)