### PR TITLE
Polish launcher layout and fixed-width shell

### DIFF
--- a/launcher/asset_skin.py
+++ b/launcher/asset_skin.py
@@ -77,6 +77,12 @@ def _soften_styles(root, gui):
     style.configure("Header.TFrame", background=palette["bg"])
     style.configure("TLabel", background=palette["bg"], foreground=palette["text"])
     style.configure("Muted.TLabel", background=palette["bg"], foreground=palette["muted"])
+    style.configure("TopStrip.TFrame", background=palette["surface"], relief="flat")
+    style.configure("TopStripTitle.TLabel", background=palette["surface"],
+                    foreground=palette["text"])
+    style.configure("TopStripHint.TLabel", background=palette["surface"],
+                    foreground=palette["muted"])
+    style.configure("Footer.TFrame", background=palette["surface"], relief="flat")
 
     # Utility cards: softer border, brighter secondary text.
     style.configure("Admin.TFrame", background=palette["surface"], relief="flat", borderwidth=0)
@@ -90,6 +96,22 @@ def _soften_styles(root, gui):
                     darkcolor=palette["surface"], relief="solid", borderwidth=1)
     style.configure("TLabelframe.Label", background=palette["bg"], foreground=palette["accent2"],
                     font=("", 10, "bold"))
+    style.configure("Card.TLabelframe", background=palette["surface"],
+                    foreground=palette["text"], bordercolor=palette["edge"],
+                    lightcolor=palette["edge"], darkcolor=palette["surface"],
+                    relief="solid", borderwidth=1)
+    style.configure("Card.TLabelframe.Label", background=palette["bg"],
+                    foreground=palette["accent2"], font=("", 10, "bold"))
+    style.configure("Card.TFrame", background=palette["surface"])
+    style.configure("Card.TLabel", background=palette["surface"], foreground=palette["text"])
+    style.configure("CardMuted.TLabel", background=palette["surface"], foreground=palette["muted"])
+    style.configure("CardHelp.TLabel", background=palette["surface"], foreground=palette["muted"])
+    style.configure("CardHint.TLabel", background=palette["surface"], foreground=palette["accent2"])
+    style.configure("CardStatus.TLabel", background=palette["surface"], foreground=palette["muted"])
+    style.configure("Card.TCheckbutton", background=palette["surface"], foreground=palette["text"])
+    style.map("Card.TCheckbutton", background=[("active", palette["surface2"])])
+    style.configure("PageActions.TFrame", background=palette["surface"], relief="flat")
+    style.configure("PageActions.TLabel", background=palette["surface"], foreground=palette["muted"])
 
     style.configure("TButton", background=palette["surface2"], foreground=palette["text"],
                     padding=(10, 5), borderwidth=1, focusthickness=1,
@@ -100,7 +122,7 @@ def _soften_styles(root, gui):
     style.configure("Accent.TButton", background=palette["accent"], foreground="#ffffff",
                     padding=(12, 6), borderwidth=0)
 
-    style.configure("Server.TNotebook", background=palette["bg"], borderwidth=0, tabmargins=(8, 8, 8, 0))
+    style.configure("Server.TNotebook", background=palette["bg"], borderwidth=0, tabmargins=(14, 8, 14, 0))
     style.configure("Server.TNotebook.Tab", padding=(14, 8), font=("", 10, "bold"),
                     background=palette["surface"], foreground=palette["muted"], borderwidth=1)
     style.map("Server.TNotebook.Tab",

--- a/launcher/dependency_panel.py
+++ b/launcher/dependency_panel.py
@@ -15,23 +15,24 @@ LZ4_PACKAGED_BUTTON = "Bundled in release"
 
 
 def add_panel(app, gui):
-    frame = gui.ttk.Frame(app.root, style="Admin.TFrame")
-    frame.pack(fill="x", padx=10, pady=(0, 4))
+    parent = getattr(app, "content", app.root)
+    frame = gui.ttk.Frame(parent, style="Admin.TFrame", padding=(12, 8))
+    frame.pack(fill="x", padx=16, pady=(0, 8))
 
     gui.ttk.Label(frame, text="Compression:", style="Admin.TLabel",
-                  font=("", 9, "bold")).pack(side="left", padx=(8, 8), pady=6)
+                  font=("", 9, "bold")).pack(side="left", padx=(0, 8))
     app._ps2_compression_var = gui.tk.StringVar(value="Checking…")
     gui.ttk.Label(frame, textvariable=app._ps2_compression_var,
-                  style="Admin.TLabel").pack(side="left", padx=(0, 8), pady=6)
+                  style="Admin.TLabel").pack(side="left", padx=(0, 8))
 
     gui.ttk.Button(frame, text="Check",
-                   command=lambda: show_status(app, gui)).pack(side="right", padx=(4, 8), pady=5)
+                   command=lambda: show_status(app, gui)).pack(side="right", padx=(4, 0))
     gui.ttk.Button(frame, text="Details",
-                   command=lambda: show_libchdr_details(gui)).pack(side="right", padx=(4, 0), pady=5)
+                   command=lambda: show_libchdr_details(gui)).pack(side="right", padx=(4, 0))
     install_text = LZ4_PACKAGED_BUTTON if optional_deps.is_frozen_app() else LZ4_SOURCE_BUTTON
     install = gui.ttk.Button(frame, text=install_text,
                              command=lambda: install_lz4(app, gui))
-    install.pack(side="right", padx=(4, 0), pady=5)
+    install.pack(side="right", padx=(4, 0))
     if optional_deps.is_frozen_app():
         install.config(state="disabled")
     app._ps2_lz4_button = install

--- a/launcher/full_skin_controls.py
+++ b/launcher/full_skin_controls.py
@@ -10,10 +10,6 @@ def install(app, gui):
     """Install per-server page action controls once before cards are built."""
     if getattr(gui, "_ps2_full_skin_controls_patched", False):
         return
-    try:
-        from . import theme_assets
-    except ImportError:
-        theme_assets = None
 
     ServerCard = gui.ServerCard
     LauncherApp = gui.LauncherApp
@@ -44,45 +40,30 @@ def install(app, gui):
                     pass
         row = max(rows or [0]) + 1
 
-        actions = gui.ttk.Frame(card, style="Admin.TFrame")
-        actions.grid(row=row, column=0, columnspan=3, sticky="ew", padx=8, pady=(4, 8))
+        actions = gui.ttk.Frame(card, style="PageActions.TFrame")
+        actions.grid(row=row, column=0, columnspan=3, sticky="ew",
+                     padx=4, pady=(8, 0))
         actions.columnconfigure(0, weight=1)
-
-        linebreak = None
-        if theme_assets is not None:
-            try:
-                linebreak = theme_assets.photo_fit(
-                    gui, "LINEBREAK", owner=card, max_width=620, max_height=36)
-            except gui.tk.TclError:
-                linebreak = None
-        if linebreak:
-            gui.tk.Label(actions, image=linebreak, bg="#081427", bd=0,
-                         highlightthickness=0).grid(
-                             row=0, column=0, columnspan=3, sticky="w",
-                             padx=8, pady=(6, 0))
-            control_row = 1
-        else:
-            control_row = 0
 
         gui.ttk.Label(
             actions,
             text="Page settings",
-            style="Admin.TLabel",
+            style="PageActions.TLabel",
             font=("", 9, "bold"),
-        ).grid(row=control_row, column=0, sticky="w", padx=(8, 4), pady=6)
+        ).grid(row=0, column=0, sticky="w", pady=(6, 0))
 
         gui.ttk.Button(
             actions,
             text="Revert to Default",
             command=lambda c=card: c.revert_to_defaults(),
-        ).grid(row=control_row, column=1, sticky="e", padx=(4, 0), pady=5)
+        ).grid(row=0, column=1, sticky="e", padx=(8, 0), pady=(6, 0))
 
         gui.ttk.Button(
             actions,
             text="Apply",
             style="Accent.TButton",
             command=lambda c=card: c.apply_page_settings(),
-        ).grid(row=control_row, column=2, sticky="e", padx=(6, 8), pady=5)
+        ).grid(row=0, column=2, sticky="e", padx=(8, 0), pady=(6, 0))
 
     def build_with_page_actions(card):
         original_build(card)

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -9,6 +9,7 @@ drained on the Tk main thread.
 
 import platform
 import queue
+import subprocess
 import sys
 import threading
 import tkinter as tk
@@ -17,7 +18,7 @@ from tkinter import filedialog, messagebox, ttk
 
 from . import config, elevate, netinfo, tray, windows_setup
 from .process import ServerProcess
-from .servers import REGISTRY, REPO_ROOT
+from .servers import REGISTRY, REPO_ROOT, frozen_self_exe, is_frozen
 
 DOT_RUNNING = "●"  # filled circle
 COLOR_RUNNING = "#2e9e44"
@@ -281,6 +282,12 @@ class LauncherApp:
         self.out_queue = queue.Queue()
         self.logs = {}
         self.saved = config.load()
+        self._tray = None
+        self._tray_option_widgets = []
+        self.close_to_tray_var = tk.BooleanVar(
+            value=self._saved_bool("close_to_tray", tray.AVAILABLE))
+        self.minimize_to_tray_var = tk.BooleanVar(
+            value=self._saved_bool("minimize_to_tray", tray.AVAILABLE))
 
         root.title("PS2 Servers")
         self._configure_window()
@@ -291,7 +298,6 @@ class LauncherApp:
 
         # On Windows, run from the system tray: closing or minimizing hides the
         # window (servers keep running) and the tray menu restores or quits.
-        self._tray = None
         self._tray_queue = queue.Queue()
         if tray.AVAILABLE:
             try:
@@ -305,11 +311,12 @@ class LauncherApp:
                 self._tray = None
 
         if self._tray:
-            root.protocol("WM_DELETE_WINDOW", self._hide_to_tray)
+            root.protocol("WM_DELETE_WINDOW", self._on_window_close)
             root.bind("<Unmap>", self._on_unmap)
             self.root.after(150, self._drain_tray)
         else:
-            root.protocol("WM_DELETE_WINDOW", self.on_close)
+            root.protocol("WM_DELETE_WINDOW", self._on_window_close)
+        self._update_tray_option_controls()
 
         self.root.after(150, self._drain_logs)
         self.root.after(600, self._poll_status)
@@ -484,6 +491,10 @@ class LauncherApp:
             remove.config(state="disabled")
         ttk.Button(footer, text="Stop all", command=self.stop_all).grid(
             row=0, column=3, sticky="e")
+        ttk.Button(footer, text="Restart", command=self.restart_app).grid(
+            row=0, column=4, sticky="e", padx=(8, 0))
+        ttk.Button(footer, text="Exit", command=self.exit_app).grid(
+            row=0, column=5, sticky="e", padx=(8, 0))
 
     def _build_about_tab(self):
         about = ttk.Frame(self.nb)
@@ -528,9 +539,27 @@ class LauncherApp:
         remove.pack(side="left", padx=(6, 0), pady=6)
         ttk.Button(actions, text="Stop all servers",
                    command=self.stop_all).pack(side="left", padx=(6, 0), pady=6)
+        ttk.Button(actions, text="Restart app",
+                   command=self.restart_app).pack(side="left", padx=(6, 0), pady=6)
+        ttk.Button(actions, text="Exit app",
+                   command=self.exit_app).pack(side="left", padx=(6, 0), pady=6)
         if not windows_setup.is_windows():
             allow.config(state="disabled")
             remove.config(state="disabled")
+
+        behavior = ttk.LabelFrame(about, text=" Window behavior ")
+        behavior.grid(row=row, column=0, sticky="ew", padx=8, pady=(8, 0))
+        behavior.columnconfigure(2, weight=1)
+        row += 1
+        close_to_tray = ttk.Checkbutton(
+            behavior, text="Close to tray", variable=self.close_to_tray_var,
+            command=self._save, style="Card.TCheckbutton")
+        close_to_tray.grid(row=0, column=0, sticky="w", padx=(6, 12), pady=6)
+        minimize_to_tray = ttk.Checkbutton(
+            behavior, text="Minimize to tray", variable=self.minimize_to_tray_var,
+            command=self._save, style="Card.TCheckbutton")
+        minimize_to_tray.grid(row=0, column=1, sticky="w", padx=(0, 12), pady=6)
+        self._tray_option_widgets.extend([close_to_tray, minimize_to_tray])
 
         text_frame = ttk.Frame(about)
         about.rowconfigure(row, weight=1)
@@ -962,6 +991,10 @@ class LauncherApp:
         self.root.after(600, self._poll_status)
 
     # -- config ----------------------------------------------------------- #
+    def _saved_bool(self, key, default=False):
+        value = self.saved.get(key, default)
+        return bool(value) if isinstance(value, bool) else bool(default)
+
     def _restore(self):
         servers = self.saved.get("servers", {})
         for key, card in self.cards.items():
@@ -969,11 +1002,17 @@ class LauncherApp:
         ip = self.saved.get("ip")
         if ip and ip in netinfo.all_ipv4():
             self.ip_var.set(ip)
+        self.close_to_tray_var.set(
+            self._saved_bool("close_to_tray", self.close_to_tray_var.get()))
+        self.minimize_to_tray_var.set(
+            self._saved_bool("minimize_to_tray", self.minimize_to_tray_var.get()))
 
     def _save(self, pending_start=None, pending_cleanup=False,
               pending_firewall_allow=False):
         data = {"servers": {key: card.values() for key, card in self.cards.items()},
-                "ip": self.ip_var.get()}
+                "ip": self.ip_var.get(),
+                "close_to_tray": bool(self.close_to_tray_var.get()),
+                "minimize_to_tray": bool(self.minimize_to_tray_var.get())}
         if pending_start:
             data["pending_start"] = pending_start
         if pending_cleanup:
@@ -986,22 +1025,80 @@ class LauncherApp:
             pass
 
     def on_close(self):
+        self.exit_app(confirm=False)
+
+    def exit_app(self, confirm=True):
+        if confirm and not self._confirm_app_shutdown("Exit PS2 Servers?"):
+            return
+        self._shutdown_app()
+
+    def restart_app(self):
+        if not self._confirm_app_shutdown("Restart PS2 Servers?"):
+            return
+        self._save()
+        command = self._restart_command()
+        try:
+            subprocess.Popen(command, cwd=None if is_frozen() else REPO_ROOT)
+        except OSError as e:
+            messagebox.showerror("Restart failed", str(e))
+            return
+        self._shutdown_app()
+
+    def _restart_command(self):
+        if is_frozen():
+            return [frozen_self_exe()]
+        return [sys.executable, "-m", "launcher"]
+
+    def _confirm_app_shutdown(self, title):
+        running = [TAB_TITLES.get(key, key.upper())
+                   for key in self.procs if self.is_running(key)]
+        if not running:
+            return True
+        return messagebox.askyesno(
+            title,
+            "This will stop running servers:\n\n{}\n\nContinue?".format(
+                ", ".join(running)))
+
+    def _shutdown_app(self):
         self._save()
         # hide first so the (up to a few seconds of) child termination doesn't
         # look like a frozen window
         self.root.withdraw()
         self.stop_all()
+        if self._tray:
+            self._tray.stop()
         self.root.destroy()
 
     # -- system tray (Windows) -------------------------------------------- #
+    def _on_window_close(self):
+        if self._should_close_to_tray():
+            self._hide_to_tray()
+            return
+        self.exit_app(confirm=False)
+
+    def _should_close_to_tray(self):
+        return bool(self._tray and self.close_to_tray_var.get())
+
+    def _should_minimize_to_tray(self):
+        return bool(self._tray and self.minimize_to_tray_var.get())
+
+    def _update_tray_option_controls(self):
+        state = "normal" if self._tray else "disabled"
+        for widget in self._tray_option_widgets:
+            try:
+                widget.config(state=state)
+            except tk.TclError:
+                pass
+
     def _hide_to_tray(self):
         # closing the window just hides it; the servers keep running in the tray
         self._save()
         self.root.withdraw()
 
     def _on_unmap(self, event):
-        # minimizing also hides to the tray (off the taskbar)
-        if event.widget is self.root and self.root.state() == "iconic":
+        # minimizing can hide to the tray (off the taskbar) when enabled.
+        if (event.widget is self.root and self.root.state() == "iconic"
+                and self._should_minimize_to_tray()):
             self.root.withdraw()
 
     def _restore_from_tray(self):
@@ -1017,17 +1114,13 @@ class LauncherApp:
                 if action == "open":
                     self._restore_from_tray()
                 elif action == "quit":
-                    self._quit_from_tray()
+                    self.exit_app(confirm=False)
         except queue.Empty:
             pass
         self.root.after(150, self._drain_tray)
 
     def _quit_from_tray(self):
-        self._save()
-        self.stop_all()
-        if self._tray:
-            self._tray.stop()
-        self.root.destroy()
+        self.exit_app(confirm=False)
 
 
 def run_gui():

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -123,7 +123,8 @@ class ServerCard(ttk.LabelFrame):
     """One server's controls, status and OPL hint."""
 
     def __init__(self, master, app, server):
-        super().__init__(master, text="  " + server.label + "  ")
+        super().__init__(master, text="  " + server.label + "  ",
+                         style="Card.TLabelframe")
         self.app = app
         self.server = server
         self.vars = {}
@@ -133,21 +134,23 @@ class ServerCard(ttk.LabelFrame):
 
     # -- widget construction ---------------------------------------------- #
     def _build(self):
+        self.configure(padding=(12, 10, 12, 12))
         self.columnconfigure(1, weight=1)
         row = 0
 
         # header: blurb + status + start/stop
         ttk.Label(self, text=self.server.blurb, wraplength=560,
-                  foreground="#b4c6df").grid(row=row, column=0, columnspan=3,
-                                             sticky="w", padx=8, pady=(6, 2))
+                  style="CardMuted.TLabel").grid(row=row, column=0, columnspan=3,
+                                                 sticky="w", padx=4, pady=(2, 6))
         row += 1
 
         self.status = ttk.Label(self, text=DOT_RUNNING + " Stopped",
-                                foreground=COLOR_STOPPED)
-        self.status.grid(row=row, column=0, sticky="w", padx=8)
+                                foreground=COLOR_STOPPED,
+                                style="CardStatus.TLabel")
+        self.status.grid(row=row, column=0, sticky="w", padx=4, pady=(0, 4))
         self.toggle_btn = ttk.Button(self, text="Start", width=10,
                                      command=self.on_toggle)
-        self.toggle_btn.grid(row=row, column=2, sticky="e", padx=8, pady=2)
+        self.toggle_btn.grid(row=row, column=2, sticky="e", padx=4, pady=(0, 4))
         if not self.server.is_available():
             self.status.config(text="n/a on this OS", foreground=COLOR_ERROR)
             self.toggle_btn.config(state="disabled")
@@ -162,9 +165,9 @@ class ServerCard(ttk.LabelFrame):
         if advanced:
             self.adv_btn = ttk.Button(self, text="Advanced ▸", width=14,
                                       command=self._toggle_advanced)
-            self.adv_btn.grid(row=row, column=0, sticky="w", padx=8, pady=2)
+            self.adv_btn.grid(row=row, column=0, sticky="w", padx=4, pady=(4, 2))
             row += 1
-            self.adv_frame = ttk.Frame(self)
+            self.adv_frame = ttk.Frame(self, style="Card.TFrame")
             self.adv_frame.grid(row=row, column=0, columnspan=3, sticky="ew")
             self.adv_frame.columnconfigure(1, weight=1)
             self.adv_frame.grid_remove()
@@ -173,39 +176,44 @@ class ServerCard(ttk.LabelFrame):
                 arow = self._add_field(self.adv_frame, f, arow)
             row += 1
 
-        self.hint = ttk.Label(self, text="", foreground="#46d9ff", wraplength=620)
-        self.hint.grid(row=row, column=0, columnspan=3, sticky="w", padx=8, pady=(2, 6))
+        self.hint = ttk.Label(self, text="", style="CardHint.TLabel",
+                              wraplength=720)
+        self.hint.grid(row=row, column=0, columnspan=3, sticky="w",
+                       padx=4, pady=(4, 0))
 
     def _add_field(self, parent, f, row):
         if f.kind == "bool":
             var = tk.BooleanVar(value=bool(f.default))
-            ttk.Checkbutton(parent, text=f.label, variable=var).grid(
-                row=row, column=0, columnspan=3, sticky="w", padx=8, pady=1)
+            ttk.Checkbutton(parent, text=f.label, variable=var,
+                            style="Card.TCheckbutton").grid(
+                row=row, column=0, columnspan=3, sticky="w", padx=4, pady=2)
             self.vars[f.key] = var
             return row + 1
 
-        ttk.Label(parent, text=f.label + ":").grid(row=row, column=0, sticky="w",
-                                                   padx=8, pady=1)
+        ttk.Label(parent, text=f.label + ":", style="Card.TLabel").grid(
+            row=row, column=0, sticky="w", padx=4, pady=2)
         if f.kind == "port":
             var = tk.StringVar(value=self.server.port_display())
             ttk.Entry(parent, textvariable=var, width=12).grid(
-                row=row, column=1, sticky="w", padx=4, pady=1)
+                row=row, column=1, sticky="w", padx=6, pady=2)
         elif f.kind in ("folder", "file"):
             var = tk.StringVar(value="")
             ttk.Entry(parent, textvariable=var).grid(
-                row=row, column=1, sticky="ew", padx=4, pady=1)
+                row=row, column=1, sticky="ew", padx=6, pady=2)
             ttk.Button(parent, text="Browse…", width=10,
                        command=lambda v=var, k=f.kind: self._browse(v, k)).grid(
-                row=row, column=2, sticky="e", padx=8, pady=1)
+                row=row, column=2, sticky="e", padx=4, pady=2)
         else:  # text
             var = tk.StringVar(value=str(f.default or ""))
             ttk.Entry(parent, textvariable=var).grid(
-                row=row, column=1, sticky="ew", padx=4, pady=1)
+                row=row, column=1, sticky="ew", padx=6, pady=2)
         self.vars[f.key] = var
         row += 1
         if f.help:  # on its own row so it never overlaps the entry/Browse button
-            ttk.Label(parent, text=f.help, foreground="#9fb7d7", font=("", 8)).grid(
-                row=row, column=1, columnspan=2, sticky="w", padx=4, pady=(0, 2))
+            ttk.Label(parent, text=f.help, style="CardHelp.TLabel",
+                      font=("", 8)).grid(
+                row=row, column=1, columnspan=2, sticky="w",
+                padx=6, pady=(0, 4))
             row += 1
         return row
 
@@ -278,6 +286,7 @@ class LauncherApp:
         self._configure_window()
         self.content = self._build_scroll_body()
         self._build()
+        self._refresh_scroll_body()
         self._restore()
 
         # On Windows, run from the system tray: closing or minimizing hides the
@@ -316,16 +325,22 @@ class LauncherApp:
         height = min(APP_INITIAL_HEIGHT, max(APP_MIN_HEIGHT, screen_height - 80))
         self.root.geometry("{}x{}".format(APP_WINDOW_WIDTH, height))
         self.root.minsize(APP_WINDOW_WIDTH, APP_MIN_HEIGHT)
+        self.root.maxsize(APP_WINDOW_WIDTH, max(APP_MIN_HEIGHT, screen_height))
         self.root.resizable(False, True)
         self.root.bind("<Configure>", self._enforce_fixed_width, add="+")
 
     def _enforce_fixed_width(self, event):
-        if event.widget is not self.root or event.width == APP_WINDOW_WIDTH or event.height <= 1:
+        if event.widget is not self.root or event.height <= 1:
             return
+        if event.width == APP_WINDOW_WIDTH and self.root.state() != "zoomed":
+            return
+        height = min(max(APP_MIN_HEIGHT, event.height), self.root.winfo_screenheight())
 
         def resize():
             try:
-                self.root.geometry("{}x{}".format(APP_WINDOW_WIDTH, event.height))
+                if self.root.state() == "zoomed":
+                    self.root.state("normal")
+                self.root.geometry("{}x{}".format(APP_WINDOW_WIDTH, height))
             except tk.TclError:
                 pass
 
@@ -345,7 +360,7 @@ class LauncherApp:
                                       width=APP_CONTENT_WIDTH)
 
         def refresh_scroll_region(event=None):
-            height = max(body.winfo_reqheight(), canvas.winfo_height())
+            height = max(1, body.winfo_reqheight())
             canvas.itemconfigure(window, width=APP_CONTENT_WIDTH, height=height)
             canvas.configure(scrollregion=canvas.bbox("all"))
 
@@ -353,7 +368,9 @@ class LauncherApp:
         canvas.bind("<Configure>", refresh_scroll_region)
         self._scroll_canvas = canvas
         self._scrollbar = scrollbar
+        self._scroll_window = window
         self._bind_body_mousewheel(canvas)
+        self._refresh_scroll_body = refresh_scroll_region
         return body
 
     def _bind_body_mousewheel(self, canvas):
@@ -389,27 +406,31 @@ class LauncherApp:
     def _build(self):
         parent = self.content
         # header: LAN IP the user types into OPL
-        header = ttk.Frame(parent)
-        header.pack(fill="x", padx=10, pady=(10, 4))
-        ttk.Label(header, text="Your PC's LAN IP:", font=("", 10, "bold")).pack(side="left")
+        header = ttk.Frame(parent, style="TopStrip.TFrame", padding=(12, 10))
+        header.pack(fill="x", padx=16, pady=(12, 8))
+        header.columnconfigure(3, weight=1)
+        ttk.Label(header, text="LAN IP", font=("", 10, "bold"),
+                  style="TopStripTitle.TLabel").grid(row=0, column=0, sticky="w")
         self.ip_var = tk.StringVar(value=netinfo.best_lan_ip())
         self.ip_combo = ttk.Combobox(header, textvariable=self.ip_var, width=18,
                                      values=netinfo.all_ipv4(), state="readonly")
-        self.ip_combo.pack(side="left", padx=6)
-        ttk.Button(header, text="Refresh", command=self._refresh_ips).pack(side="left")
-        ttk.Label(header, text="  (enter this in OPL where it asks for the PC/server IP)",
-                  foreground="#9fb7d7").pack(side="left")
+        self.ip_combo.grid(row=0, column=1, sticky="w", padx=(10, 6))
+        ttk.Button(header, text="Refresh", command=self._refresh_ips).grid(
+            row=0, column=2, sticky="w")
+        ttk.Label(header, text="Enter this in OPL where it asks for the PC/server IP.",
+                  style="TopStripHint.TLabel", wraplength=420).grid(
+            row=0, column=3, sticky="w", padx=(12, 0))
 
         # main tabs: one server per tab, plus a shared terminal tab
         self.nb = ttk.Notebook(parent)
-        self.nb.pack(fill="both", expand=True, padx=10, pady=4)
+        self.nb.pack(fill="x", padx=16, pady=(0, 12))
         self.server_tabs = {}
 
         for server in REGISTRY.values():
             tab = ttk.Frame(self.nb)
             tab.columnconfigure(0, weight=1)
             card = ServerCard(tab, self, server)
-            card.grid(row=0, column=0, sticky="new", padx=8, pady=8)
+            card.grid(row=0, column=0, sticky="ew", padx=10, pady=10)
             self.nb.add(tab, text=TAB_TITLES.get(server.key, server.label))
             self.server_tabs[server.key] = tab
             self.cards[server.key] = card
@@ -434,18 +455,20 @@ class LauncherApp:
         self._build_about_tab()
 
         # footer
-        footer = ttk.Frame(parent)
-        footer.pack(fill="x", padx=10, pady=(0, 10))
+        footer = ttk.Frame(parent, style="Footer.TFrame", padding=(12, 10))
+        footer.pack(fill="x", padx=16, pady=(0, 14))
+        footer.columnconfigure(2, weight=1)
         allow = ttk.Button(footer, text="Allow through firewall",
                            command=self.allow_windows_setup)
-        allow.pack(side="left")
+        allow.grid(row=0, column=0, sticky="w")
         remove = ttk.Button(footer, text="Remove PS2 Servers firewall rules",
                             command=self.remove_windows_setup)
-        remove.pack(side="left", padx=(6, 0))
+        remove.grid(row=0, column=1, sticky="w", padx=(8, 0))
         if not windows_setup.is_windows():
             allow.config(state="disabled")
             remove.config(state="disabled")
-        ttk.Button(footer, text="Stop all", command=self.stop_all).pack(side="right")
+        ttk.Button(footer, text="Stop all", command=self.stop_all).grid(
+            row=0, column=3, sticky="e")
 
     def _build_about_tab(self):
         about = ttk.Frame(self.nb)

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -330,14 +330,18 @@ class LauncherApp:
         self.root.bind("<Configure>", self._enforce_fixed_width, add="+")
 
     def _enforce_fixed_width(self, event):
-        if event.widget is not self.root or event.height <= 1:
+        if str(event.widget) != str(self.root) or event.height <= 1:
             return
         if event.width == APP_WINDOW_WIDTH and self.root.state() != "zoomed":
             return
-        height = min(max(APP_MIN_HEIGHT, event.height), self.root.winfo_screenheight())
 
         def resize():
             try:
+                height = self.root.winfo_height()
+                if height <= 1:
+                    height = event.height
+                height = min(max(APP_MIN_HEIGHT, height),
+                             self.root.winfo_screenheight())
                 if self.root.state() == "zoomed":
                     self.root.state("normal")
                 self.root.geometry("{}x{}".format(APP_WINDOW_WIDTH, height))
@@ -352,8 +356,8 @@ class LauncherApp:
                            bd=0, background=bg)
         scrollbar = ttk.Scrollbar(self.root, orient="vertical", command=canvas.yview)
         canvas.configure(yscrollcommand=scrollbar.set)
-        canvas.pack(side="left", fill="both", expand=True)
         scrollbar.pack(side="right", fill="y")
+        canvas.pack(side="left", fill="both", expand=True)
 
         body = ttk.Frame(canvas)
         window = canvas.create_window((0, 0), window=body, anchor="nw",
@@ -361,8 +365,13 @@ class LauncherApp:
 
         def refresh_scroll_region(event=None):
             height = max(1, body.winfo_reqheight())
-            canvas.itemconfigure(window, width=APP_CONTENT_WIDTH, height=height)
-            canvas.configure(scrollregion=canvas.bbox("all"))
+            current_width = str(canvas.itemcget(window, "width"))
+            current_height = str(canvas.itemcget(window, "height"))
+            if current_width != str(APP_CONTENT_WIDTH) or current_height != str(height):
+                canvas.itemconfigure(window, width=APP_CONTENT_WIDTH, height=height)
+                scrollregion = canvas.bbox("all")
+                if scrollregion:
+                    canvas.configure(scrollregion=scrollregion)
 
         body.bind("<Configure>", refresh_scroll_region)
         canvas.bind("<Configure>", refresh_scroll_region)
@@ -375,7 +384,13 @@ class LauncherApp:
 
     def _bind_body_mousewheel(self, canvas):
         def should_scroll_page(event):
-            if isinstance(event.widget, tk.Text):
+            widget = event.widget
+            if isinstance(widget, str):
+                try:
+                    widget = canvas.nametowidget(widget)
+                except (KeyError, tk.TclError):
+                    widget = None
+            if hasattr(widget, "winfo_class") and widget.winfo_class() == "Text":
                 return False
             first, last = canvas.yview()
             return first > 0.0 or last < 1.0

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -129,6 +129,12 @@ def _apply_gui_review_fixes(gui):
         style.configure("Header.TFrame", background=palette["bg"])
         style.configure("TLabel", background=palette["bg"], foreground=palette["text"])
         style.configure("Muted.TLabel", background=palette["bg"], foreground=palette["muted"])
+        style.configure("TopStrip.TFrame", background=palette["panel"], relief="flat")
+        style.configure("TopStripTitle.TLabel", background=palette["panel"],
+                        foreground=palette["text"])
+        style.configure("TopStripHint.TLabel", background=palette["panel"],
+                        foreground=palette["muted"])
+        style.configure("Footer.TFrame", background=palette["panel"], relief="flat")
         style.configure("Admin.TLabel", background=palette["panel"], foreground=palette["muted"])
         style.configure("AdminYes.TLabel", background=palette["panel"], foreground=palette["ok"])
         style.configure("AdminNo.TLabel", background=palette["panel"], foreground=palette["warn"])
@@ -155,9 +161,23 @@ def _apply_gui_review_fixes(gui):
                         bordercolor=palette["accent"], relief="solid")
         style.configure("TLabelframe.Label", background=palette["bg"], foreground=palette["accent2"],
                         font=("", 10, "bold"))
+        style.configure("Card.TLabelframe", background=palette["panel"], foreground=palette["text"],
+                        bordercolor="#18416f", relief="solid", borderwidth=1)
+        style.configure("Card.TLabelframe.Label", background=palette["bg"],
+                        foreground=palette["accent2"], font=("", 10, "bold"))
+        style.configure("Card.TFrame", background=palette["panel"])
+        style.configure("Card.TLabel", background=palette["panel"], foreground=palette["text"])
+        style.configure("CardMuted.TLabel", background=palette["panel"], foreground=palette["muted"])
+        style.configure("CardHelp.TLabel", background=palette["panel"], foreground=palette["muted"])
+        style.configure("CardHint.TLabel", background=palette["panel"], foreground=palette["accent2"])
+        style.configure("CardStatus.TLabel", background=palette["panel"], foreground=palette["muted"])
+        style.configure("Card.TCheckbutton", background=palette["panel"], foreground=palette["text"])
+        style.map("Card.TCheckbutton", background=[("active", palette["panel2"])])
+        style.configure("PageActions.TFrame", background=palette["panel"], relief="flat")
+        style.configure("PageActions.TLabel", background=palette["panel"], foreground=palette["muted"])
         style.configure("Admin.TFrame", background=palette["panel"], relief="solid", borderwidth=1)
         style.configure("Server.TNotebook", background=palette["bg"], borderwidth=0,
-                        tabmargins=(8, 6, 8, 0))
+                        tabmargins=(14, 8, 14, 0))
         style.configure("Server.TNotebook.Tab", padding=(16, 7), font=("", 10, "bold"),
                         background=palette["panel"], foreground=palette["muted"], borderwidth=1)
         style.map("Server.TNotebook.Tab",
@@ -166,8 +186,7 @@ def _apply_gui_review_fixes(gui):
                               ("!selected", palette["panel"])],
                   foreground=[("selected", palette["accent2"]),
                               ("active", palette["text"]),
-                              ("!selected", palette["muted"])],
-                  expand=[("selected", (2, 2, 2, 0))])
+                              ("!selected", palette["muted"])])
 
     def draw_banner(canvas, width=760, height=78):
         canvas.delete("all")
@@ -202,14 +221,14 @@ def _apply_gui_review_fixes(gui):
 
     def build_banner(self):
         frame = gui.ttk.Frame(content_parent(self), style="Header.TFrame")
-        frame.pack(fill="x", padx=10, pady=(10, 0))
+        frame.pack(fill="x", padx=16, pady=(12, 0))
 
-        banner = asset_photo(self, "BANNER", max_width=980, max_height=520)
+        banner = asset_photo(self, "BANNER")
         if banner:
-            height = 168
+            height = 180
             canvas = gui.tk.Canvas(frame, height=height, highlightthickness=0,
                                    bg=palette["bg"], bd=0)
-            canvas.pack(fill="x", expand=True)
+            canvas.pack(fill="x")
 
             def draw(event=None):
                 width = event.width if event else 820
@@ -227,25 +246,29 @@ def _apply_gui_review_fixes(gui):
         accent = asset_photo(self, "ACCENT", max_width=780, max_height=36)
         if accent:
             gui.tk.Label(frame, image=accent, bg=palette["bg"], bd=0,
-                         highlightthickness=0).pack(anchor="w", pady=(2, 0))
+                         highlightthickness=0).pack(anchor="w", pady=(4, 0))
 
     def add_admin_panel(self):
         if not gui.windows_setup.is_windows():
             return
-        frame = gui.ttk.Frame(content_parent(self), style="Admin.TFrame")
-        frame.pack(fill="x", padx=10, pady=(6, 4))
+        frame = gui.ttk.Frame(content_parent(self), style="Admin.TFrame",
+                              padding=(12, 8))
+        frame.pack(fill="x", padx=16, pady=(8, 8))
+        frame.columnconfigure(1, weight=1)
         is_admin = gui.elevate.is_admin()
         status_style = "AdminYes.TLabel" if is_admin else "AdminNo.TLabel"
         status_text = "Administrator: Yes" if is_admin else "Administrator: No"
         gui.ttk.Label(frame, text=status_text, style=status_style,
-                      font=("", 9, "bold")).pack(side="left", padx=(8, 10), pady=6)
+                      font=("", 9, "bold")).grid(row=0, column=0, sticky="w",
+                                                 padx=(0, 12))
         gui.ttk.Label(frame,
                       text="Normal launch stays non-admin. Elevate only for firewall changes or advanced port 445.",
-                      style="Admin.TLabel").pack(side="left", padx=(0, 8), pady=6)
+                      style="Admin.TLabel", wraplength=560).grid(
+                          row=0, column=1, sticky="w")
         button = gui.ttk.Button(frame, text="Restart as administrator",
                                 style="Accent.TButton",
                                 command=lambda: restart_as_admin(self))
-        button.pack(side="right", padx=8, pady=5)
+        button.grid(row=0, column=2, sticky="e", padx=(12, 0))
         if is_admin or not gui.elevate.can_elevate():
             button.config(state="disabled")
         self._ps2_admin_frame = frame


### PR DESCRIPTION
## Summary

- lock the launcher shell width more defensively so maximized windows do not expose unused black space
- top-align the scroll body so shorter pages no longer stretch into large empty notebook panels
- move compression status into the fixed content shell
- unify server-card, tab, utility-strip, and page-action styling
- simplify page settings controls by removing the decorative linebreak from the action row

## Verification

- `python -m py_compile launcher\gui.py launcher\main.py launcher\dependency_panel.py launcher\full_skin_controls.py launcher\asset_skin.py`
- hidden Tk construction smoke test for fixed width, scroll region, and width enforcement
- `python -m compileall -q launcher smbv1_server udpbd_server udpfs_server ps2servers.py`
- `python -m launcher --selfcheck`
- `python udpbd_server\selftest.py`
