### PR TITLE
Add automatic main branch release workflow

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -1,0 +1,99 @@
+name: Release on main
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-on-main
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows
+            os: windows-latest
+            artifact_name: PS2Servers-Windows
+            asset_name: PS2Servers-Windows.zip
+            package_command: Compress-Archive -Path dist/PS2Servers.exe -DestinationPath PS2Servers-Windows.zip -Force
+          - name: Linux
+            os: ubuntu-latest
+            artifact_name: PS2Servers-Linux
+            asset_name: PS2Servers-Linux.tar.gz
+            package_command: tar -czf PS2Servers-Linux.tar.gz -C dist PS2Servers
+          - name: macOS
+            os: macos-latest
+            artifact_name: PS2Servers-macOS
+            asset_name: PS2Servers-macOS.zip
+            package_command: ditto -c -k --sequesterRsrc --keepParent "dist/PS2 Servers.app" PS2Servers-macOS.zip
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build dependencies
+        run: python -m pip install --upgrade pip nuitka ordered-set zstandard
+
+      - name: Build app
+        run: python build/build.py
+
+      - name: Package artifact
+        shell: bash
+        run: ${{ matrix.package_command }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.asset_name }}
+          if-no-files-found: error
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Create release tag
+        id: tag
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          TAG="main-${GITHUB_RUN_NUMBER}-${SHORT_SHA}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: PS2 Servers ${{ steps.tag.outputs.tag }}
+          body: |
+            Automatic release from `main`.
+
+            Commit: ${{ github.sha }}
+          files: release-assets/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -25,17 +25,14 @@ jobs:
             os: windows-latest
             artifact_name: PS2Servers-Windows
             asset_name: PS2Servers-Windows.zip
-            package_command: Compress-Archive -Path dist/PS2Servers.exe -DestinationPath PS2Servers-Windows.zip -Force
           - name: Linux
             os: ubuntu-latest
             artifact_name: PS2Servers-Linux
             asset_name: PS2Servers-Linux.tar.gz
-            package_command: tar -czf PS2Servers-Linux.tar.gz -C dist PS2Servers
           - name: macOS
             os: macos-latest
             artifact_name: PS2Servers-macOS
             asset_name: PS2Servers-macOS.zip
-            package_command: ditto -c -k --sequesterRsrc --keepParent "dist/PS2 Servers.app" PS2Servers-macOS.zip
 
     steps:
       - name: Check out repository
@@ -46,15 +43,38 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install build dependencies
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y patchelf python3-tk
+
+      - name: Install Python build dependencies
         run: python -m pip install --upgrade pip nuitka ordered-set zstandard
 
       - name: Build app
         run: python build/build.py
 
-      - name: Package artifact
+      - name: Package Windows app
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Compress-Archive -Path dist/PS2Servers.exe -DestinationPath ${{ matrix.asset_name }} -Force
+
+      - name: Package Linux app
+        if: runner.os == 'Linux'
         shell: bash
-        run: ${{ matrix.package_command }}
+        run: tar -czf ${{ matrix.asset_name }} -C dist PS2Servers
+
+      - name: Package macOS app
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          APP_PATH="dist/PS2 Servers.app"
+          if [ ! -d "$APP_PATH" ]; then
+            APP_PATH="$(find dist -maxdepth 1 -name '*.app' -type d | head -n 1)"
+          fi
+          test -n "$APP_PATH"
+          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" ${{ matrix.asset_name }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release-on-main.yml`.
- Runs automatically on every push to `main`, with manual `workflow_dispatch` support.
- Builds the Nuitka launcher on Windows, Linux, and macOS using the existing `build/build.py` script.
- Uploads platform-specific archives as workflow artifacts.
- Publishes a GitHub Release with all built assets attached.
- Uses unique release tags in the form `main-<run_number>-<short_sha>` so every main-branch push can create its own release without tag collisions.

## Notes
- The workflow grants `contents: write` so `GITHUB_TOKEN` can create tags/releases.
- Linux installs `patchelf` and `python3-tk` before running the Nuitka build.
- macOS packaging searches `dist/*.app` as a fallback if the exact app bundle name differs.

## Validation
- Created the workflow on a branch for review.
- Hardened packaging steps so Windows uses PowerShell, Linux uses tar, and macOS uses ditto.