### PR TITLE
Auto-configure Windows SMB1 and firewall from the GUI

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -56,8 +56,8 @@ def main():
         "--output-filename=" + out,
         "--company-name=PS2-Servers",
         "--product-name=PS2 Servers",
-        "--product-version=0.1.4",
-        "--file-version=0.1.4",
+        "--product-version=0.1.5",
+        "--file-version=0.1.5",
     ]
     for rel in DATA_FILES:
         cmd.append("--include-data-files={}={}".format(os.path.join(ROOT, rel), rel))

--- a/launcher/elevate.py
+++ b/launcher/elevate.py
@@ -1,17 +1,14 @@
-"""Windows UAC elevation for the one option that needs admin rights.
+"""Windows UAC elevation for setup tasks that need admin rights.
 
-Only SMBv1's ``--take-445`` needs administrator privileges (it pauses Windows'
-LanmanServer to bind the standard port 445). Managing a single elevated child
-from a non-elevated parent is painful on Windows (UIPI blocks piping and
-termination), so instead we relaunch the *whole* launcher elevated -- then every
-server still streams its logs and stops normally.
+The launcher relaunches itself elevated instead of trying to manage one elevated
+child process. That keeps server logs, shutdown, and tray handling normal.
 """
 
 import os
 import platform
 import sys
 
-from .servers import REPO_ROOT, is_frozen
+from .servers import REPO_ROOT, frozen_self_exe, is_frozen
 
 
 def is_admin():
@@ -40,7 +37,7 @@ def relaunch_as_admin():
     try:
         import ctypes
         if is_frozen():
-            exe, params, cwd = sys.executable, "", None
+            exe, params, cwd = frozen_self_exe(), "", None
         else:  # from source: re-run `python -m launcher` from the repo root
             exe, params, cwd = sys.executable, "-m launcher", REPO_ROOT
         # ShellExecuteW returns a value > 32 on success.

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -12,7 +12,7 @@ import queue
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 
-from . import config, elevate, netinfo, tray
+from . import config, elevate, netinfo, tray, windows_setup
 from .process import ServerProcess
 from .servers import REGISTRY, REPO_ROOT
 
@@ -30,7 +30,7 @@ TAB_TITLES = {
 
 def opl_hint(key, ip, values):
     if key == "smbv1":
-        port = str(values.get("port") or 1445)
+        port = "445" if values.get("take_445") else str(values.get("port") or 1445)
         return ("In OPL → Network:  IP {}  ·  Port {}  ·  Share 'games'  "
                 "·  NetBIOS off  ·  user/pass blank".format(ip, port))
     if key == "udpfs":
@@ -220,6 +220,8 @@ class LauncherApp:
 
         self.root.after(150, self._drain_logs)
         self.root.after(600, self._poll_status)
+        if self.saved.get("pending_start"):
+            self.root.after(350, self._start_pending)
 
     def _build(self):
         # header: LAN IP the user types into OPL
@@ -296,27 +298,7 @@ class LauncherApp:
                                  "Please set: " + ", ".join(missing))
             return
 
-        if key == "smbv1" and values.get("take_445") and not elevate.is_admin():
-            if not elevate.can_elevate():
-                messagebox.showerror(
-                    "Administrator required",
-                    "'Take port 445' needs Windows administrator rights.")
-                return
-            if messagebox.askyesno(
-                    "Administrator required",
-                    "'Take port 445' needs administrator rights.\n\n"
-                    "Restart the launcher as administrator now? Your settings are "
-                    "saved — then click Start again."):
-                self._save()
-                if elevate.relaunch_as_admin():
-                    self.stop_all()  # free ports before the elevated instance starts
-                    if self._tray:
-                        self._tray.stop()
-                    self.root.destroy()
-                else:
-                    messagebox.showerror(
-                        "Elevation failed",
-                        "Could not restart as administrator.")
+        if not self._ensure_windows_ready(key, values):
             return
 
         try:
@@ -336,6 +318,71 @@ class LauncherApp:
         self.procs[key] = proc
         card.refresh_status(True)
         self.nb.select(self.terminal_tab)
+
+    def _ensure_windows_ready(self, key, values):
+        if not windows_setup.is_windows():
+            return True
+
+        setup_needed = True
+        try:
+            setup_needed = windows_setup.needs_setup(key, values)
+        except Exception as e:
+            self._append_log(key, "[setup] Windows setup check failed; elevation will retry: {}\n".format(e))
+
+        admin_required = setup_needed or (key == "smbv1" and values.get("take_445"))
+        if admin_required and not elevate.is_admin():
+            if not elevate.can_elevate():
+                messagebox.showerror(
+                    "Administrator required",
+                    "Windows network setup needs administrator rights.")
+                return False
+
+            summary = windows_setup.setup_summary(key, values)
+            if messagebox.askyesno(
+                    "Administrator required",
+                    "PS2 Servers needs administrator rights to {}.\n\n"
+                    "Restart the launcher as administrator now? Your settings are "
+                    "saved and the server will continue automatically.".format(summary)):
+                self._save(pending_start=key)
+                if elevate.relaunch_as_admin():
+                    self.stop_all()  # free ports before the elevated instance starts
+                    if self._tray:
+                        self._tray.stop()
+                    self.root.destroy()
+                else:
+                    messagebox.showerror(
+                        "Elevation failed",
+                        "Could not restart as administrator.")
+            return False
+
+        if elevate.is_admin():
+            try:
+                result = windows_setup.apply_setup(key, values)
+            except windows_setup.WindowsSetupError as e:
+                messagebox.showerror("Windows setup failed", str(e))
+                self._append_log(key, "[setup] failed:\n{}\n".format(e))
+                return False
+
+            output = result.get("output") or ""
+            if output:
+                self._append_log(key, "[setup] {}\n".format(output.replace("\n", "\n[setup] ")))
+            if result.get("restart_needed"):
+                messagebox.showwarning(
+                    "Windows restart may be needed",
+                    "Windows enabled or changed an SMB1 optional feature and reported "
+                    "that a restart may be needed before that Windows feature is fully active.\n\n"
+                    "The PS2 Servers app will still try to start now.")
+        return True
+
+    def _start_pending(self):
+        key = self.saved.get("pending_start")
+        if key not in self.cards:
+            return
+        self.saved.pop("pending_start", None)
+        self._save()
+        self.nb.select(self.server_tabs[key])
+        self._append_log(key, "[launcher] continuing after administrator restart\n")
+        self.start_server(key)
 
     def stop_server(self, key):
         proc = self.procs.get(key)
@@ -401,9 +448,11 @@ class LauncherApp:
         if ip and ip in netinfo.all_ipv4():
             self.ip_var.set(ip)
 
-    def _save(self):
+    def _save(self, pending_start=None):
         data = {"servers": {key: card.values() for key, card in self.cards.items()},
                 "ip": self.ip_var.get()}
+        if pending_start:
+            data["pending_start"] = pending_start
         try:
             config.save(data)
         except OSError:

--- a/launcher/windows_setup.py
+++ b/launcher/windows_setup.py
@@ -1,0 +1,263 @@
+"""Windows setup helpers for the GUI launcher.
+
+The GUI uses these helpers to keep end users out of PowerShell, Windows Features,
+and Windows Firewall screens. All mutating actions require an elevated launcher;
+the unelevated launcher only checks whether setup is already complete.
+"""
+
+import os
+import platform
+import subprocess
+import sys
+
+from .servers import frozen_self_exe, is_frozen
+
+
+SMB1_FEATURES = (
+    "SMB1Protocol",
+    "SMB1Protocol-Client",
+    "SMB1Protocol-Server",
+)
+SMB1_REMOVAL_FEATURE = "SMB1Protocol-Deprecation"
+
+UDPBD_PORT = 0xBDBD
+
+
+class WindowsSetupError(RuntimeError):
+    """Raised when Windows setup cannot be checked or applied."""
+
+
+def is_windows():
+    return platform.system() == "Windows"
+
+
+def _powershell(script):
+    """Run a small PowerShell script and return CompletedProcess."""
+    return subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy", "Bypass",
+            "-Command", script,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _ps_quote(value):
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _server_program_path():
+    """Path to allow through Windows Firewall.
+
+    Packaged builds must allow the original onefile executable, not Nuitka's
+    temporary extracted inner exe. Source runs allow python.exe because the
+    server child is also python.exe.
+    """
+    if is_frozen():
+        return frozen_self_exe()
+    return sys.executable
+
+
+def _parse_port(value, default):
+    if value in ("", None, False):
+        return int(default)
+    try:
+        return int(str(value), 0)
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def _server_ports(key, values):
+    """Return [(protocol, port, purpose), ...] for fixed inbound ports."""
+    if key == "smbv1":
+        port = 445 if values.get("take_445") else _parse_port(values.get("port"), 1445)
+        return [("TCP", port, "SMBv1")]
+    if key == "udpfs":
+        return [("UDP", _parse_port(values.get("port"), 0xF5F6), "UDPFS discovery")]
+    if key == "udpbd":
+        return [("UDP", UDPBD_PORT, "UDPBD")]
+    return []
+
+
+def _rule_names(key, values):
+    rules = [
+        "PS2 Servers - App"
+    ]
+    for proto, port, purpose in _server_ports(key, values):
+        rules.append("PS2 Servers - {} {} {}".format(purpose, proto, port))
+    return rules
+
+
+def needs_setup(key, values):
+    """True if an elevated setup pass is needed before starting this server.
+
+    Query failures deliberately return True: if Windows blocks the check, the
+    elevated path is the safer and more useful fallback.
+    """
+    if not is_windows():
+        return False
+
+    feature_lines = []
+    if key == "smbv1":
+        feature_array = "@({})".format(",".join(_ps_quote(f) for f in SMB1_FEATURES))
+        removal = _ps_quote(SMB1_REMOVAL_FEATURE)
+        feature_lines = [
+            "$features = {}".format(feature_array),
+            "foreach ($name in $features) {",
+            "  $f = Get-WindowsOptionalFeature -Online -FeatureName $name -ErrorAction SilentlyContinue",
+            "  if ($null -ne $f -and $f.State -ne 'Enabled') { Write-Output ('NEED_FEATURE=' + $name) }",
+            "}",
+            "$d = Get-WindowsOptionalFeature -Online -FeatureName {} -ErrorAction SilentlyContinue".format(removal),
+            "if ($null -ne $d -and $d.State -eq 'Enabled') { Write-Output ('NEED_DISABLE=' + {}) }".format(removal),
+        ]
+
+    port_rule_names = _rule_names(key, values)[1:]
+    rule_array = "@({})".format(",".join(_ps_quote(n) for n in port_rule_names))
+    program = _ps_quote(os.path.abspath(_server_program_path()))
+    app_rule = _ps_quote("PS2 Servers - App")
+    script = "\n".join(feature_lines + [
+        "$appRuleName = {}".format(app_rule),
+        "$appProgram = {}".format(program),
+        "$appRule = Get-NetFirewallRule -DisplayName $appRuleName -ErrorAction SilentlyContinue",
+        "if (-not $appRule) {",
+        "  Write-Output ('NEED_RULE=' + $appRuleName)",
+        "} else {",
+        "  $appFilter = $appRule | Get-NetFirewallApplicationFilter",
+        "  $programs = @($appFilter | ForEach-Object { $_.Program })",
+        "  if ($programs -notcontains $appProgram) { Write-Output ('NEED_RULE=' + $appRuleName) }",
+        "}",
+        "$rules = {}".format(rule_array),
+        "foreach ($name in $rules) {",
+        "  if (-not (Get-NetFirewallRule -DisplayName $name -ErrorAction SilentlyContinue)) {",
+        "    Write-Output ('NEED_RULE=' + $name)",
+        "  }",
+        "}",
+    ])
+    res = _powershell(script)
+    if res.returncode != 0:
+        return True
+    return bool((res.stdout or "").strip())
+
+
+def apply_setup(key, values):
+    """Enable required Windows features and firewall rules.
+
+    Returns a dict:
+      changed: whether anything was changed
+      restart_needed: Windows reported a pending restart for an optional feature
+      output: human-readable setup log
+    """
+    if not is_windows():
+        return {"changed": False, "restart_needed": False, "output": ""}
+
+    program = os.path.abspath(_server_program_path())
+    rules = []
+    rules.append({
+        "name": "PS2 Servers - App",
+        "protocol": "Any",
+        "port": None,
+        "program": program,
+    })
+    for proto, port, purpose in _server_ports(key, values):
+        rules.append({
+            "name": "PS2 Servers - {} {} {}".format(purpose, proto, port),
+            "protocol": proto,
+            "port": int(port),
+            "program": None,
+        })
+
+    feature_script = []
+    if key == "smbv1":
+        feature_array = "@({})".format(",".join(_ps_quote(f) for f in SMB1_FEATURES))
+        removal = _ps_quote(SMB1_REMOVAL_FEATURE)
+        feature_script = [
+            "$features = {}".format(feature_array),
+            "foreach ($name in $features) {",
+            "  $f = Get-WindowsOptionalFeature -Online -FeatureName $name -ErrorAction SilentlyContinue",
+            "  if ($null -eq $f) {",
+            "    Write-Output ('SMB1 missing optional feature: ' + $name)",
+            "    continue",
+            "  }",
+            "  if ($f.State -ne 'Enabled') {",
+            "    Write-Output ('Enabling Windows optional feature: ' + $name)",
+            "    $r = Enable-WindowsOptionalFeature -Online -FeatureName $name -All -NoRestart -ErrorAction Stop",
+            "    $changed = $true",
+            "    if ($r.RestartNeeded) { $restartNeeded = $true }",
+            "  } else {",
+            "    Write-Output ('Windows optional feature already enabled: ' + $name)",
+            "  }",
+            "}",
+            "$d = Get-WindowsOptionalFeature -Online -FeatureName {} -ErrorAction SilentlyContinue".format(removal),
+            "if ($null -ne $d -and $d.State -eq 'Enabled') {",
+            "  Write-Output ('Disabling SMB1 automatic removal: ' + {})".format(removal),
+            "  $r = Disable-WindowsOptionalFeature -Online -FeatureName {} -NoRestart -ErrorAction Stop".format(removal),
+            "  $changed = $true",
+            "  if ($r.RestartNeeded) { $restartNeeded = $true }",
+            "}",
+        ]
+
+    rule_lines = []
+    for rule in rules:
+        name = _ps_quote(rule["name"])
+        proto = _ps_quote(rule["protocol"])
+        rule_lines += [
+            "$ruleName = {}".format(name),
+            "$existing = Get-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue",
+            "if ($existing) {",
+            "  Write-Output ('Refreshing firewall rule: ' + $ruleName)",
+            "  Remove-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue",
+            "} else {",
+            "  Write-Output ('Creating firewall rule: ' + $ruleName)",
+            "}",
+        ]
+        if rule["program"]:
+            rule_lines.append(
+                "New-NetFirewallRule -DisplayName $ruleName -Direction Inbound -Action Allow "
+                "-Profile Any -Protocol Any -Program {} -ErrorAction Stop | Out-Null".format(
+                    _ps_quote(rule["program"]))
+            )
+        else:
+            rule_lines.append(
+                "New-NetFirewallRule -DisplayName $ruleName -Direction Inbound -Action Allow "
+                "-Profile Any -Protocol {} -LocalPort {} -ErrorAction Stop | Out-Null".format(
+                    proto, int(rule["port"]))
+            )
+        rule_lines.append("$changed = $true")
+
+    script = "\n".join([
+        "$ErrorActionPreference = 'Stop'",
+        "$changed = $false",
+        "$restartNeeded = $false",
+    ] + feature_script + rule_lines + [
+        "Write-Output ('SETUP_CHANGED=' + $changed)",
+        "Write-Output ('RESTART_NEEDED=' + $restartNeeded)",
+    ])
+
+    res = _powershell(script)
+    output = ((res.stdout or "") + (res.stderr or "")).strip()
+    if res.returncode != 0:
+        raise WindowsSetupError(output or "Windows setup failed.")
+
+    upper = output.upper()
+    return {
+        "changed": "SETUP_CHANGED=TRUE" in upper,
+        "restart_needed": "RESTART_NEEDED=TRUE" in upper,
+        "output": output,
+    }
+
+
+def setup_summary(key, values):
+    if not is_windows():
+        return ""
+    parts = []
+    if key == "smbv1":
+        parts.append("enable the Windows SMB 1.0/CIFS feature tree")
+    ports = _server_ports(key, values)
+    if ports:
+        parts.append("create Windows Firewall allow rules")
+    if not parts:
+        return "apply Windows network setup"
+    return " and ".join(parts)


### PR DESCRIPTION
## Summary

- Adds `launcher/windows_setup.py` for Windows-only setup checks and elevated setup application.
- Enables the SMB 1.0/CIFS optional-feature tree for the SMBv1 tab: `SMB1Protocol`, `SMB1Protocol-Client`, and `SMB1Protocol-Server`.
- Disables SMB1 automatic removal when Windows exposes `SMB1Protocol-Deprecation`, so Windows does not quietly undo the setup later.
- Creates/refreshes Windows Firewall inbound rules for the app plus the selected server port.
- Keeps users out of terminal/settings: the GUI prompts for UAC only when needed, saves the selected server, relaunches elevated, then continues the server automatically.
- Fixes packaged one-file UAC relaunch to use the original Nuitka onefile executable instead of the temporary extracted child executable.
- Bumps the packaged app version to 0.1.5.

## Notes

Windows may report that a restart is needed after changing optional features. The GUI warns about that but still attempts to start the selected server immediately.