### PR TITLE
Change default SMB port to 1111; discourage ports below 1033

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -288,7 +288,7 @@ jobs:
 
             PS2 Servers is an open-source PS2 homebrew utility for user-controlled local server setup. It runs local LAN servers for Open PS2 Loader:
 
-            - SMBv1/RiptOPL: built-in SMB/CIFS subset, normally TCP port `1445`.
+            - SMBv1/RiptOPL: built-in SMB/CIFS subset, normally TCP port `1111` (below 1033 discouraged).
             - UDPFS: UDP file/block serving, normally UDP port `0xF5F6`.
             - UDPBD: UDP block-device serving, normally UDP port `0xBDBD`.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
 
           PS2 Servers is an open-source PS2 homebrew utility for user-controlled local server setup. It runs local LAN servers for Open PS2 Loader:
 
-          - SMBv1/RiptOPL: built-in SMB/CIFS subset, normally TCP port \`1445\`.
+          - SMBv1/RiptOPL: built-in SMB/CIFS subset, normally TCP port \`1111\` (below 1033 discouraged).
           - UDPFS: UDP file/block serving, normally UDP port \`0xF5F6\`.
           - UDPBD: UDP block-device serving, normally UDP port \`0xBDBD\`.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ antivirus products may flag the packaged Windows EXE heuristically.
 
 The SMBv1/RiptOPL server does **not** enable Windows' built-in SMB1 optional
 feature tree. It speaks the OPL-compatible SMB1/CIFS subset itself and normally
-listens on custom TCP port `1445`; OPL connects to this program directly.
+listens on custom TCP port `1111`; OPL connects to this program directly. (Avoid
+ports below 1033 — Windows can reserve or block low ports.)
 
 Windows setup is intentionally narrow:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,7 +42,8 @@ The SMBv1/RiptOPL server does **not** enable or depend on Windows' built-in SMB1
 optional feature tree.
 
 Normal SMB mode uses PS2 Servers' own small SMB/CIFS implementation and listens
-on a custom TCP port, normally `1445`. OPL connects to this program directly.
+on a custom TCP port, by default `1111` (ports below 1033 are discouraged, as
+Windows can reserve or block low ports). OPL connects to this program directly.
 Windows file sharing does not need to expose SMB1.
 
 The advanced "Take port 445" option is different:

--- a/docs/antivirus-transparency.md
+++ b/docs/antivirus-transparency.md
@@ -61,7 +61,7 @@ the folder. macOS already ships as a standalone `.app`.
 PS2 Servers only exposes local server behavior that the user chooses from the
 GUI:
 
-- SMBv1/RiptOPL: built-in SMB/CIFS subset, normally TCP port 1445.
+- SMBv1/RiptOPL: built-in SMB/CIFS subset, normally TCP port 1111. (Ports below 1033 are discouraged — Windows can reserve or block low ports.)
 - UDPFS: UDP file/block serving, normally UDP port 0xF5F6.
 - UDPBD: UDP block-device serving, normally UDP port 0xBDBD.
 

--- a/docs/falsepositives.html
+++ b/docs/falsepositives.html
@@ -514,7 +514,7 @@
       </p>
 
       <ul class="checks">
-        <li><strong>SMBv1/RiptOPL:</strong> local SMB/CIFS-compatible server, normally TCP 1445.</li>
+        <li><strong>SMBv1/RiptOPL:</strong> local SMB/CIFS-compatible server, normally TCP 1111 (ports below 1033 discouraged).</li>
         <li><strong>UDPFS:</strong> local UDP file/block serving, normally UDP 0xF5F6.</li>
         <li><strong>UDPBD:</strong> local UDP block-device serving, normally UDP 0xBDBD.</li>
         <li><strong>Firewall helper:</strong> optional Windows Firewall allow rules after user action.</li>

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -47,7 +47,7 @@ What it runs
 
 How SMB mode works
 
-Normal SMB mode listens on a custom TCP port, usually 1445. OPL connects directly to PS2 Servers at that port and share name. PS2 Servers speaks the small SMB/CIFS subset that OPL expects.
+Normal SMB mode listens on a custom TCP port, by default 1111. OPL connects directly to PS2 Servers at that port and share name. PS2 Servers speaks the small SMB/CIFS subset that OPL expects. Avoid ports below 1033 -- Windows can reserve or block low ports.
 
 That means normal SMB mode does not need Windows File Sharing, does not need Windows SMB1 enabled, and does not expose your normal Windows shares through SMB1.
 
@@ -110,7 +110,7 @@ TAB_TITLES = {
 
 def opl_hint(key, ip, values):
     if key == "smbv1":
-        port = "445" if values.get("take_445") else str(values.get("port") or 1445)
+        port = "445" if values.get("take_445") else str(values.get("port") or 1111)
         return ("In OPL → Network:  IP {}  ·  Port {}  ·  Share 'games'  "
                 "·  NetBIOS off  ·  user/pass blank".format(ip, port))
     if key == "udpfs":

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -184,15 +184,16 @@ SMBV1 = ServerDef(
     blurb="Share a games folder over SMB. Works even on Windows 11 where the OS "
     "removed SMB1.",
     runtime="python",
-    default_port=1445,
+    default_port=1111,
     share_hint="games",
     module_file=_repo("smbv1_server", "smbserver_opl.py"),
     module_dir=_repo("smbv1_server"),
     fields=[
         Field("games_folder", "Games folder", "folder", required=True,
               help="Folder of PS2 games/apps to share."),
-        Field("port", "Port", "port", default=1445, advanced=True,
-              help="TCP port (default 1445)."),
+        Field("port", "Port", "port", default=1111, advanced=True,
+              help="TCP port (default 1111). Avoid ports below 1033 -- Windows can "
+              "reserve or block low ports."),
         Field("read_only", "Read-only", "bool", default=False, advanced=True,
               help="No saves / no VMC writes."),
         Field("take_445", "Take port 445 (admin)", "bool", default=False, advanced=True,

--- a/launcher/windows_setup.py
+++ b/launcher/windows_setup.py
@@ -109,7 +109,7 @@ def _parse_port(value, default):
 def _server_ports(key, values):
     """Return [(protocol, port, purpose), ...] for fixed inbound ports."""
     if key == "smbv1":
-        port = 445 if values.get("take_445") else _parse_port(values.get("port"), 1445)
+        port = 445 if values.get("take_445") else _parse_port(values.get("port"), 1111)
         return [("TCP", port, "SMBv1")]
     if key == "udpfs":
         return [("UDP", _parse_port(values.get("port"), 0xF5F6), "UDPFS discovery")]

--- a/smbv1_server/README.md
+++ b/smbv1_server/README.md
@@ -40,8 +40,8 @@ python smbserver_opl.py --share games=D:/PS2Games
 It prints something like:
 
 ```
- RiptOPL SMBv1 server -- listening on 0.0.0.0:1445
- In OPL  ->  SMB Server IP: 192.168.1.50   Port: 1445   user/pass: blank (guest)
+ RiptOPL SMBv1 server -- listening on 0.0.0.0:1111
+ In OPL  ->  SMB Server IP: 192.168.1.50   Port: 1111   user/pass: blank (guest)
             Share: games   ->   D:\PS2Games   (writable)
  (writable -- OPL can save settings + VMC-on-SMB here; pass --read-only to lock it)
 ```
@@ -52,7 +52,7 @@ Then in OPL → **Settings → Network**:
 |------------------|----------------------------------------|
 | Address type     | **IP address** (turn NetBIOS *off*)    |
 | PC IP Address    | the LAN IP the server printed          |
-| **Port**         | **1445** (the printed port)            |
+| **Port**         | **1111** (the printed port)            |
 | Share            | `games`                                |
 | User / Password  | **blank** (guest)                      |
 
@@ -62,7 +62,8 @@ Save, and your network games should populate from the share.
 
 ```
 --share NAME=PATH   a share to export (repeatable), e.g. --share apps=E:/PS2Apps
---port N            TCP port (default 1445). If it's taken, the server walks forward
+--port N            TCP port (default 1111; avoid ports below 1033, which Windows can
+                    reserve/block). If it's taken, the server walks forward
                     and prints the real one — just match OPL's Port field to it.
 --bind ADDR         interface to bind (default 0.0.0.0 = all)
 --read-only         serve the share read-only (no saves / no VMC writes); default is writable
@@ -86,7 +87,7 @@ makes the server sit on the standard port 445. Windows still holds 445 via its o
 sharing) while the server runs, and **restarts it on exit**. It needs an **Administrator** shell.
 
 It only *stops* the service (never disables it), so even a hard kill self-heals on the next
-reboot. Still — the plain `--port 1445` default is simpler and touches nothing; prefer it unless
+reboot. Still — the plain `--port 1111` default is simpler and touches nothing; prefer it unless
 you specifically need 445.
 
 ## Status / testing

--- a/smbv1_server/Start-SMB-Server.bat
+++ b/smbv1_server/Start-SMB-Server.bat
@@ -17,7 +17,7 @@ REM    --take-445     use the standard port 445 (admin; pauses Windows file shar
 REM    add a 2nd share:  --share apps="E:\PS2Apps"
 REM ============================================================================
 set "GAMES=D:\PS2Games"
-set "PORT=1445"
+set "PORT=1111"
 REM ============================================================================
 
 REM A folder dragged onto this .bat overrides the GAMES setting above.

--- a/smbv1_server/smbserver_opl.py
+++ b/smbv1_server/smbserver_opl.py
@@ -883,6 +883,9 @@ def main(argv=None):
     if args.take_445:
         port = 445
         restore = _take_445()
+    elif port < 1 or port > 65535:
+        print("ERROR: port %d is out of the valid range (1-65535)." % port, file=sys.stderr)
+        return 2
     elif port < 1033:
         # Low ports overlap well-known/privileged ports and Windows reserved /
         # excluded port ranges, which frequently block the bind. (--take-445

--- a/smbv1_server/smbserver_opl.py
+++ b/smbv1_server/smbserver_opl.py
@@ -10,7 +10,7 @@
 # authored from MS-CIFS and Open-PS2-Loader's own cdvdman/smb.h -- no third-party code copied.
 #
 #   python smbserver_opl.py --share games=D:/PS2Games
-#   then in OPL: SMB IP = this PC's LAN IP, SMB Port = 1445 (the printed port), Share = games,
+#   then in OPL: SMB IP = this PC's LAN IP, SMB Port = 1111 (the printed port), Share = games,
 #   user/pass blank (guest). Read-only by default; pass --writable for VMC-on-SMB.
 #
 # License: same as the surrounding RiptOPL project.
@@ -853,8 +853,9 @@ def main(argv=None):
         description="Minimal SMBv1 server for Open-PS2-Loader (guest auth, custom port).")
     ap.add_argument("--share", action="append", default=[], metavar="NAME=PATH",
                     help="a share, e.g. --share games=D:/PS2Games (repeatable)")
-    ap.add_argument("--port", type=int, default=1445,
-                    help="TCP port (default 1445; set OPL's SMB Port to match)")
+    ap.add_argument("--port", type=int, default=1111,
+                    help="TCP port (default 1111; set OPL's SMB Port to match). "
+                         "Avoid ports below 1033 -- Windows can reserve/block them.")
     ap.add_argument("--bind", default="0.0.0.0", help="bind address (default all interfaces)")
     ap.add_argument("--read-only", action="store_true",
                     help="serve the share read-only (no saves / no VMC writes); default is writable")
@@ -882,6 +883,13 @@ def main(argv=None):
     if args.take_445:
         port = 445
         restore = _take_445()
+    elif port < 1033:
+        # Low ports overlap well-known/privileged ports and Windows reserved /
+        # excluded port ranges, which frequently block the bind. (--take-445
+        # deliberately uses 445 and is handled above.)
+        print(" WARNING: port %d is below 1033. Windows can reserve or block low "
+              "ports; if the bind fails or OPL cannot connect, use a higher port "
+              "such as the default 1111." % port)
 
     # Bind; if the chosen port is taken/reserved, walk forward and report the real one.
     lsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/tools/check_release_compliance.py
+++ b/tools/check_release_compliance.py
@@ -103,7 +103,7 @@ def main():
         "Windows executable: PS2Servers.exe",
         "Windows release package: PS2Servers-windows-x64.zip",
         "SMBv1/RiptOPL",
-        "TCP port 1445",
+        "TCP port 1111",
         "UDP port 0xF5F6",
         "UDP port 0xBDBD",
         "does not enable Windows SMB1",


### PR DESCRIPTION
## What
- **Default SMB (SMBv1/RiptOPL) port: 1445 → 1111.**
- **Discourage ports below 1033:** the server prints a runtime warning when a port < 1033 is chosen, and the GUI/CLI help + docs steer users to 1033+. Low ports overlap well-known/privileged ports and Windows reserved/excluded ranges, which often block the bind. `--take-445` (the deliberate 445 mode) is unaffected.

## Where
Functional: `launcher/servers.py` (default + field help), `launcher/windows_setup.py` (firewall fallback), `launcher/gui.py` (hint), `smbv1_server/smbserver_opl.py` (argparse default + sub-1033 warning), `Start-SMB-Server.bat`.
Docs/CI: README, SECURITY, antivirus-transparency.md, falsepositives.html, smbv1 README, both release workflows, and the compliance-checker needle (`TCP port 1445` → `TCP port 1111`, kept in lockstep).

## Verified
compileall · check_release_compliance.py (passes with the updated needle) · udpbd selftest · runtime check that the default is 1111 and the sub-1033 warning fires.

Note: existing users with a saved port keep it; this only changes the default for new setups (and they'll set OPL's SMB Port to whatever the launcher displays).