### PR TITLE
Harden --selfcheck cleanup and frozen_self_exe argv access

### DIFF
--- a/launcher/main.py
+++ b/launcher/main.py
@@ -52,29 +52,39 @@ def _selfcheck():
 
     print("is_frozen:", is_frozen())
     print("sys.executable:", sys.executable)
-    print("sys.argv[0]:", sys.argv[0])
+    print("sys.argv[0]:", sys.argv[0] if sys.argv else None)
     print("NUITKA_ONEFILE_BINARY:", os.environ.get("NUITKA_ONEFILE_BINARY"))
     print("frozen_self_exe:", frozen_self_exe())
 
-    img = os.path.join(tempfile.mkdtemp(prefix="ps2chk_"), "a.img")
-    with open(img, "wb") as f:
-        f.write(b"\0" * 65536)
-    cmd = serve_command("udpbd", [img])
-    print("serve_command:", cmd)
-    try:
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.STDOUT, text=True)
-    except OSError as e:
-        print("SPAWN FAILED:", e)
-        return 1
-    time.sleep(3)
-    alive = proc.poll() is None
-    print("server alive:", alive)
-    if not alive:
-        print("output:", (proc.stdout.read() or "")[:500])
-    proc.terminate()
-    print("RESULT:", "PASS" if alive else "FAIL")
-    return 0 if alive else 1
+    with tempfile.TemporaryDirectory(prefix="ps2chk_",
+                                     ignore_cleanup_errors=True) as tmpdir:
+        img = os.path.join(tmpdir, "a.img")
+        with open(img, "wb") as f:
+            f.write(b"\0" * 65536)
+        cmd = serve_command("udpbd", [img])
+        print("serve_command:", cmd)
+        try:
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                    stderr=subprocess.STDOUT, text=True)
+        except OSError as e:
+            print("SPAWN FAILED:", e)
+            return 1
+        alive = False
+        try:
+            time.sleep(3)
+            alive = proc.poll() is None
+            print("server alive:", alive)
+            if not alive:
+                print("output:", (proc.stdout.read() or "")[:500])
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+        print("RESULT:", "PASS" if alive else "FAIL")
+        return 0 if alive else 1
 
 
 def _print_list():

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -39,8 +39,9 @@ def frozen_self_exe():
     ORIGINAL onefile exe the user started. Nuitka exposes it via the
     NUITKA_ONEFILE_BINARY env var; sys.argv[0] is the next-best source.
     """
-    for candidate in (os.environ.get("NUITKA_ONEFILE_BINARY"),
-                      getattr(sys, "argv", [None])[0]):
+    argv = getattr(sys, "argv", None)
+    argv0 = argv[0] if argv else None
+    for candidate in (os.environ.get("NUITKA_ONEFILE_BINARY"), argv0):
         if candidate:
             path = os.path.abspath(candidate)
             if os.path.exists(path):


### PR DESCRIPTION
Addresses Gemini feedback on #13. `--selfcheck` now cleans up its temp dir (`TemporaryDirectory`) and reaps the subprocess in a `finally`; `frozen_self_exe` guards an empty `sys.argv`. Diagnostic/defensive only — no change to shipped behavior, so no re-release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)