### PR TITLE
Harden Windows SMB setup and release verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  python-checks:
+    name: Python checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Compile Python sources
+        run: python -m compileall -q launcher smbv1_server udpbd_server udpfs_server ps2servers.py
+
+      - name: Run UDPBD protocol selftest
+        run: python udpbd_server/selftest.py

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 concurrency:
   group: release-on-main
@@ -53,7 +55,9 @@ jobs:
           sudo apt-get install -y patchelf python3-tk
 
       - name: Install Python build dependencies
-        run: python -m pip install --upgrade pip nuitka ordered-set zstandard
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-build.txt
 
       - name: Build app
         run: python build/build.py
@@ -83,6 +87,11 @@ jobs:
           test -n "$APP_PATH"
           ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" ${{ matrix.asset_name }}
 
+      - name: Generate artifact attestation
+        uses: actions/attest@v4
+        with:
+          subject-path: ${{ matrix.asset_name }}
+
       - name: Upload release asset artifact
         uses: actions/upload-artifact@v4
         with:
@@ -90,9 +99,36 @@ jobs:
           path: ${{ matrix.asset_name }}
           if-no-files-found: error
 
+  source:
+    name: Package source archive
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Create portable source zip
+        shell: bash
+        run: |
+          git archive --format=zip --output=PS2Servers-source.zip HEAD
+
+      - name: Generate source attestation
+        uses: actions/attest@v4
+        with:
+          subject-path: PS2Servers-source.zip
+
+      - name: Upload source artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: PS2Servers-source.zip
+          path: PS2Servers-source.zip
+          if-no-files-found: error
+
   release:
     name: Publish release
-    needs: build
+    needs:
+      - build
+      - source
     runs-on: ubuntu-latest
 
     steps:
@@ -104,6 +140,19 @@ jobs:
         with:
           path: release-assets
           merge-multiple: true
+
+      - name: Generate SHA256 checksums
+        shell: bash
+        run: |
+          cd release-assets
+          sha256sum \
+            PS2Servers-linux-x64 \
+            PS2Servers-macos-arm64.zip \
+            PS2Servers-macos-x64.zip \
+            PS2Servers-source.zip \
+            PS2Servers-windows-x64.exe \
+            > SHA256SUMS.txt
+          cat SHA256SUMS.txt
 
       - name: Create release tag
         id: tag
@@ -121,10 +170,18 @@ jobs:
             Automatic release from `main`.
 
             Commit: ${{ github.sha }}
+
+            Security notes:
+            - The Windows SMB server uses PS2 Servers' built-in SMB/CIFS implementation and does not enable Windows SMB1.
+            - Release assets include `SHA256SUMS.txt`.
+            - GitHub artifact attestations are generated for binary and source artifacts.
+            - For the lowest-trust path, use `PS2Servers-source.zip` and run from source.
           files: |
             release-assets/PS2Servers-linux-x64
             release-assets/PS2Servers-macos-arm64.zip
             release-assets/PS2Servers-macos-x64.zip
+            release-assets/PS2Servers-source.zip
             release-assets/PS2Servers-windows-x64.exe
+            release-assets/SHA256SUMS.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,27 @@ It detects your PC's LAN IP and shows the exact settings to enter in OPL.
 - **From source:** double-click **`Start-Launcher.bat`** (Windows) or run
   `./start-launcher.sh` (Linux/macOS). Requires Python 3.
 
+## Windows security note
+
+PS2 Servers is an unsigned open-source network tool. Because it runs local server
+processes and may ask Windows Firewall to allow inbound LAN traffic, some
+antivirus products may flag the packaged Windows EXE heuristically.
+
+The SMBv1/RiptOPL server does **not** enable Windows' built-in SMB1 optional
+feature tree. It speaks the OPL-compatible SMB1/CIFS subset itself and normally
+listens on custom TCP port `1445`; OPL connects to this program directly.
+
+Windows setup is intentionally narrow:
+
+- no automatic enabling of Windows SMB1;
+- no disabling of SMB1 automatic removal;
+- Windows Firewall changes are limited to rules named `PS2 Servers - ...`;
+- a cleanup script is provided at `tools/remove-windows-firewall-rules.ps1`;
+- advanced port `445` mode is optional and temporarily pauses Windows File
+  Sharing only while that server mode is running.
+
+See [SECURITY.md](SECURITY.md) for verification, cleanup, and reporting details.
+
 ## What's inside
 
 All three servers are pure-Python (standard library) and run on Windows, Linux and macOS.
@@ -50,9 +71,23 @@ python -m launcher --list            # show servers available on this machine
 executable per OS — no Python install required for the end user:
 
 ```sh
-python -m pip install nuitka
+python -m pip install -r requirements-build.txt
 python build/build.py            # -> dist/PS2Servers(.exe)
 ```
+
+## Release verification
+
+Automatic releases include `SHA256SUMS.txt`, a portable source ZIP, and GitHub
+artifact attestations for the packaged assets. Example verification:
+
+```sh
+sha256sum -c SHA256SUMS.txt
+gh attestation verify PS2Servers-windows-x64.exe -R NathanNeurotic/PS2-Servers
+```
+
+Checksums prove the file was downloaded intact. Attestations prove build
+provenance. Neither is a magic safety certificate; if you want the lowest-trust
+path, inspect and run from source.
 
 ## Status
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,85 @@
+# Security Policy
+
+## Project security posture
+
+PS2 Servers is an open-source local-network tool for PlayStation 2 homebrew use.
+It starts small LAN server processes so Open PS2 Loader and compatible forks can
+load files from a PC.
+
+The packaged Windows executable is unsigned. Antivirus products may flag unsigned
+network tools heuristically, especially when they open local server ports or ask
+for Windows Firewall rules.
+
+## Windows SMB behavior
+
+The SMBv1/RiptOPL server does **not** enable or depend on Windows' built-in SMB1
+optional feature tree.
+
+Normal SMB mode uses PS2 Servers' own small SMB/CIFS implementation and listens
+on a custom TCP port, normally `1445`. OPL connects to this program directly.
+Windows file sharing does not need to expose SMB1.
+
+The advanced "Take port 445" option is different:
+
+- it is optional;
+- it requires administrator rights;
+- it temporarily pauses Windows File Sharing / `LanmanServer` while the PS2
+  Servers SMB server is running;
+- it does not enable Windows SMB1;
+- it does not permanently disable Windows file sharing.
+
+## Windows Firewall behavior
+
+When needed, the launcher may ask for administrator rights to create inbound
+Windows Firewall allow rules named with the prefix:
+
+```text
+PS2 Servers -
+```
+
+Manual cleanup from an elevated PowerShell prompt:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\tools\remove-windows-firewall-rules.ps1
+```
+
+or:
+
+```powershell
+Get-NetFirewallRule -DisplayName "PS2 Servers - *" -ErrorAction SilentlyContinue |
+  Remove-NetFirewallRule
+```
+
+## Release verification
+
+Release assets are built by GitHub Actions from this public repository. Releases
+include:
+
+- packaged Windows/Linux/macOS assets;
+- a portable source ZIP;
+- `SHA256SUMS.txt` for release asset checksums;
+- GitHub artifact attestations for build provenance.
+
+GitHub artifact attestations can be verified with the GitHub CLI. Example:
+
+```sh
+gh attestation verify PS2Servers-windows-x64.exe -R NathanNeurotic/PS2-Servers
+```
+
+Checksums verify file integrity, and attestations verify build provenance. They do
+not prove that a program is harmless. Users who want the lowest-trust path should
+inspect the source and run from source instead of using the unsigned packaged EXE.
+
+## Reporting a security issue
+
+Please open a GitHub issue if the report can be public.
+
+For malware or antivirus false-positive reports, include:
+
+- the exact release asset name;
+- the release tag or commit SHA;
+- the detecting product name and version;
+- the full detection name;
+- a VirusTotal or vendor report link if available.
+
+Do not upload third-party private samples or user data to the issue tracker.

--- a/launcher/windows_setup.py
+++ b/launcher/windows_setup.py
@@ -1,8 +1,9 @@
 """Windows setup helpers for the GUI launcher.
 
-The GUI uses these helpers to keep end users out of PowerShell, Windows Features,
-and Windows Firewall screens. All mutating actions require an elevated launcher;
-the unelevated launcher only checks whether setup is already complete.
+The launcher uses these helpers to keep end users out of Windows Firewall
+screens. Normal PS2 Servers SMB mode uses the repo's own small SMB/CIFS server
+on a custom TCP port and does not enable or depend on the Windows SMB1 optional
+feature tree.
 """
 
 import os
@@ -12,19 +13,12 @@ import sys
 
 from .servers import frozen_self_exe, is_frozen
 
-
-SMB1_FEATURES = (
-    "SMB1Protocol",
-    "SMB1Protocol-Client",
-    "SMB1Protocol-Server",
-)
-SMB1_REMOVAL_FEATURE = "SMB1Protocol-Deprecation"
-
 UDPBD_PORT = 0xBDBD
+FIREWALL_RULE_PREFIX = "PS2 Servers - "
 
 
 class WindowsSetupError(RuntimeError):
-    """Raised when Windows setup cannot be checked or applied."""
+    """Raised when Windows setup cannot be checked, applied, or removed."""
 
 
 def is_windows():
@@ -92,34 +86,42 @@ def _rule_names(key, values):
     return rules
 
 
+def _firewall_rules(key, values):
+    program = os.path.abspath(_server_program_path())
+    rules = [{
+        "name": "PS2 Servers - App",
+        "protocol": "Any",
+        "port": None,
+        "program": program,
+    }]
+    for proto, port, purpose in _server_ports(key, values):
+        rules.append({
+            "name": "PS2 Servers - {} {} {}".format(purpose, proto, port),
+            "protocol": proto,
+            "port": int(port),
+            "program": None,
+        })
+    return rules
+
+
 def needs_setup(key, values):
-    """True if an elevated setup pass is needed before starting this server.
+    """True if an elevated firewall setup pass is needed before starting.
 
     Query failures deliberately return True: if Windows blocks the check, the
     elevated path is the safer and more useful fallback.
+
+    Important: this check deliberately does not inspect or request Windows SMB1
+    optional features. The bundled SMB server speaks the OPL-compatible SMB1/CIFS
+    subset itself and should normally run on a custom port.
     """
     if not is_windows():
         return False
-
-    feature_lines = []
-    if key == "smbv1":
-        feature_array = "@({})".format(",".join(_ps_quote(f) for f in SMB1_FEATURES))
-        removal = _ps_quote(SMB1_REMOVAL_FEATURE)
-        feature_lines = [
-            "$features = {}".format(feature_array),
-            "foreach ($name in $features) {",
-            "  $f = Get-WindowsOptionalFeature -Online -FeatureName $name -ErrorAction SilentlyContinue",
-            "  if ($null -ne $f -and $f.State -ne 'Enabled') { Write-Output ('NEED_FEATURE=' + $name) }",
-            "}",
-            "$d = Get-WindowsOptionalFeature -Online -FeatureName {} -ErrorAction SilentlyContinue".format(removal),
-            "if ($null -ne $d -and $d.State -eq 'Enabled') { Write-Output ('NEED_DISABLE=' + {}) }".format(removal),
-        ]
 
     port_rule_names = _rule_names(key, values)[1:]
     rule_array = "@({})".format(",".join(_ps_quote(n) for n in port_rule_names))
     program = _ps_quote(os.path.abspath(_server_program_path()))
     app_rule = _ps_quote("PS2 Servers - App")
-    script = "\n".join(feature_lines + [
+    script = "\n".join([
         "$appRuleName = {}".format(app_rule),
         "$appProgram = {}".format(program),
         "$appRule = Get-NetFirewallRule -DisplayName $appRuleName -ErrorAction SilentlyContinue",
@@ -147,64 +149,20 @@ def needs_setup(key, values):
 
 
 def apply_setup(key, values):
-    """Enable required Windows features and firewall rules.
+    """Create required Windows Firewall allow rules.
 
     Returns a dict:
       changed: whether anything was changed
-      restart_needed: Windows reported a pending restart for an optional feature
+      restart_needed: always False; firewall-only setup does not require reboot
       output: human-readable setup log
+
+    This function does not enable Windows SMB1 optional features.
     """
     if not is_windows():
         return {"changed": False, "restart_needed": False, "output": ""}
 
-    program = os.path.abspath(_server_program_path())
-    rules = []
-    rules.append({
-        "name": "PS2 Servers - App",
-        "protocol": "Any",
-        "port": None,
-        "program": program,
-    })
-    for proto, port, purpose in _server_ports(key, values):
-        rules.append({
-            "name": "PS2 Servers - {} {} {}".format(purpose, proto, port),
-            "protocol": proto,
-            "port": int(port),
-            "program": None,
-        })
-
-    feature_script = []
-    if key == "smbv1":
-        feature_array = "@({})".format(",".join(_ps_quote(f) for f in SMB1_FEATURES))
-        removal = _ps_quote(SMB1_REMOVAL_FEATURE)
-        feature_script = [
-            "$features = {}".format(feature_array),
-            "foreach ($name in $features) {",
-            "  $f = Get-WindowsOptionalFeature -Online -FeatureName $name -ErrorAction SilentlyContinue",
-            "  if ($null -eq $f) {",
-            "    Write-Output ('SMB1 missing optional feature: ' + $name)",
-            "    continue",
-            "  }",
-            "  if ($f.State -ne 'Enabled') {",
-            "    Write-Output ('Enabling Windows optional feature: ' + $name)",
-            "    $r = Enable-WindowsOptionalFeature -Online -FeatureName $name -All -NoRestart -ErrorAction Stop",
-            "    $changed = $true",
-            "    if ($r.RestartNeeded) { $restartNeeded = $true }",
-            "  } else {",
-            "    Write-Output ('Windows optional feature already enabled: ' + $name)",
-            "  }",
-            "}",
-            "$d = Get-WindowsOptionalFeature -Online -FeatureName {} -ErrorAction SilentlyContinue".format(removal),
-            "if ($null -ne $d -and $d.State -eq 'Enabled') {",
-            "  Write-Output ('Disabling SMB1 automatic removal: ' + {})".format(removal),
-            "  $r = Disable-WindowsOptionalFeature -Online -FeatureName {} -NoRestart -ErrorAction Stop".format(removal),
-            "  $changed = $true",
-            "  if ($r.RestartNeeded) { $restartNeeded = $true }",
-            "}",
-        ]
-
     rule_lines = []
-    for rule in rules:
+    for rule in _firewall_rules(key, values):
         name = _ps_quote(rule["name"])
         proto = _ps_quote(rule["protocol"])
         rule_lines += [
@@ -234,10 +192,9 @@ def apply_setup(key, values):
     script = "\n".join([
         "$ErrorActionPreference = 'Stop'",
         "$changed = $false",
-        "$restartNeeded = $false",
-    ] + feature_script + rule_lines + [
+    ] + rule_lines + [
         "Write-Output ('SETUP_CHANGED=' + $changed)",
-        "Write-Output ('RESTART_NEEDED=' + $restartNeeded)",
+        "Write-Output 'NOTE=No Windows SMB1 optional features were enabled or changed.'",
     ])
 
     try:
@@ -252,7 +209,48 @@ def apply_setup(key, values):
     upper = output.upper()
     return {
         "changed": "SETUP_CHANGED=TRUE" in upper,
-        "restart_needed": "RESTART_NEEDED=TRUE" in upper,
+        "restart_needed": False,
+        "output": output,
+    }
+
+
+def remove_setup():
+    """Remove PS2 Servers Windows Firewall rules.
+
+    This is intentionally narrow: it removes only rules whose display names start
+    with "PS2 Servers - ". It does not touch Windows optional features or other
+    firewall rules.
+    """
+    if not is_windows():
+        return {"changed": False, "restart_needed": False, "output": ""}
+
+    prefix = _ps_quote(FIREWALL_RULE_PREFIX + "*")
+    script = "\n".join([
+        "$ErrorActionPreference = 'Stop'",
+        "$rules = @(Get-NetFirewallRule -DisplayName {} -ErrorAction SilentlyContinue)".format(prefix),
+        "if ($rules.Count -eq 0) {",
+        "  Write-Output 'No PS2 Servers firewall rules found.'",
+        "  Write-Output 'SETUP_CHANGED=False'",
+        "} else {",
+        "  foreach ($rule in $rules) { Write-Output ('Removing firewall rule: ' + $rule.DisplayName) }",
+        "  $rules | Remove-NetFirewallRule -ErrorAction Stop",
+        "  Write-Output ('Removed PS2 Servers firewall rules: ' + $rules.Count)",
+        "  Write-Output 'SETUP_CHANGED=True'",
+        "}",
+    ])
+
+    try:
+        res = _powershell(script)
+    except OSError as e:
+        raise WindowsSetupError("Failed to run PowerShell: {}".format(e)) from e
+
+    output = ((res.stdout or "") + (res.stderr or "")).strip()
+    if res.returncode != 0:
+        raise WindowsSetupError(output or "Windows cleanup failed.")
+
+    return {
+        "changed": "SETUP_CHANGED=TRUE" in output.upper(),
+        "restart_needed": False,
         "output": output,
     }
 
@@ -262,10 +260,13 @@ def setup_summary(key, values):
         return ""
     parts = []
     if key == "smbv1":
-        parts.append("enable the Windows SMB 1.0/CIFS feature tree")
-    ports = _server_ports(key, values)
-    if ports:
-        parts.append("create Windows Firewall allow rules")
+        parts.append("create Windows Firewall allow rules for the built-in PS2 Servers SMB server")
+        if values.get("take_445"):
+            parts.append("temporarily use TCP 445 by pausing Windows file sharing while the server runs")
+    else:
+        ports = _server_ports(key, values)
+        if ports:
+            parts.append("create Windows Firewall allow rules")
     if not parts:
         return "apply Windows network setup"
     return " and ".join(parts)

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,6 @@
+# Build-only dependencies for packaged release artifacts.
+# Pinned to avoid unbounded dependency drift in GitHub Actions release builds.
+
+Nuitka==2.7.12
+ordered-set==4.1.0
+zstandard==0.23.0

--- a/tools/remove-windows-firewall-rules.ps1
+++ b/tools/remove-windows-firewall-rules.ps1
@@ -1,3 +1,5 @@
+#Requires -RunAsAdministrator
+
 # Remove PS2 Servers Windows Firewall rules.
 #
 # Run from an elevated PowerShell prompt:

--- a/tools/remove-windows-firewall-rules.ps1
+++ b/tools/remove-windows-firewall-rules.ps1
@@ -1,0 +1,24 @@
+# Remove PS2 Servers Windows Firewall rules.
+#
+# Run from an elevated PowerShell prompt:
+#   powershell -ExecutionPolicy Bypass -File .\tools\remove-windows-firewall-rules.ps1
+#
+# This only removes firewall rules whose display names start with "PS2 Servers - ".
+# It does not enable, disable, install, or remove Windows SMB1 optional features.
+
+$ErrorActionPreference = "Stop"
+
+$rules = @(Get-NetFirewallRule -DisplayName "PS2 Servers - *" -ErrorAction SilentlyContinue)
+
+if ($rules.Count -eq 0) {
+    Write-Host "No PS2 Servers firewall rules found."
+    exit 0
+}
+
+foreach ($rule in $rules) {
+    Write-Host ("Removing firewall rule: " + $rule.DisplayName)
+}
+
+$rules | Remove-NetFirewallRule -ErrorAction Stop
+
+Write-Host ("Removed PS2 Servers firewall rules: " + $rules.Count)


### PR DESCRIPTION
## Summary

This PR hardens the Windows setup path and release process in response to AV / supply-chain concerns.

### Windows behavior

- Removes all Windows SMB1 optional-feature enable/disable behavior from `launcher/windows_setup.py`.
- Keeps SMB mode aligned with the repo architecture: PS2 Servers' own SMB/CIFS implementation on a custom port, not the Windows SMB stack.
- Limits Windows setup to PS2 Servers firewall rules only.
- Adds `remove_setup()` for narrow firewall-rule cleanup.
- Adds `tools/remove-windows-firewall-rules.ps1` for manual cleanup.
- Documents that advanced port 445 mode pauses `LanmanServer` only while that mode is running and does not enable Windows SMB1.

### Release / supply-chain visibility

- Adds GitHub artifact attestations using `actions/attest@v4`.
- Adds release `SHA256SUMS.txt`.
- Adds `PS2Servers-source.zip` to releases as a lowest-trust alternative to the unsigned EXE.
- Adds `requirements-build.txt` so release builds do not drift through fully unbounded Nuitka/ordered-set/zstandard installs.
- Adds a basic CI workflow for Python compile checks and the UDPBD selftest.

### Documentation

- Adds `SECURITY.md` with security posture, Windows SMB behavior, cleanup commands, release verification, and report details.
- Updates `README.md` with a clear Windows security note and release verification instructions.

## Validation

Local syntax check performed before writing the Windows setup replacement:

```sh
python -m py_compile windows_setup.py
```

The new CI workflow should run `compileall` and `udpbd_server/selftest.py` on PRs.