### PR TITLE
Stabilize launcher visual layout baseline

### DIFF
--- a/launcher/main.py
+++ b/launcher/main.py
@@ -232,8 +232,11 @@ def _apply_gui_review_fixes(gui):
 
     def bind_wrap(widget, offset=48):
         def update(event=None):
-            root_width = widget.winfo_toplevel().winfo_width()
-            set_wrap(widget, root_width - offset)
+            try:
+                root_width = widget.winfo_toplevel().winfo_width()
+                set_wrap(widget, root_width - offset)
+            except gui.tk.TclError:
+                pass
         widget.bind("<Configure>", update, add="+")
         widget.after_idle(update)
 

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -269,7 +269,10 @@ def _apply_gui_review_fixes(gui):
         canvas.pack(fill="x", expand=True)
 
         def redraw(event=None):
-            draw_banner(canvas, event.width if event else canvas.winfo_width())
+            try:
+                draw_banner(canvas, event.width if event else canvas.winfo_width())
+            except gui.tk.TclError:
+                pass
 
         canvas.bind("<Configure>", redraw)
         canvas.after_idle(redraw)

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -64,16 +64,14 @@ The launcher shows whether it is currently running as administrator. Use "Restar
 
 
 def _apply_gui_review_fixes(gui):
-    """Apply terminal UX fixes, clearer tabs, a light PS2 skin, and admin UX."""
-    original_text = gui.tk.Text
+    """Apply the active launcher theme and a stable, responsive layout baseline.
+
+    This stays as a runtime shim so release-risk remains low, but it deliberately
+    avoids image stretching, fixed-width root geometry, and off-screen button rows.
+    """
     original_notebook = gui.ttk.Notebook
     original_launcher_init = gui.LauncherApp.__init__
     original_build = gui.LauncherApp._build
-
-    try:
-        from . import theme_assets
-    except ImportError:
-        theme_assets = None
 
     palette = {
         "bg": "#030713",
@@ -88,6 +86,7 @@ def _apply_gui_review_fixes(gui):
         "warn": "#ffcf5a",
         "error": "#ff426d",
         "entry": "#07101f",
+        "disabled": "#5f6f8d",
     }
 
     if ADMIN_ABOUT_TEXT not in gui.ABOUT_TEXT:
@@ -96,15 +95,6 @@ def _apply_gui_review_fixes(gui):
     gui.COLOR_RUNNING = palette["ok"]
     gui.COLOR_STOPPED = palette["muted"]
     gui.COLOR_ERROR = palette["error"]
-
-    def asset_photo(app, name, max_width=None, max_height=None):
-        if theme_assets is None:
-            return None
-        try:
-            return theme_assets.photo_fit(
-                gui, name, owner=app, max_width=max_width, max_height=max_height)
-        except gui.tk.TclError:
-            return None
 
     def content_parent(app):
         return getattr(app, "content", app.root)
@@ -142,12 +132,12 @@ def _apply_gui_review_fixes(gui):
                         borderwidth=1, focusthickness=1, focuscolor=palette["accent"])
         style.map("TButton",
                   background=[("active", palette["panel3"]), ("pressed", palette["accent"])],
-                  foreground=[("disabled", "#5f6f8d"), ("pressed", "#ffffff")])
+                  foreground=[("disabled", palette["disabled"]), ("pressed", "#ffffff")])
         style.configure("Accent.TButton", background=palette["accent"], foreground="#ffffff",
                         borderwidth=1, focusthickness=1, focuscolor=palette["accent2"])
         style.map("Accent.TButton",
                   background=[("active", "#12b8ff"), ("pressed", "#006fd0")],
-                  foreground=[("disabled", "#5f6f8d"), ("!disabled", "#ffffff")])
+                  foreground=[("disabled", palette["disabled"]), ("!disabled", "#ffffff")])
         style.configure("TEntry", fieldbackground=palette["entry"], foreground=palette["text"],
                         insertcolor=palette["text"], bordercolor=palette["panel3"])
         style.configure("TCombobox", fieldbackground=palette["entry"], foreground=palette["text"],
@@ -177,8 +167,8 @@ def _apply_gui_review_fixes(gui):
         style.configure("PageActions.TLabel", background=palette["panel"], foreground=palette["muted"])
         style.configure("Admin.TFrame", background=palette["panel"], relief="solid", borderwidth=1)
         style.configure("Server.TNotebook", background=palette["bg"], borderwidth=0,
-                        tabmargins=(14, 8, 14, 0))
-        style.configure("Server.TNotebook.Tab", padding=(16, 7), font=("", 10, "bold"),
+                        tabmargins=(8, 6, 8, 0))
+        style.configure("Server.TNotebook.Tab", padding=(12, 6), font=("", 10, "bold"),
                         background=palette["panel"], foreground=palette["muted"], borderwidth=1)
         style.map("Server.TNotebook.Tab",
                   background=[("selected", palette["panel3"]),
@@ -188,65 +178,102 @@ def _apply_gui_review_fixes(gui):
                               ("active", palette["text"]),
                               ("!selected", palette["muted"])])
 
-    def draw_banner(canvas, width=760, height=78):
+    def configure_window(self):
+        screen_width = max(640, self.root.winfo_screenwidth())
+        screen_height = max(480, self.root.winfo_screenheight())
+        width = min(1040, max(760, screen_width - 96))
+        height = min(780, max(520, screen_height - 96))
+        min_width = min(760, max(640, screen_width - 96))
+        min_height = min(480, max(420, screen_height - 96))
+        x = max(0, int((screen_width - width) / 2))
+        y = max(0, int((screen_height - height) / 3))
+        self.root.geometry("{}x{}+{}+{}".format(width, height, x, y))
+        self.root.minsize(min_width, min_height)
+        self.root.resizable(True, True)
+
+    def build_scroll_body(self):
+        bg = self.root.cget("background")
+        shell = gui.ttk.Frame(self.root)
+        shell.pack(fill="both", expand=True)
+
+        canvas = gui.tk.Canvas(shell, highlightthickness=0, bd=0, background=bg)
+        scrollbar = gui.ttk.Scrollbar(shell, orient="vertical", command=canvas.yview)
+        canvas.configure(yscrollcommand=scrollbar.set)
+        scrollbar.pack(side="right", fill="y")
+        canvas.pack(side="left", fill="both", expand=True)
+
+        body = gui.ttk.Frame(canvas)
+        window = canvas.create_window((0, 0), window=body, anchor="nw")
+
+        def refresh_scroll_region(event=None):
+            try:
+                width = max(1, canvas.winfo_width())
+                height = max(1, body.winfo_reqheight())
+                canvas.itemconfigure(window, width=width)
+                canvas.configure(scrollregion=(0, 0, width, height))
+            except gui.tk.TclError:
+                pass
+
+        body.bind("<Configure>", refresh_scroll_region)
+        canvas.bind("<Configure>", refresh_scroll_region)
+        self._scroll_shell = shell
+        self._scroll_canvas = canvas
+        self._scrollbar = scrollbar
+        self._scroll_window = window
+        self._bind_body_mousewheel(canvas)
+        self._refresh_scroll_body = refresh_scroll_region
+        return body
+
+    def set_wrap(widget, width):
+        try:
+            widget.configure(wraplength=max(220, int(width)))
+        except gui.tk.TclError:
+            pass
+
+    def bind_wrap(widget, offset=48):
+        def update(event=None):
+            root_width = widget.winfo_toplevel().winfo_width()
+            set_wrap(widget, root_width - offset)
+        widget.bind("<Configure>", update, add="+")
+        widget.after_idle(update)
+
+    def draw_banner(canvas, width, height=88):
+        width = max(320, int(width))
         canvas.delete("all")
         canvas.create_rectangle(0, 0, width, height, fill=palette["bg"], outline="")
-        for y, color in ((10, "#061534"), (38, "#082351"), (68, "#061534")):
+        canvas.create_rectangle(0, 0, width, height, fill=palette["panel"], outline="#18416f")
+        for y, color in ((12, "#061534"), (42, "#082351"), (78, "#061534")):
             canvas.create_line(0, y, width, y, fill=color)
-        for x in range(32, width, 96):
-            canvas.create_line(x, 0, x, height, fill="#081f48")
-        canvas.create_line(0, height - 2, width, height - 2, fill=palette["accent"], width=2)
-        canvas.create_line(0, height - 5, width, height - 5, fill="#013a7a")
-        for x in (42, 132, width - 185, width - 72):
-            canvas.create_rectangle(x, 18, x + 18, 36, outline=palette["accent"], width=1)
-            canvas.create_line(x, 18, x + 9, 10, x + 27, 10, x + 18, 18, fill="#0b69ff")
-            canvas.create_line(x + 18, 36, x + 27, 28, x + 27, 10, fill="#0848b8")
-        canvas.create_text(24, 24, anchor="w", text="PS2", fill=palette["accent2"],
+        for x in range(36, width + 96, 96):
+            canvas.create_line(x, 0, x - 38, height, fill="#081f48")
+        canvas.create_line(0, height - 3, width, height - 3, fill=palette["accent"], width=2)
+        for x in (42, 132, max(220, width - 190), max(300, width - 82)):
+            if 0 <= x < width - 28:
+                canvas.create_rectangle(x, 18, x + 18, 36, outline=palette["accent"], width=1)
+                canvas.create_line(x, 18, x + 9, 10, x + 27, 10, x + 18, 18,
+                                   fill="#0b69ff")
+                canvas.create_line(x + 18, 36, x + 27, 28, x + 27, 10, fill="#0848b8")
+        canvas.create_text(24, 25, anchor="w", text="PS2", fill=palette["accent2"],
                            font=("", 26, "bold"))
-        canvas.create_text(112, 26, anchor="w", text="SERVERS", fill=palette["text"],
+        canvas.create_text(112, 27, anchor="w", text="SERVERS", fill=palette["text"],
                            font=("", 18, "bold"))
-        canvas.create_text(24, 56, anchor="w", text="SMBv1  ·  UDPFS  ·  UDPBD  ·  no terminal required",
+        canvas.create_text(24, 61, anchor="w",
+                           text="SMBv1  ·  UDPFS  ·  UDPBD  ·  no terminal required",
                            fill=palette["muted"], font=("", 9))
-
-    def install_background(self):
-        background = asset_photo(self, "BACKGROUND", max_width=960, max_height=640)
-        if not background:
-            return
-        parent = content_parent(self)
-        label = gui.tk.Label(parent, image=background, bg=palette["bg"], bd=0,
-                             highlightthickness=0)
-        label.place(x=0, y=0, relwidth=1, relheight=1)
-        label.lower()
-        self._ps2_theme_background = label
 
     def build_banner(self):
         frame = gui.ttk.Frame(content_parent(self), style="Header.TFrame")
         frame.pack(fill="x", padx=16, pady=(12, 0))
+        canvas = gui.tk.Canvas(frame, height=88, highlightthickness=0,
+                               bg=palette["bg"], bd=0)
+        canvas.pack(fill="x", expand=True)
 
-        banner = asset_photo(self, "BANNER")
-        if banner:
-            height = 180
-            canvas = gui.tk.Canvas(frame, height=height, highlightthickness=0,
-                                   bg=palette["bg"], bd=0)
-            canvas.pack(fill="x")
+        def redraw(event=None):
+            draw_banner(canvas, event.width if event else canvas.winfo_width())
 
-            def draw(event=None):
-                width = event.width if event else 820
-                y = min(0, (height - banner.height()) // 2)
-                canvas.delete("all")
-                canvas.create_rectangle(0, 0, width, height, fill=palette["bg"], outline="")
-                canvas.create_image(0, y, anchor="nw", image=banner)
-
-            canvas.bind("<Configure>", draw)
-            draw()
-            self._ps2_theme_banner = canvas
-        else:
-            gui.ttk.Label(frame, text="PS2 Servers", font=("", 22, "bold")).pack(anchor="w")
-
-        accent = asset_photo(self, "ACCENT", max_width=780, max_height=36)
-        if accent:
-            gui.tk.Label(frame, image=accent, bg=palette["bg"], bd=0,
-                         highlightthickness=0).pack(anchor="w", pady=(4, 0))
+        canvas.bind("<Configure>", redraw)
+        canvas.after_idle(redraw)
+        self._ps2_theme_banner = canvas
 
     def add_admin_panel(self):
         if not gui.windows_setup.is_windows():
@@ -260,15 +287,17 @@ def _apply_gui_review_fixes(gui):
         status_text = "Administrator: Yes" if is_admin else "Administrator: No"
         gui.ttk.Label(frame, text=status_text, style=status_style,
                       font=("", 9, "bold")).grid(row=0, column=0, sticky="w",
-                                                 padx=(0, 12))
-        gui.ttk.Label(frame,
-                      text="Normal launch stays non-admin. Elevate only for firewall changes or advanced port 445.",
-                      style="Admin.TLabel", wraplength=560).grid(
-                          row=0, column=1, sticky="w")
+                                                 padx=(0, 12), pady=(0, 4))
+        note = gui.ttk.Label(
+            frame,
+            text="Normal launch stays non-admin. Elevate only for firewall changes or advanced port 445.",
+            style="Admin.TLabel")
+        note.grid(row=0, column=1, sticky="ew", pady=(0, 4))
+        bind_wrap(note, offset=360)
         button = gui.ttk.Button(frame, text="Restart as administrator",
                                 style="Accent.TButton",
                                 command=lambda: restart_as_admin(self))
-        button.grid(row=0, column=2, sticky="e", padx=(12, 0))
+        button.grid(row=0, column=2, sticky="e", padx=(12, 0), pady=(0, 4))
         if is_admin or not gui.elevate.can_elevate():
             button.config(state="disabled")
         self._ps2_admin_frame = frame
@@ -298,16 +327,6 @@ def _apply_gui_review_fixes(gui):
         else:
             gui.messagebox.showerror("Elevation failed", "Could not restart as administrator.")
 
-    def wrapped_text(*args, **kwargs):
-        if kwargs.get("wrap") == "none":
-            kwargs["wrap"] = "char"
-        kwargs.setdefault("background", palette["entry"])
-        kwargs.setdefault("foreground", palette["text"])
-        kwargs.setdefault("insertbackground", palette["text"])
-        kwargs.setdefault("selectbackground", palette["accent"])
-        kwargs.setdefault("selectforeground", "#ffffff")
-        return original_text(*args, **kwargs)
-
     class StyledNotebook(original_notebook):
         def __init__(self, *args, **kwargs):
             kwargs.setdefault("style", "Server.TNotebook")
@@ -320,11 +339,35 @@ def _apply_gui_review_fixes(gui):
             kwargs.setdefault("padding", (8, 8))
             return super().add(child, **kwargs)
 
+    def normalize_original_widgets(self):
+        try:
+            self.nb.pack_configure(fill="both", expand=True)
+        except (gui.tk.TclError, AttributeError):
+            pass
+
+        for card in getattr(self, "cards", {}).values():
+            for child in card.winfo_children():
+                if getattr(child, "winfo_class", lambda: "")() == "TLabel":
+                    text = str(child.cget("text"))
+                    if text:
+                        bind_wrap(child, offset=96)
+
+        parent = content_parent(self)
+        for child in parent.winfo_children():
+            try:
+                style = child.cget("style")
+            except gui.tk.TclError:
+                style = ""
+            if style == "Footer.TFrame":
+                for index in range(6):
+                    child.columnconfigure(index, weight=0)
+                child.columnconfigure(2, weight=1)
+
     def launcher_build(self):
-        install_background(self)
         build_banner(self)
         add_admin_panel(self)
         original_build(self)
+        normalize_original_widgets(self)
 
     def launcher_init(self, root):
         apply_theme(root)
@@ -343,8 +386,9 @@ def _apply_gui_review_fixes(gui):
             widget.see("end")
         widget.config(state="disabled")
 
-    gui.tk.Text = wrapped_text
     gui.ttk.Notebook = StyledNotebook
+    gui.LauncherApp._configure_window = configure_window
+    gui.LauncherApp._build_scroll_body = build_scroll_body
     gui.LauncherApp._build = launcher_build
     gui.LauncherApp.__init__ = launcher_init
     gui.LauncherApp._append_log = append_log


### PR DESCRIPTION
## Summary
- Make the launcher window responsive instead of hard-fixed to 1024px.
- Make the scroll canvas follow the actual window width.
- Replace the clipped image banner path with a procedural responsive PS2-style banner.
- Keep the admin panel, PS2 dark palette, notebook styling, and safer terminal log behavior.

## Verification
- Syntax checked locally before commit.
- Compare shows this branch only changes `launcher/main.py`.

Manual Windows GUI smoke testing is recommended before merge.