### PR TITLE
Fix Windows CHD release packaging

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            asset_name: PS2Servers-windows-x64.exe
+            asset_name: PS2Servers-windows-x64.zip
           - os: ubuntu-latest
             asset_name: PS2Servers-linux-x64
           - os: macos-latest
@@ -101,7 +101,14 @@ jobs:
       - name: Package Windows executable
         if: runner.os == 'Windows'
         shell: pwsh
-        run: Copy-Item -Path dist/PS2Servers.exe -Destination ${{ matrix.asset_name }} -Force
+        run: |
+          $packageDir = "PS2Servers-windows-x64"
+          New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
+          Copy-Item -Path dist/PS2Servers.exe -Destination "$packageDir/PS2Servers.exe" -Force
+          if (Test-Path build/native) {
+            Copy-Item -Path build/native -Destination $packageDir -Recurse -Force
+          }
+          Compress-Archive -Path $packageDir -DestinationPath ${{ matrix.asset_name }} -Force
 
       - name: Package Linux executable
         if: runner.os == 'Linux'
@@ -184,7 +191,7 @@ jobs:
             PS2Servers-macos-arm64.zip \
             PS2Servers-macos-x64.zip \
             PS2Servers-source.zip \
-            PS2Servers-windows-x64.exe \
+            PS2Servers-windows-x64.zip \
             > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
@@ -215,7 +222,7 @@ jobs:
             release-assets/PS2Servers-macos-arm64.zip
             release-assets/PS2Servers-macos-x64.zip
             release-assets/PS2Servers-source.zip
-            release-assets/PS2Servers-windows-x64.exe
+            release-assets/PS2Servers-windows-x64.zip
             release-assets/SHA256SUMS.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            asset: PS2Servers-windows-x64.exe
+            asset: PS2Servers-windows-x64.zip
           - os: ubuntu-latest
             asset: PS2Servers-linux-x64
           - os: macos-latest
@@ -92,12 +92,25 @@ jobs:
         # cross-target path again and can reuse arm64 native extensions.
         run: arch -x86_64 python build/build.py
 
-      - name: Stage artifact
+      - name: Stage Windows artifact
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path out -Force | Out-Null
+          $packageDir = "out/PS2Servers-windows-x64"
+          New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
+          Copy-Item -Path dist/PS2Servers.exe -Destination "$packageDir/PS2Servers.exe" -Force
+          if (Test-Path build/native) {
+            Copy-Item -Path build/native -Destination $packageDir -Recurse -Force
+          }
+          Compress-Archive -Path $packageDir -DestinationPath "out/${{ matrix.asset }}" -Force
+
+      - name: Stage Unix artifact
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           mkdir -p out
           case "$RUNNER_OS" in
-            Windows) cp dist/PS2Servers.exe "out/${{ matrix.asset }}" ;;
             Linux)   cp dist/PS2Servers "out/${{ matrix.asset }}" ;;
             macOS)   app=$(ls -d dist/*.app | head -1)
                      ( cd dist && zip -r -y "../out/${{ matrix.asset }}" "$(basename "$app")" ) ;;
@@ -113,12 +126,12 @@ jobs:
 
           | OS | File |
           | --- | --- |
-          | Windows x64 | \`PS2Servers-windows-x64.exe\` |
+          | Windows x64 | \`PS2Servers-windows-x64.zip\` |
           | Linux x64 | \`PS2Servers-linux-x64\` |
           | macOS — Apple Silicon | \`PS2Servers-macos-arm64.zip\` |
           | macOS — Intel | \`PS2Servers-macos-x64.zip\` |
 
-          Run it: Windows — double-click. Linux — \`chmod +x PS2Servers-linux-x64\`, then run. macOS — unzip and right-click → Open (unsigned).
+          Run it: Windows — unzip and double-click \`PS2Servers.exe\`. Linux — \`chmod +x PS2Servers-linux-x64\`, then run. macOS — unzip and right-click → Open (unsigned).
 
           Compression note: ZSO/LZ4 support is bundled. CHD support is backed by a libchdr native library built from source during release packaging.
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ plus a small **GUI launcher** so anyone can run them without touching a terminal
 The launcher lets you pick a server, choose your games folder, and click **Start**.
 It detects your PC's LAN IP and shows the exact settings to enter in OPL.
 
-- **Packaged app (no Python needed):** double-click **`PS2Servers`** (`.exe` on
-  Windows) — see [Build the app](#build-the-single-file-app) to produce it.
+- **Packaged app (no Python needed):** download the release for your OS. On
+  Windows, unzip `PS2Servers-windows-x64.zip` and double-click
+  **`PS2Servers.exe`**.
 - **From source:** double-click **`Start-Launcher.bat`** (Windows) or run
   `./start-launcher.sh` (Linux/macOS). Requires Python 3.
 
@@ -78,7 +79,7 @@ python -m launcher --serve udpfs -d D:/PS2Games
 python -m launcher --list            # show servers available on this machine
 ```
 
-## Build the single-file app
+## Build the packaged app
 
 [Nuitka](https://nuitka.net) bundles the launcher and all three servers into one
 executable per OS — no Python install required for the end user:
@@ -95,7 +96,7 @@ artifact attestations for the packaged assets. Example verification:
 
 ```sh
 sha256sum -c SHA256SUMS.txt
-gh attestation verify PS2Servers-windows-x64.exe -R NathanNeurotic/PS2-Servers
+gh attestation verify PS2Servers-windows-x64.zip -R NathanNeurotic/PS2-Servers
 ```
 
 Checksums prove the file was downloaded intact. Attestations prove build

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,7 +89,7 @@ include:
 GitHub artifact attestations can be verified with the GitHub CLI. Example:
 
 ```sh
-gh attestation verify PS2Servers-windows-x64.exe -R NathanNeurotic/PS2-Servers
+gh attestation verify PS2Servers-windows-x64.zip -R NathanNeurotic/PS2-Servers
 ```
 
 Checksums verify file integrity, and attestations verify build provenance. They do

--- a/build/build_libchdr.py
+++ b/build/build_libchdr.py
@@ -75,7 +75,10 @@ def find_outputs():
     system = platform.system()
     patterns = []
     if system == "Windows":
-        patterns = ["**/chdr.dll", "**/libchdr.dll", "**/libchdr-0.dll"]
+        # Stage libchdr plus any DLLs it was linked against. The Windows release
+        # ZIP carries build/native beside the EXE, and the runtime adds that
+        # directory to the DLL search path before loading libchdr.
+        patterns = ["**/*.dll"]
     elif system == "Darwin":
         patterns = ["**/libchdr*.dylib"]
     else:
@@ -96,6 +99,10 @@ def stage_outputs(files):
     reset_dir(NATIVE_DIR)
     if not files:
         raise RuntimeError("libchdr build produced no native library files")
+    if platform.system() == "Windows":
+        lib_names = {"chdr.dll", "libchdr.dll", "libchdr-0.dll"}
+        if not any(os.path.basename(path).lower() in lib_names for path in files):
+            raise RuntimeError("libchdr build produced DLLs, but no libchdr DLL")
 
     for src in files:
         dest = os.path.join(NATIVE_DIR, os.path.basename(src))

--- a/docs/index.html
+++ b/docs/index.html
@@ -86,11 +86,11 @@
     <section class="section" id="download">
       <div class="container">
         <h2>Release assets built for normal humans.</h2>
-        <p class="section-intro">Automatic releases produce straightforward platform files: Windows as an `.exe`, Linux as a raw executable, and macOS as architecture-specific app zips.</p>
+        <p class="section-intro">Automatic releases produce straightforward platform files: Windows as a zip with the app and native support files, Linux as a raw executable, and macOS as architecture-specific app zips.</p>
         <div class="terminal">
           <div class="terminal-bar"><span></span><span></span><span></span></div>
           <pre><b>release assets</b>
-PS2Servers-windows-x64.exe
+PS2Servers-windows-x64.zip
 PS2Servers-linux-x64
 PS2Servers-macos-arm64.zip
 PS2Servers-macos-x64.zip

--- a/launcher/optional_deps.py
+++ b/launcher/optional_deps.py
@@ -42,6 +42,91 @@ def check_lz4():
                              "Python package 'lz4' is not available.")
 
 
+_DLL_DIR_HANDLES = []
+
+
+def _libchdr_names():
+    system = platform.system()
+    if system == "Windows":
+        return ["chdr.dll", "libchdr.dll", "libchdr-0.dll"]
+    if system == "Darwin":
+        return ["libchdr.dylib", "libchdr.0.dylib"]
+    return ["libchdr.so.0", "libchdr.so"]
+
+
+def _candidate_native_dirs():
+    package_dir = os.path.dirname(os.path.abspath(__file__))
+    root_dir = os.path.dirname(package_dir)
+    exe_dir = os.path.dirname(os.path.abspath(sys.executable))
+    cwd = os.getcwd()
+    dirs = [
+        os.environ.get("PS2SERVERS_NATIVE_LIB_DIR"),
+        os.path.join(root_dir, "native"),
+        os.path.join(root_dir, "build", "native"),
+    ]
+
+    frozen_root = getattr(sys, "_MEIPASS", None)
+    if frozen_root:
+        dirs.append(os.path.join(frozen_root, "native"))
+
+    dirs.extend([
+        os.path.join(exe_dir, "native"),
+        os.path.join(cwd, "native"),
+        os.path.join(cwd, "build", "native"),
+    ])
+
+    seen = set()
+    out = []
+    for path in dirs:
+        if not path:
+            continue
+        norm = os.path.normcase(os.path.abspath(path))
+        if norm not in seen:
+            out.append(path)
+            seen.add(norm)
+    return out
+
+
+def _prepare_native_dir(path):
+    if not os.path.isdir(path):
+        return
+    current = os.environ.get("PATH", "")
+    parts = current.split(os.pathsep) if current else []
+    if path not in parts:
+        os.environ["PATH"] = path + (os.pathsep + current if current else "")
+    if platform.system() == "Windows" and hasattr(os, "add_dll_directory"):
+        try:
+            _DLL_DIR_HANDLES.append(os.add_dll_directory(path))
+        except (OSError, AttributeError):
+            pass
+
+
+def _libchdr_candidates():
+    candidates = []
+    names = _libchdr_names()
+    for directory in _candidate_native_dirs():
+        _prepare_native_dir(directory)
+        for name in names:
+            candidates.append(os.path.join(directory, name))
+
+    found = ctypes.util.find_library("chdr")
+    if found:
+        candidates.append(found)
+    candidates.extend(names)
+
+    seen = set()
+    out = []
+    for candidate in candidates:
+        if not candidate:
+            continue
+        has_sep = os.path.sep in candidate or (os.path.altsep and os.path.altsep in candidate)
+        norm = os.path.normcase(os.path.abspath(candidate)) if has_sep else candidate
+        if norm not in seen:
+            out.append(candidate)
+            seen.add(norm)
+    return out
+
+
 def _try_load_library(candidates):
     errors = []
     for candidate in candidates:
@@ -56,10 +141,7 @@ def _try_load_library(candidates):
 
 
 def check_libchdr():
-    found = ctypes.util.find_library("chdr")
-    candidates = [found, "libchdr.so.0", "libchdr.so", "libchdr.dylib",
-                  "libchdr.0.dylib", "chdr.dll", "libchdr.dll", "libchdr-0.dll"]
-    loaded, error = _try_load_library(candidates)
+    loaded, error = _try_load_library(_libchdr_candidates())
     if loaded:
         return OptionalDepStatus("libchdr", "CHD support", True,
                                  "libchdr is available ({})".format(loaded))

--- a/udpfs_server/compressed_iso/chd.py
+++ b/udpfs_server/compressed_iso/chd.py
@@ -40,6 +40,10 @@ def _native_dirs():
     if env_dir:
         dirs.append(env_dir)
 
+    frozen_root = getattr(sys, "_MEIPASS", None)
+    if frozen_root:
+        dirs.append(os.path.join(frozen_root, "native"))
+
     # In Nuitka onefile builds, data files are extracted next to the inner binary.
     exe_dir = os.path.dirname(os.path.abspath(sys.executable))
     dirs.append(os.path.join(exe_dir, "native"))
@@ -49,6 +53,7 @@ def _native_dirs():
     dirs.append(os.path.join(os.path.dirname(here), "native"))
     dirs.append(os.path.join(os.path.dirname(os.path.dirname(here)), "native"))
     dirs.append(os.path.join(os.getcwd(), "native"))
+    dirs.append(os.path.join(os.getcwd(), "build", "native"))
 
     unique = []
     for path in dirs:


### PR DESCRIPTION
## Summary
- Publish Windows releases as `PS2Servers-windows-x64.zip` instead of a naked EXE.
- Include the staged native `libchdr` DLL directory beside `PS2Servers.exe` in the Windows ZIP.
- Make the GUI CHD status check search bundled native paths before system paths.
- Keep UDPFS CHD runtime lookup aligned with bundled/source `native` fallbacks.

## Verification
- `python -m py_compile launcher\optional_deps.py build\build_libchdr.py udpfs_server\compressed_iso\chd.py`
- `python -m compileall -q launcher udpfs_server build`
- `python -m launcher --selfcheck`
- `python udpbd_server\selftest.py`
- `git diff --check`
