### PR TITLE
Bump build version stamp to 0.1.4

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -51,8 +51,8 @@ def main():
         "--output-filename=" + out,
         "--company-name=PS2-Servers",
         "--product-name=PS2 Servers",
-        "--product-version=0.1.0",
-        "--file-version=0.1.0",
+        "--product-version=0.1.4",
+        "--file-version=0.1.4",
     ]
     for rel in DATA_FILES:
         cmd.append("--include-data-files={}={}".format(os.path.join(ROOT, rel), rel))


### PR DESCRIPTION
Bumps the exe version metadata 0.1.0 -> 0.1.4 ahead of cutting v0.1.4 (rebuild from current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)