### PR TITLE
Dedupe native DLL directory registration

### DIFF
--- a/launcher/optional_deps.py
+++ b/launcher/optional_deps.py
@@ -43,6 +43,28 @@ def check_lz4():
 
 
 _DLL_DIR_HANDLES = []
+_DLL_DIR_PATHS = set()
+_PATH_DIRS = None
+_PREPARED_NATIVE_DIRS = set()
+
+
+def _normalize_path_entry(path):
+    if os.path.isabs(path):
+        return os.path.normcase(os.path.normpath(path))
+    return os.path.normcase(os.path.abspath(path))
+
+
+def _known_path_dirs():
+    global _PATH_DIRS
+    if _PATH_DIRS is None:
+        current = os.environ.get("PATH", "")
+        parts = current.split(os.pathsep) if current else []
+        _PATH_DIRS = {
+            _normalize_path_entry(part)
+            for part in parts
+            if part
+        }
+    return _PATH_DIRS
 
 
 def _libchdr_names():
@@ -89,17 +111,29 @@ def _candidate_native_dirs():
 
 
 def _prepare_native_dir(path):
-    if not os.path.isdir(path):
+    abs_path = os.path.abspath(path)
+    norm_path = os.path.normcase(abs_path)
+    if norm_path in _PREPARED_NATIVE_DIRS:
         return
-    current = os.environ.get("PATH", "")
-    parts = current.split(os.pathsep) if current else []
-    if path not in parts:
-        os.environ["PATH"] = path + (os.pathsep + current if current else "")
+    if not os.path.isdir(abs_path):
+        return
+
+    path_dirs = _known_path_dirs()
+    if norm_path not in path_dirs:
+        current = os.environ.get("PATH", "")
+        os.environ["PATH"] = abs_path + (os.pathsep + current if current else "")
+        path_dirs.add(norm_path)
+
     if platform.system() == "Windows" and hasattr(os, "add_dll_directory"):
+        if norm_path in _DLL_DIR_PATHS:
+            _PREPARED_NATIVE_DIRS.add(norm_path)
+            return
         try:
-            _DLL_DIR_HANDLES.append(os.add_dll_directory(path))
+            _DLL_DIR_HANDLES.append(os.add_dll_directory(abs_path))
+            _DLL_DIR_PATHS.add(norm_path)
         except (OSError, ValueError, AttributeError):
             pass
+    _PREPARED_NATIVE_DIRS.add(norm_path)
 
 
 def _libchdr_candidates():

--- a/udpfs_server/compressed_iso/chd.py
+++ b/udpfs_server/compressed_iso/chd.py
@@ -23,6 +23,28 @@ from .base import CompressedFileWrapper
 # ---------------------------------------------------------------------------
 
 _DLL_DIR_HANDLES = []
+_DLL_DIR_PATHS = set()
+_PATH_DIRS = None
+_PREPARED_NATIVE_DIRS = set()
+
+
+def _normalize_path_entry(path):
+    if os.path.isabs(path):
+        return os.path.normcase(os.path.normpath(path))
+    return os.path.normcase(os.path.abspath(path))
+
+
+def _known_path_dirs():
+    global _PATH_DIRS
+    if _PATH_DIRS is None:
+        current = os.environ.get("PATH", "")
+        parts = current.split(os.pathsep) if current else []
+        _PATH_DIRS = {
+            _normalize_path_entry(part)
+            for part in parts
+            if part
+        }
+    return _PATH_DIRS
 
 
 def _lib_names():
@@ -69,17 +91,29 @@ def _native_dirs():
 
 
 def _prepare_native_dir(path):
-    if not os.path.isdir(path):
+    abs_path = os.path.abspath(path)
+    norm_path = os.path.normcase(abs_path)
+    if norm_path in _PREPARED_NATIVE_DIRS:
         return
-    current = os.environ.get("PATH", "")
-    parts = current.split(os.pathsep) if current else []
-    if path not in parts:
-        os.environ["PATH"] = path + (os.pathsep + current if current else "")
+    if not os.path.isdir(abs_path):
+        return
+
+    path_dirs = _known_path_dirs()
+    if norm_path not in path_dirs:
+        current = os.environ.get("PATH", "")
+        os.environ["PATH"] = abs_path + (os.pathsep + current if current else "")
+        path_dirs.add(norm_path)
+
     if platform.system() == "Windows" and hasattr(os, "add_dll_directory"):
+        if norm_path in _DLL_DIR_PATHS:
+            _PREPARED_NATIVE_DIRS.add(norm_path)
+            return
         try:
-            _DLL_DIR_HANDLES.append(os.add_dll_directory(path))
+            _DLL_DIR_HANDLES.append(os.add_dll_directory(abs_path))
+            _DLL_DIR_PATHS.add(norm_path)
         except (OSError, ValueError, AttributeError):
             pass
+    _PREPARED_NATIVE_DIRS.add(norm_path)
 
 
 def _candidate_paths():


### PR DESCRIPTION
## Summary
- Address Gemini review feedback from PR #41.
- Avoid duplicate `os.add_dll_directory()` registrations for repeated native directory checks.
- Normalize PATH comparisons before prepending native library directories.
- Apply the same guard in the GUI dependency checker and UDPFS CHD runtime loader.

## Verification
- `python -m py_compile launcher\optional_deps.py udpfs_server\compressed_iso\chd.py`
- `python -m compileall -q launcher udpfs_server`
- `python -m launcher --selfcheck`
- `python udpbd_server\selftest.py`
- `git diff --check`
- Monkey-patched `os.add_dll_directory` regression checks returned `1` call after invoking each loader's `_prepare_native_dir()` twice with the same path.
