### PR TITLE
main(): readable sys.argv guard

### DIFF
--- a/launcher/main.py
+++ b/launcher/main.py
@@ -14,7 +14,9 @@ import sys
 
 
 def main(argv=None):
-    argv = list((getattr(sys, "argv", None) or [])[1:] if argv is None else argv)
+    if argv is None:
+        argv = (getattr(sys, "argv", None) or [])[1:]
+    argv = list(argv)
 
     if "--serve" in argv:
         i = argv.index("--serve")


### PR DESCRIPTION
Readability: split the dense argv one-liner into an if-block (same behavior). Diagnostic/defensive only; no re-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)