### PR TITLE
main(): guard a missing sys.argv too

### DIFF
--- a/launcher/main.py
+++ b/launcher/main.py
@@ -14,7 +14,7 @@ import sys
 
 
 def main(argv=None):
-    argv = list(sys.argv[1:] if argv is None else argv)
+    argv = list(getattr(sys, "argv", [])[1:] if argv is None else argv)
 
     if "--serve" in argv:
         i = argv.index("--serve")


### PR DESCRIPTION
Addresses Gemini feedback on #15 — completes the guards so a (theoretically) missing `sys.argv` doesn't crash `main()` before the inner guards matter. No change to normal behavior; diagnostic/defensive only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)