### PR TITLE
build,ci: batch all 8 Dependabot bumps (one validated release)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -37,11 +37,11 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
         if: matrix.macos_arch != 'x86_64'
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -137,7 +137,7 @@ jobs:
           subject-path: ${{ matrix.asset_name }}
 
       - name: Upload release asset artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.asset_name }}
           path: ${{ matrix.asset_name }}
@@ -188,7 +188,7 @@ jobs:
       - name: Upload folder release asset artifact
         if: matrix.folder_asset != ''
         continue-on-error: true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.folder_asset }}
           path: ${{ matrix.folder_asset }}
@@ -200,7 +200,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Create portable source zip
         shell: bash
@@ -213,7 +213,7 @@ jobs:
           subject-path: PS2Servers-source.zip
 
       - name: Upload source artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: PS2Servers-source.zip
           path: PS2Servers-source.zip
@@ -228,10 +228,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download release asset artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: release-assets
           merge-multiple: true
@@ -267,7 +267,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: PS2 Servers ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,12 @@ jobs:
             asset: PS2Servers-macos-x64.zip
             macos_arch: x86_64
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Most jobs use setup-python. The macOS x86_64 cross-build instead needs a
       # universal2 interpreter (with universal Tcl/Tk) and must execute Python as
       # x86_64 so compiled dependencies like lz4 match the Intel artifact.
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         if: matrix.macos_arch != 'x86_64'
         with:
           python-version: "3.12"
@@ -248,7 +248,7 @@ jobs:
           subject-path: out/${{ matrix.folder_asset }}
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.asset }}
           path: |
@@ -258,7 +258,7 @@ jobs:
       - name: Upload folder build artifact
         if: matrix.folder_asset != ''
         continue-on-error: true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.folder_asset }}
           path: |
@@ -267,7 +267,7 @@ jobs:
 
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           name: PS2 Servers ${{ github.ref_name }}
           body_path: out/release-notes.md
@@ -278,7 +278,7 @@ jobs:
       - name: Attach folder build to release
         if: startsWith(github.ref, 'refs/tags/') && matrix.folder_asset != ''
         continue-on-error: true
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           name: PS2 Servers ${{ github.ref_name }}
           body_path: out/release-notes.md

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,7 +1,7 @@
 # Build-only dependencies for packaged release artifacts.
 # Pinned to avoid unbounded dependency drift in GitHub Actions release builds.
 
-Nuitka==2.7.12
+Nuitka==4.1.3
 ordered-set==4.1.0
-zstandard==0.23.0
-lz4==4.4.4
+zstandard==0.25.0
+lz4==4.4.5


### PR DESCRIPTION
Consolidates Dependabot PRs #48–#55 into one change so they ship as a single release (not eight) and the upload/download-artifact majors move together.

**pip:** Nuitka 2.7.12→4.1.3, zstandard 0.23.0→0.25.0, lz4 4.4.4→4.4.5
**actions (SHA-pinned):** checkout v4→v7.0.0, setup-python v5→v6.3.0, upload-artifact v4→v7.0.1, download-artifact v4→v8.0.1, action-gh-release v2→v3.0.1

Validated with a no-publish `release.yml` workflow_dispatch build before merge. Supersedes #48, #49, #50, #51, #52, #53, #54, #55.