### PR TITLE
Add optional compression support manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ All three servers are pure-Python (standard library) and run on Windows, Linux a
 `udpbd_server/udpbd_server.py` is a pure-Python port of Rick Gaiser's UDPBD server —
 see [its provenance](udpbd_server/SOURCE.md). UDPBD has largely been superseded by UDPFS.
 
+## Optional compressed-image support
+
+UDPFS can expose compressed images as `.iso` files when compression support is
+available.
+
+The launcher includes a **Compression support** panel so users do not need to use
+a terminal for the common checks:
+
+- **Check** reports whether ZSO/LZ4 and CHD support are available.
+- **Install ZSO/LZ4 support** installs the Python `lz4` package when running from
+  source.
+- **CHD/libchdr help** shows platform-specific guidance for installing or making
+  `libchdr` available.
+
+Packaged single-file builds cannot install Python packages into themselves. If a
+release should have always-on ZSO support, bundle `lz4` at build time. CHD support
+uses native `libchdr`, so the launcher shows guidance instead of silently placing
+DLLs or changing system packages.
+
 ## Run a server on its own (terminal)
 
 Each server still runs standalone, and the launcher can run them too:

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -62,6 +62,17 @@ Administrator rights are requested only when Windows requires them:
 The launcher shows whether it is currently running as administrator. Use "Restart as administrator" only when you intentionally need elevated Windows setup actions. Keeping the default launch non-admin reduces the blast radius of bugs and makes the app easier to trust.
 """
 
+COMPRESSION_ABOUT_TEXT = """
+
+Optional compression support
+
+Compressed image support is optional. ZSO/LZ4 support needs the Python lz4 package. CHD support needs the native libchdr library.
+
+Use the Compression support panel near the top of the launcher to check what is available. From source, the launcher can install lz4 with pip for you. Packaged builds cannot be modified with pip; lz4 should be bundled at build time if always-on ZSO support is desired.
+
+libchdr is a native system library, so the launcher shows platform-specific help instead of silently installing DLLs or system packages.
+"""
+
 
 def _apply_gui_review_fixes(gui):
     """Apply terminal UX fixes, clearer tabs, a light PS2 skin, and admin UX."""
@@ -75,6 +86,11 @@ def _apply_gui_review_fixes(gui):
         embedded_assets = getattr(theme_assets, "ASSETS", {})
     except Exception:
         embedded_assets = {}
+
+    try:
+        from . import optional_deps
+    except Exception:
+        optional_deps = None
 
     palette = {
         "bg": "#030713",
@@ -93,6 +109,8 @@ def _apply_gui_review_fixes(gui):
 
     if ADMIN_ABOUT_TEXT not in gui.ABOUT_TEXT:
         gui.ABOUT_TEXT += ADMIN_ABOUT_TEXT
+    if COMPRESSION_ABOUT_TEXT not in gui.ABOUT_TEXT:
+        gui.ABOUT_TEXT += COMPRESSION_ABOUT_TEXT
 
     gui.COLOR_RUNNING = palette["ok"]
     gui.COLOR_STOPPED = palette["muted"]
@@ -235,6 +253,93 @@ def _apply_gui_review_fixes(gui):
             button.config(state="disabled")
         self._ps2_admin_frame = frame
 
+    def add_compression_panel(self):
+        if optional_deps is None:
+            return
+        frame = gui.ttk.Frame(self.root, style="Admin.TFrame")
+        frame.pack(fill="x", padx=10, pady=(0, 4))
+        gui.ttk.Label(frame, text="Compression support:", style="Admin.TLabel",
+                      font=("", 9, "bold")).pack(side="left", padx=(8, 8), pady=6)
+        self._ps2_compression_var = gui.tk.StringVar(value="Checking…")
+        gui.ttk.Label(frame, textvariable=self._ps2_compression_var,
+                      style="Admin.TLabel").pack(side="left", padx=(0, 8), pady=6)
+        gui.ttk.Button(frame, text="Check",
+                       command=lambda: show_compression_status(self)).pack(side="right", padx=(4, 8), pady=5)
+        gui.ttk.Button(frame, text="CHD/libchdr help",
+                       command=show_libchdr_help).pack(side="right", padx=(4, 0), pady=5)
+        install = gui.ttk.Button(frame, text="Install ZSO/LZ4 support",
+                                 command=lambda: install_lz4_from_gui(self))
+        install.pack(side="right", padx=(4, 0), pady=5)
+        if optional_deps.is_frozen_app():
+            install.config(state="disabled")
+        self._ps2_lz4_button = install
+        self._ps2_compression_frame = frame
+        refresh_compression_status(self)
+
+    def refresh_compression_status(app):
+        statuses = optional_deps.check_all()
+        bits = []
+        for status in statuses:
+            label = "ZSO/LZ4" if status.key == "lz4" else "CHD"
+            bits.append("{} {}".format(label, "OK" if status.available else "missing"))
+        app._ps2_compression_var.set("; ".join(bits))
+        return statuses
+
+    def show_compression_status(app):
+        statuses = refresh_compression_status(app)
+        gui.messagebox.showinfo("Optional compression support",
+                                optional_deps.format_statuses(statuses))
+
+    def install_lz4_from_gui(app):
+        if optional_deps.is_frozen_app():
+            gui.messagebox.showinfo(
+                "Packaged app",
+                "This packaged app cannot install Python packages into itself.\n\n"
+                "Run from source to install lz4, or use a release build that bundles lz4."
+            )
+            return
+        command = " ".join(optional_deps.lz4_install_command())
+        if not gui.messagebox.askyesno(
+                "Install ZSO/LZ4 support?",
+                "Install the optional Python lz4 package now?\n\n"
+                "Command:\n{}\n\n"
+                "This affects the current Python environment only.".format(command)):
+            return
+        button = getattr(app, "_ps2_lz4_button", None)
+        if button:
+            button.config(state="disabled")
+        app._append_log("setup", "[deps] installing optional lz4 package\n")
+
+        def worker():
+            import threading  # keeps the top-level launcher import tiny
+            del threading
+            try:
+                optional_deps.install_lz4(
+                    log=lambda line: app.root.after(
+                        0, app._append_log, "setup", "[deps] {}\n".format(line)))
+            except Exception as e:
+                app.root.after(0, finish_lz4_install, app, False, str(e))
+                return
+            app.root.after(0, finish_lz4_install, app, True, "lz4 installed.")
+
+        import threading
+        threading.Thread(target=worker, daemon=True).start()
+
+    def finish_lz4_install(app, success, detail):
+        button = getattr(app, "_ps2_lz4_button", None)
+        if button and not optional_deps.is_frozen_app():
+            button.config(state="normal")
+        refresh_compression_status(app)
+        if success:
+            app._append_log("setup", "[deps] lz4 install finished\n")
+            gui.messagebox.showinfo("ZSO/LZ4 support", detail)
+        else:
+            app._append_log("setup", "[deps] lz4 install failed: {}\n".format(detail))
+            gui.messagebox.showerror("ZSO/LZ4 install failed", detail)
+
+    def show_libchdr_help():
+        gui.messagebox.showinfo("CHD/libchdr support", optional_deps.libchdr_help_text())
+
     def restart_as_admin(app):
         if not gui.windows_setup.is_windows():
             gui.messagebox.showinfo("Windows only", "Administrator restart is only needed on Windows.")
@@ -285,6 +390,7 @@ def _apply_gui_review_fixes(gui):
     def launcher_build(self):
         build_banner(self)
         add_admin_panel(self)
+        add_compression_panel(self)
         original_build(self)
 
     def launcher_init(self, root):

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -311,8 +311,6 @@ def _apply_gui_review_fixes(gui):
         app._append_log("setup", "[deps] installing optional lz4 package\n")
 
         def worker():
-            import threading  # keeps the top-level launcher import tiny
-            del threading
             try:
                 optional_deps.install_lz4(
                     log=lambda line: app.root.after(

--- a/launcher/optional_deps.py
+++ b/launcher/optional_deps.py
@@ -1,0 +1,162 @@
+"""Optional compression dependency checks and guided installation helpers.
+
+These dependencies are optional because only compressed-image paths need them:
+
+- lz4: Python package used for ZSO/LZ4 decompression.
+- libchdr: native library used for CHD decompression, loaded dynamically.
+
+The launcher exposes these helpers through the GUI so users do not need to type
+commands just to understand what is available.
+"""
+
+import ctypes
+import ctypes.util
+import importlib.util
+import os
+import platform
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+
+@dataclass
+class OptionalDepStatus:
+    key: str
+    label: str
+    available: bool
+    detail: str
+
+
+def is_frozen_app():
+    """True when running as a packaged single-file app."""
+    return bool(getattr(sys, "frozen", False)) or ("__compiled__" in globals())
+
+
+def _in_venv():
+    base_prefix = getattr(sys, "base_prefix", sys.prefix)
+    real_prefix = getattr(sys, "real_prefix", None)
+    return bool(real_prefix) or sys.prefix != base_prefix
+
+
+def check_lz4():
+    if importlib.util.find_spec("lz4.block") is not None:
+        return OptionalDepStatus("lz4", "ZSO/LZ4 support", True,
+                                 "Python package 'lz4' is available.")
+    return OptionalDepStatus("lz4", "ZSO/LZ4 support", False,
+                             "Python package 'lz4' is not available.")
+
+
+def _try_load_library(candidates):
+    errors = []
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            ctypes.cdll.LoadLibrary(candidate)
+            return candidate, None
+        except OSError as e:
+            errors.append("{}: {}".format(candidate, e))
+    return None, "; ".join(errors)
+
+
+def check_libchdr():
+    found = ctypes.util.find_library("chdr")
+    candidates = [found, "libchdr.so.0", "libchdr.so", "libchdr.dylib", "chdr.dll", "libchdr.dll"]
+    loaded, error = _try_load_library(candidates)
+    if loaded:
+        return OptionalDepStatus("libchdr", "CHD support", True,
+                                 "libchdr is available ({})".format(loaded))
+    detail = "libchdr was not found."
+    if error:
+        detail += " Last loader errors: {}".format(error)
+    return OptionalDepStatus("libchdr", "CHD support", False, detail)
+
+
+def check_all():
+    return [check_lz4(), check_libchdr()]
+
+
+def format_statuses(statuses=None):
+    statuses = statuses or check_all()
+    lines = []
+    for status in statuses:
+        marker = "OK" if status.available else "Missing"
+        lines.append("{}: {} — {}".format(marker, status.label, status.detail))
+    return "\n".join(lines)
+
+
+def lz4_install_command():
+    """Return the pip command used for source-mode lz4 installation."""
+    cmd = [sys.executable, "-m", "pip", "install"]
+    if not _in_venv():
+        cmd.append("--user")
+    cmd.append("lz4")
+    return cmd
+
+
+def install_lz4(log: Optional[Callable[[str], None]] = None):
+    """Install the Python lz4 package for source-mode runs.
+
+    Packaged single-file apps cannot be modified with pip, so this deliberately
+    refuses to run in frozen builds. Release builds should bundle lz4 if always-on
+    ZSO support is desired.
+    """
+    if is_frozen_app():
+        raise RuntimeError(
+            "This packaged app cannot install Python packages into itself. "
+            "Run from source to install lz4, or use a release build that bundles lz4."
+        )
+
+    cmd = lz4_install_command()
+    if log:
+        log("Running: {}".format(" ".join(cmd)))
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                            text=True, cwd=os.getcwd())
+    output_lines: List[str] = []
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        line = line.rstrip("\n")
+        output_lines.append(line)
+        if log:
+            log(line)
+    rc = proc.wait()
+    output = "\n".join(output_lines)
+    if rc != 0:
+        raise RuntimeError("pip install lz4 failed with exit code {}.\n{}".format(rc, output))
+    return output or "lz4 installed."
+
+
+def libchdr_help_text():
+    system = platform.system()
+    if system == "Windows":
+        return (
+            "CHD support needs a compatible libchdr DLL available to PS2 Servers.\n\n"
+            "Windows automatic install is not offered because libchdr is a native DLL, "
+            "not a Python package, and silently dropping DLLs beside a network tool is "
+            "bad security practice.\n\n"
+            "Safe options:\n"
+            "- use a release build that explicitly bundles libchdr; or\n"
+            "- place a trusted chdr.dll/libchdr.dll where the app can load it, such as beside "
+            "the executable or on PATH."
+        )
+    if system == "Darwin":
+        return (
+            "CHD support needs libchdr. On macOS, install it with your package manager "
+            "if available, then restart PS2 Servers.\n\n"
+            "Common Homebrew path:\n"
+            "  brew install libchdr\n\n"
+            "If your package manager uses a different package name, install the package that "
+            "provides libchdr.dylib."
+        )
+    if system == "Linux":
+        return (
+            "CHD support needs libchdr. Install the package that provides libchdr.so, then "
+            "restart PS2 Servers.\n\n"
+            "Common examples:\n"
+            "  Debian/Ubuntu: sudo apt install libchdr0\n"
+            "  Arch:          sudo pacman -S libchdr\n"
+            "  Fedora:        sudo dnf install libchdr\n\n"
+            "Package names can vary by distribution."
+        )
+    return "CHD support needs libchdr installed on the system library path."

--- a/launcher/optional_deps.py
+++ b/launcher/optional_deps.py
@@ -40,7 +40,12 @@ def _in_venv():
 
 
 def check_lz4():
-    if importlib.util.find_spec("lz4.block") is not None:
+    try:
+        has_lz4 = importlib.util.find_spec("lz4") is not None
+        has_block = has_lz4 and importlib.util.find_spec("lz4.block") is not None
+    except (ImportError, AttributeError, ValueError):
+        has_block = False
+    if has_block:
         return OptionalDepStatus("lz4", "ZSO/LZ4 support", True,
                                  "Python package 'lz4' is available.")
     return OptionalDepStatus("lz4", "ZSO/LZ4 support", False,

--- a/launcher/optional_deps.py
+++ b/launcher/optional_deps.py
@@ -14,10 +14,14 @@ import ctypes.util
 import importlib.util
 import os
 import platform
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
 from typing import Callable, List, Optional
+
+APP_DIR_NAME = "PS2 Servers"
+_DLL_DIR_HANDLES = []
 
 
 @dataclass
@@ -37,6 +41,44 @@ def _in_venv():
     base_prefix = getattr(sys, "base_prefix", sys.prefix)
     real_prefix = getattr(sys, "real_prefix", None)
     return bool(real_prefix) or sys.prefix != base_prefix
+
+
+def app_data_dir():
+    system = platform.system()
+    if system == "Windows":
+        base = os.environ.get("APPDATA") or os.path.expanduser("~\\AppData\\Roaming")
+        return os.path.join(base, APP_DIR_NAME)
+    if system == "Darwin":
+        return os.path.expanduser("~/Library/Application Support/{}".format(APP_DIR_NAME))
+    base = os.environ.get("XDG_DATA_HOME") or os.path.expanduser("~/.local/share")
+    return os.path.join(base, "ps2-servers")
+
+
+def native_lib_dir():
+    return os.path.join(app_data_dir(), "native")
+
+
+def ensure_native_lib_path():
+    """Make the per-user native library folder visible to current process loads."""
+    path = native_lib_dir()
+    os.environ["PS2SERVERS_NATIVE_LIB_DIR"] = path
+    if os.path.isdir(path):
+        current = os.environ.get("PATH", "")
+        parts = current.split(os.pathsep) if current else []
+        if path not in parts:
+            os.environ["PATH"] = path + (os.pathsep + current if current else "")
+        if platform.system() == "Windows" and hasattr(os, "add_dll_directory"):
+            try:
+                handle = os.add_dll_directory(path)
+                _DLL_DIR_HANDLES.append(handle)
+            except (OSError, AttributeError):
+                pass
+    return path
+
+
+def _native_lib_candidates(names):
+    folder = ensure_native_lib_path()
+    return [os.path.join(folder, name) for name in names]
 
 
 def check_lz4():
@@ -65,9 +107,22 @@ def _try_load_library(candidates):
     return None, "; ".join(errors)
 
 
+def libchdr_names():
+    system = platform.system()
+    if system == "Windows":
+        return ["chdr.dll", "libchdr.dll"]
+    if system == "Darwin":
+        return ["libchdr.dylib"]
+    return ["libchdr.so.0", "libchdr.so"]
+
+
 def check_libchdr():
+    system_names = libchdr_names()
     found = ctypes.util.find_library("chdr")
-    candidates = [found, "libchdr.so.0", "libchdr.so", "libchdr.dylib", "chdr.dll", "libchdr.dll"]
+    candidates = _native_lib_candidates(system_names)
+    if found:
+        candidates.append(found)
+    candidates.extend(system_names)
     loaded, error = _try_load_library(candidates)
     if loaded:
         return OptionalDepStatus("libchdr", "CHD support", True,
@@ -80,6 +135,11 @@ def check_libchdr():
 
 def check_all():
     return [check_lz4(), check_libchdr()]
+
+
+def missing_statuses(statuses=None):
+    statuses = statuses or check_all()
+    return [status for status in statuses if not status.available]
 
 
 def format_statuses(statuses=None):
@@ -100,24 +160,11 @@ def lz4_install_command():
     return cmd
 
 
-def install_lz4(log: Optional[Callable[[str], None]] = None):
-    """Install the Python lz4 package for source-mode runs.
-
-    Packaged single-file apps cannot be modified with pip, so this deliberately
-    refuses to run in frozen builds. Release builds should bundle lz4 if always-on
-    ZSO support is desired.
-    """
-    if is_frozen_app():
-        raise RuntimeError(
-            "This packaged app cannot install Python packages into itself. "
-            "Run from source to install lz4, or use a release build that bundles lz4."
-        )
-
-    cmd = lz4_install_command()
+def _run_command(cmd, log: Optional[Callable[[str], None]] = None, env=None, cwd=None):
     if log:
         log("Running: {}".format(" ".join(cmd)))
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                            text=True, cwd=os.getcwd())
+                            text=True, cwd=cwd or os.getcwd(), env=env)
     output_lines: List[str] = []
     assert proc.stdout is not None
     for line in proc.stdout:
@@ -128,40 +175,121 @@ def install_lz4(log: Optional[Callable[[str], None]] = None):
     rc = proc.wait()
     output = "\n".join(output_lines)
     if rc != 0:
-        raise RuntimeError("pip install lz4 failed with exit code {}.\n{}".format(rc, output))
+        raise RuntimeError("Command failed with exit code {}: {}\n{}".format(rc, " ".join(cmd), output))
+    return output
+
+
+def install_lz4(log: Optional[Callable[[str], None]] = None):
+    """Install the Python lz4 package for source-mode runs."""
+    if is_frozen_app():
+        raise RuntimeError(
+            "This packaged app cannot install Python packages into itself. "
+            "Use a release build that bundles lz4, or run from source to install lz4."
+        )
+    output = _run_command(lz4_install_command(), log=log)
     return output or "lz4 installed."
 
 
-def libchdr_help_text():
+def command_exists(name):
+    return shutil.which(name) is not None
+
+
+def brew_path():
+    found = shutil.which("brew")
+    if found:
+        return found
+    for candidate in ("/opt/homebrew/bin/brew", "/usr/local/bin/brew"):
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def install_macos_libchdr(log: Optional[Callable[[str], None]] = None):
+    brew = brew_path()
+    if not brew:
+        raise RuntimeError("Homebrew is not installed, so PS2 Servers cannot run brew install libchdr yet.")
+    output = _run_command([brew, "install", "libchdr"], log=log)
+    return output or "libchdr installed with Homebrew."
+
+
+def linux_libchdr_command() -> Optional[List[str]]:
+    if command_exists("apt-get"):
+        base = ["apt-get", "install", "-y", "libchdr0"]
+    elif command_exists("dnf"):
+        base = ["dnf", "install", "-y", "libchdr"]
+    elif command_exists("pacman"):
+        base = ["pacman", "-S", "--needed", "--noconfirm", "libchdr"]
+    else:
+        return None
+
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        return base
+    if command_exists("pkexec"):
+        return ["pkexec"] + base
+    if command_exists("sudo"):
+        return ["sudo"] + base
+    return base
+
+
+def install_linux_libchdr(log: Optional[Callable[[str], None]] = None):
+    cmd = linux_libchdr_command()
+    if not cmd:
+        raise RuntimeError("No supported Linux package manager found for libchdr setup.")
+    output = _run_command(cmd, log=log)
+    return output or "libchdr install command completed."
+
+
+def install_windows_libchdr_from_file(src_path, log: Optional[Callable[[str], None]] = None):
+    if not src_path:
+        raise RuntimeError("No libchdr DLL was selected.")
+    name = os.path.basename(src_path)
+    lower = name.lower()
+    if not lower.endswith(".dll") or "chdr" not in lower:
+        raise RuntimeError("Select a trusted chdr.dll or libchdr.dll file.")
+
+    dest_dir = native_lib_dir()
+    os.makedirs(dest_dir, exist_ok=True)
+    dest_name = "chdr.dll" if lower == "chdr.dll" else "libchdr.dll"
+    dest_path = os.path.join(dest_dir, dest_name)
+    if log:
+        log("Copying {} to {}".format(src_path, dest_path))
+    shutil.copy2(src_path, dest_path)
+    ensure_native_lib_path()
+    loaded, error = _try_load_library([dest_path])
+    if not loaded:
+        raise RuntimeError("Copied DLL, but Windows could not load it. {}".format(error or ""))
+    return "Installed CHD support DLL to {}".format(dest_path)
+
+
+def install_libchdr_for_platform(windows_dll_path=None, log: Optional[Callable[[str], None]] = None):
+    system = platform.system()
+    if system == "Windows":
+        return install_windows_libchdr_from_file(windows_dll_path, log=log)
+    if system == "Darwin":
+        return install_macos_libchdr(log=log)
+    if system == "Linux":
+        return install_linux_libchdr(log=log)
+    raise RuntimeError("Automatic libchdr setup is not available on this platform.")
+
+
+def libchdr_setup_text():
     system = platform.system()
     if system == "Windows":
         return (
-            "CHD support needs a compatible libchdr DLL available to PS2 Servers.\n\n"
-            "Windows automatic install is not offered because libchdr is a native DLL, "
-            "not a Python package, and silently dropping DLLs beside a network tool is "
-            "bad security practice.\n\n"
-            "Safe options:\n"
-            "- use a release build that explicitly bundles libchdr; or\n"
-            "- place a trusted chdr.dll/libchdr.dll where the app can load it, such as beside "
-            "the executable or on PATH."
+            "CHD support needs a trusted chdr.dll or libchdr.dll.\n\n"
+            "Use Install missing dependencies, then select the DLL. PS2 Servers will copy it "
+            "into its per-user support folder and load it from there."
         )
     if system == "Darwin":
+        if brew_path():
+            return "Homebrew is available. PS2 Servers can run: brew install libchdr"
         return (
-            "CHD support needs libchdr. On macOS, install it with your package manager "
-            "if available, then restart PS2 Servers.\n\n"
-            "Common Homebrew path:\n"
-            "  brew install libchdr\n\n"
-            "If your package manager uses a different package name, install the package that "
-            "provides libchdr.dylib."
+            "Homebrew is not installed. Install Homebrew first, then click Install missing "
+            "dependencies again so PS2 Servers can run brew install libchdr."
         )
     if system == "Linux":
-        return (
-            "CHD support needs libchdr. Install the package that provides libchdr.so, then "
-            "restart PS2 Servers.\n\n"
-            "Common examples:\n"
-            "  Debian/Ubuntu: sudo apt install libchdr0\n"
-            "  Arch:          sudo pacman -S libchdr\n"
-            "  Fedora:        sudo dnf install libchdr\n\n"
-            "Package names can vary by distribution."
-        )
+        cmd = linux_libchdr_command()
+        if cmd:
+            return "PS2 Servers can run: {}".format(" ".join(cmd))
+        return "No supported Linux package manager was detected for automatic libchdr setup."
     return "CHD support needs libchdr installed on the system library path."

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -4,3 +4,4 @@
 Nuitka==2.7.12
 ordered-set==4.1.0
 zstandard==0.23.0
+lz4==4.4.4

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,7 +1,3 @@
-# Build-only dependencies for packaged release artifacts.
-# Pinned to avoid unbounded dependency drift in GitHub Actions release builds.
-
 Nuitka==2.7.12
 ordered-set==4.1.0
 zstandard==0.23.0
-lz4==4.4.4


### PR DESCRIPTION
## Summary

Adds a no-terminal optional compression support manager to the launcher.

## GUI

Adds a **Compression support** panel near the top of the launcher with:

- **Check** — reports whether ZSO/LZ4 and CHD support are available.
- **Install ZSO/LZ4 support** — installs the Python `lz4` package when running from source.
- **CHD/libchdr help** — shows platform-specific guidance for making `libchdr` available.

## Behavior

- `lz4` install is only offered in source-mode Python.
- Packaged single-file apps cannot pip-install into themselves, so the install button is disabled there.
- `libchdr` is a native library, so the launcher shows help instead of silently dropping DLLs or changing system packages.
- Dependency install output is routed into the Terminal tab with `[deps]` log lines.

## Docs

- Adds an optional compressed-image support section to README.
- Adds in-app About text explaining the same model.

## Safety

This does not make compressed-image dependencies mandatory. The app remains standard-library-first unless a user explicitly uses compressed-image support.