### PR TITLE
Harden native library directory handling

### DIFF
--- a/launcher/optional_deps.py
+++ b/launcher/optional_deps.py
@@ -80,9 +80,10 @@ def _candidate_native_dirs():
     for path in dirs:
         if not path:
             continue
-        norm = os.path.normcase(os.path.abspath(path))
+        abs_path = os.path.abspath(path)
+        norm = os.path.normcase(abs_path)
         if norm not in seen:
-            out.append(path)
+            out.append(abs_path)
             seen.add(norm)
     return out
 
@@ -97,7 +98,7 @@ def _prepare_native_dir(path):
     if platform.system() == "Windows" and hasattr(os, "add_dll_directory"):
         try:
             _DLL_DIR_HANDLES.append(os.add_dll_directory(path))
-        except (OSError, AttributeError):
+        except (OSError, ValueError, AttributeError):
             pass
 
 

--- a/udpfs_server/compressed_iso/chd.py
+++ b/udpfs_server/compressed_iso/chd.py
@@ -56,9 +56,15 @@ def _native_dirs():
     dirs.append(os.path.join(os.getcwd(), "build", "native"))
 
     unique = []
+    seen = set()
     for path in dirs:
-        if path and path not in unique:
-            unique.append(path)
+        if not path:
+            continue
+        abs_path = os.path.abspath(path)
+        norm = os.path.normcase(abs_path)
+        if norm not in seen:
+            unique.append(abs_path)
+            seen.add(norm)
     return unique
 
 
@@ -72,7 +78,7 @@ def _prepare_native_dir(path):
     if platform.system() == "Windows" and hasattr(os, "add_dll_directory"):
         try:
             _DLL_DIR_HANDLES.append(os.add_dll_directory(path))
-        except (OSError, AttributeError):
+        except (OSError, ValueError, AttributeError):
             pass
 
 


### PR DESCRIPTION
## Summary
- Address Gemini review feedback from PR #40.
- Return absolute native library directories from the GUI dependency checker before calling Windows DLL search APIs.
- Apply the same absolute-path normalization and `ValueError` guard to the UDPFS CHD runtime loader.

## Verification
- `python -m py_compile launcher\optional_deps.py udpfs_server\compressed_iso\chd.py`
- `python -m compileall -q launcher udpfs_server`
- `python -m launcher --selfcheck`
- `python udpbd_server\selftest.py`
- `git diff --check`
- Relative `PS2SERVERS_NATIVE_LIB_DIR=relative_native` resolves to an absolute path in both loaders.
