### PR TITLE
Convert GUI to tabbed layout

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -1,9 +1,10 @@
 """Tkinter GUI -- the front-end any user sees.
 
-One card per server: pick a folder/file, hit Start, and the card shows exactly
-what to enter in OPL plus a live log. No terminal required. The GUI never blocks
-on a server; each runs as a subprocess (see process.py) and its output is pumped
-to the log via a thread-safe queue drained on the Tk main thread.
+One tab per server: pick a folder/file, hit Start, and the card shows exactly
+what to enter in OPL. The Terminal tab shows live output from every server. No
+terminal required. The GUI never blocks on a server; each runs as a subprocess
+(see process.py) and its output is pumped to the log via a thread-safe queue
+drained on the Tk main thread.
 """
 
 import platform
@@ -19,6 +20,12 @@ DOT_RUNNING = "●"  # filled circle
 COLOR_RUNNING = "#2e9e44"
 COLOR_STOPPED = "#b0b0b0"
 COLOR_ERROR = "#d23c3c"
+
+TAB_TITLES = {
+    "smbv1": "SMBv1",
+    "udpfs": "UDPFS",
+    "udpbd": "UDPBD",
+}
 
 
 def opl_hint(key, ip, values):
@@ -185,7 +192,7 @@ class LauncherApp:
         self.saved = config.load()
 
         root.title("PS2 Servers")
-        root.minsize(720, 600)
+        root.minsize(720, 540)
         self._build()
         self._restore()
 
@@ -227,25 +234,35 @@ class LauncherApp:
         ttk.Label(header, text="  (enter this in OPL where it asks for the PC/server IP)",
                   foreground="#888").pack(side="left")
 
-        # server cards
-        cards = ttk.Frame(self.root)
-        cards.pack(fill="x", padx=10, pady=4)
+        # main tabs: one server per tab, plus a shared terminal tab
+        self.nb = ttk.Notebook(self.root)
+        self.nb.pack(fill="both", expand=True, padx=10, pady=4)
+        self.server_tabs = {}
+
         for server in REGISTRY.values():
-            card = ServerCard(cards, self, server)
-            card.pack(fill="x", pady=5)
+            tab = ttk.Frame(self.nb)
+            tab.columnconfigure(0, weight=1)
+            card = ServerCard(tab, self, server)
+            card.grid(row=0, column=0, sticky="new", padx=8, pady=8)
+            self.nb.add(tab, text=TAB_TITLES.get(server.key, server.label))
+            self.server_tabs[server.key] = tab
             self.cards[server.key] = card
 
-        # logs
-        logframe = ttk.LabelFrame(self.root, text="  Logs  ")
-        logframe.pack(fill="both", expand=True, padx=10, pady=(4, 6))
-        self.nb = ttk.Notebook(logframe)
-        self.nb.pack(fill="both", expand=True, padx=4, pady=4)
+        self.terminal_tab = ttk.Frame(self.nb)
+        self.terminal_tab.rowconfigure(0, weight=1)
+        self.terminal_tab.columnconfigure(0, weight=1)
+        self.terminal = tk.Text(self.terminal_tab, height=16, wrap="none",
+                                state="disabled", background="#101418",
+                                foreground="#d8dee9", insertbackground="#d8dee9")
+        scroll = ttk.Scrollbar(self.terminal_tab, orient="vertical",
+                               command=self.terminal.yview)
+        self.terminal.configure(yscrollcommand=scroll.set)
+        self.terminal.grid(row=0, column=0, sticky="nsew", padx=(8, 0), pady=8)
+        scroll.grid(row=0, column=1, sticky="ns", padx=(0, 8), pady=8)
+        self.nb.add(self.terminal_tab, text="TERMINAL")
+
         for server in REGISTRY.values():
-            txt = tk.Text(self.nb, height=8, wrap="none", state="disabled",
-                          background="#101418", foreground="#d8dee9",
-                          insertbackground="#d8dee9")
-            self.nb.add(txt, text=server.label)
-            self.logs[server.key] = txt
+            self.logs[server.key] = self.terminal
 
         # footer
         footer = ttk.Frame(self.root)
@@ -318,7 +335,7 @@ class LauncherApp:
             return
         self.procs[key] = proc
         card.refresh_status(True)
-        self.nb.select(list(REGISTRY).index(key))
+        self.nb.select(self.terminal_tab)
 
     def stop_server(self, key):
         proc = self.procs.get(key)
@@ -350,12 +367,19 @@ class LauncherApp:
     def _append_log(self, key, text):
         widget = self.logs[key]
         widget.config(state="normal")
-        widget.insert("end", text)
+        widget.insert("end", self._terminal_text(key, text))
         lines = int(widget.index("end-1c").split(".")[0])
         if lines > 2000:  # keep the log bounded so memory/redraw stay cheap
             widget.delete("1.0", "{}.0".format(lines - 2000))
         widget.see("end")
         widget.config(state="disabled")
+
+    def _terminal_text(self, key, text):
+        prefix = "[{}] ".format(TAB_TITLES.get(key, key.upper()))
+        return "".join(
+            prefix + line if line.strip("\r\n") else line
+            for line in text.splitlines(True)
+        )
 
     # -- status polling --------------------------------------------------- #
     def _poll_status(self):

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -35,12 +35,42 @@ def main(argv=None):
         return _selfcheck()
 
     try:
-        from .gui import run_gui
+        from . import gui
     except ImportError as e:  # Tkinter not present in this Python build
         print("GUI unavailable ({}). Servers on this machine:".format(e))
         _print_list()
         return 1
-    return run_gui()
+    _apply_gui_review_fixes(gui)
+    return gui.run_gui()
+
+
+def _apply_gui_review_fixes(gui):
+    """Apply terminal UX fixes for the tabbed launcher.
+
+    Keeps long terminal lines readable and avoids forcing the terminal back to
+    the bottom while a user is reading earlier log output.
+    """
+    original_text = gui.tk.Text
+
+    def wrapped_text(*args, **kwargs):
+        if kwargs.get("wrap") == "none":
+            kwargs["wrap"] = "char"
+        return original_text(*args, **kwargs)
+
+    def append_log(self, key, text):
+        widget = self.logs[key]
+        at_bottom = widget.yview()[1] >= 0.99
+        widget.config(state="normal")
+        widget.insert("end", self._terminal_text(key, text))
+        lines = int(widget.index("end-1c").split(".")[0])
+        if lines > 2000:  # keep the log bounded so memory/redraw stay cheap
+            widget.delete("1.0", "{}.0".format(lines - 2000))
+        if at_bottom:
+            widget.see("end")
+        widget.config(state="disabled")
+
+    gui.tk.Text = wrapped_text
+    gui.LauncherApp._append_log = append_log
 
 
 def _selfcheck():


### PR DESCRIPTION
## Summary
- Replaces the single vertical stack of server cards with top-level tabs: `SMBv1`, `UDPFS`, `UDPBD`, and `TERMINAL`.
- Moves each server's controls into its own tab.
- Consolidates all runtime output into the `TERMINAL` tab with server-prefixed log lines.
- Adds a vertical scrollbar to the terminal output.
- Applies terminal review fixes so long lines wrap and active output only auto-scrolls when the terminal is already near the bottom.

## Validation
- Compared branch against `main`: two modified files, `launcher/gui.py` and `launcher/main.py`.
- PR is open and mergeable.