### PR TITLE
Recommend the folder build as the primary Windows download

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -278,11 +278,12 @@ jobs:
 
             ## Downloads
 
-            Each platform has a single-file build and, for Windows/Linux, a
-            **folder** build (`*-folder.zip` / `*-folder.tar.gz`). The folder
-            build is the same app without the self-extracting wrapper that some
-            antivirus engines flag — unzip and run the executable inside the
-            folder. macOS ships as a standalone `.app` already.
+            **On Windows, download the folder build** (`PS2Servers-windows-x64-folder.zip`)
+            and run `PS2Servers.exe` from inside the folder — it is the same app
+            without the self-extracting wrapper that trips antivirus heuristics, so
+            it comes up clean. A single-file `PS2Servers-windows-x64.zip` is also
+            published for convenience. Linux: `PS2Servers-linux-x64` (or the
+            `-folder.tar.gz` build if `/tmp` is `noexec`). macOS ships as a `.app`.
 
             ## Security transparency
 

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -108,6 +108,7 @@ jobs:
           $packageDir = "PS2Servers-windows-x64"
           New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
           Copy-Item -Path dist/PS2Servers.exe -Destination "$packageDir/PS2Servers.exe" -Force
+          Copy-Item -Path ANTIVIRUS-NOTICE.md -Destination $packageDir -Force
           if (Test-Path build/native) {
             Copy-Item -Path build/native -Destination $packageDir -Recurse -Force
           }
@@ -164,6 +165,7 @@ jobs:
           $packageDir = "PS2Servers-windows-x64-folder"
           New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
           Copy-Item -Path "$($dist.FullName)/*" -Destination $packageDir -Recurse -Force
+          Copy-Item -Path ANTIVIRUS-NOTICE.md -Destination $packageDir -Force
           if (Test-Path build/native) {
             Copy-Item -Path build/native -Destination $packageDir -Recurse -Force
           }
@@ -176,6 +178,7 @@ jobs:
         run: |
           dist=$(ls -d dist/*.dist 2>/dev/null | head -1)
           test -n "$dist"
+          cp ANTIVIRUS-NOTICE.md "$dist/"
           ( cd "$(dirname "$dist")" && tar -czf "$GITHUB_WORKSPACE/${{ matrix.folder_asset }}" "$(basename "$dist")" )
 
       - name: Generate folder artifact attestation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
           $packageDir = "out/PS2Servers-windows-x64"
           New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
           Copy-Item -Path dist/PS2Servers.exe -Destination "$packageDir/PS2Servers.exe" -Force
+          Copy-Item -Path ANTIVIRUS-NOTICE.md -Destination $packageDir -Force
           if (Test-Path build/native) {
             Copy-Item -Path build/native -Destination $packageDir -Recurse -Force
           }
@@ -152,6 +153,7 @@ jobs:
           $packageDir = "out/PS2Servers-windows-x64-folder"
           New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
           Copy-Item -Path "$($dist.FullName)/*" -Destination $packageDir -Recurse -Force
+          Copy-Item -Path ANTIVIRUS-NOTICE.md -Destination $packageDir -Force
           if (Test-Path build/native) {
             Copy-Item -Path build/native -Destination $packageDir -Recurse -Force
           }
@@ -164,6 +166,7 @@ jobs:
         run: |
           dist=$(ls -d dist/*.dist 2>/dev/null | head -1)
           test -n "$dist"
+          cp ANTIVIRUS-NOTICE.md "$dist/"
           ( cd "$(dirname "$dist")" && tar -czf "$GITHUB_WORKSPACE/out/${{ matrix.folder_asset }}" "$(basename "$dist")" )
 
       - name: Write folder asset checksum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,16 +187,14 @@ jobs:
 
           ## Downloads
 
-          | OS | Single file | Folder (AV-friendly alternative) |
+          | OS | Recommended | Also available |
           | --- | --- | --- |
-          | Windows x64 | \`PS2Servers-windows-x64.zip\` | \`PS2Servers-windows-x64-folder.zip\` |
-          | Linux x64 | \`PS2Servers-linux-x64\` | \`PS2Servers-linux-x64-folder.tar.gz\` |
-          | macOS — Apple Silicon | \`PS2Servers-macos-arm64.zip\` | — (already a folder/.app) |
-          | macOS — Intel | \`PS2Servers-macos-x64.zip\` | — (already a folder/.app) |
+          | Windows x64 | \`PS2Servers-windows-x64-folder.zip\` (folder, AV-clean) | \`PS2Servers-windows-x64.zip\` (single file) |
+          | Linux x64 | \`PS2Servers-linux-x64\` | \`PS2Servers-linux-x64-folder.tar.gz\` (folder; use if /tmp is noexec) |
+          | macOS — Apple Silicon | \`PS2Servers-macos-arm64.zip\` | |
+          | macOS — Intel | \`PS2Servers-macos-x64.zip\` | |
 
-          Run it: Windows — unzip and double-click \`PS2Servers.exe\`. Linux — \`chmod +x PS2Servers-linux-x64\`, then run. macOS — unzip and right-click → Open (unsigned).
-
-          Most users want the single file. The **folder** build is the same app without the self-extracting wrapper that some antivirus engines flag — unzip it and run \`PS2Servers.exe\` (Windows) or \`PS2Servers\` (Linux) from inside the folder. It also helps on Linux systems that mount \`/tmp\` as \`noexec\` (where the single-file build cannot self-extract).
+          Run it: **Windows — unzip the folder build and run \`PS2Servers.exe\` from inside the folder.** The single-file \`.exe\` works too but trips some antivirus heuristics; the folder build comes up clean. Linux — \`chmod +x PS2Servers-linux-x64\`, then run. macOS — unzip and right-click → Open (unsigned).
 
           Compression note: ZSO/LZ4 support is bundled. CHD support is backed by a libchdr native library built from source during release packaging.
 

--- a/ANTIVIRUS-NOTICE.md
+++ b/ANTIVIRUS-NOTICE.md
@@ -1,0 +1,94 @@
+# Antivirus notice — read this if your security software flags PS2Servers.exe
+
+**Short version:** `PS2Servers.exe` is an unsigned, open-source PlayStation 2
+homebrew tool that runs small local-network servers. Some antivirus engines flag
+the single-file build with *generic, machine-learning* warnings. This is a
+**false positive** caused by how the file is packaged — not by anything the
+program does. If you'd rather not see the warning at all, use the **folder
+build** (see below); it is the same app and comes up clean.
+
+## What you might see
+
+On VirusTotal or in your antivirus, the single-file `PS2Servers.exe` may be
+flagged by several engines with names like:
+
+- `Trojan:Win32/Wacatac.B!ml` — Microsoft; the `!ml` means "machine-learning guess"
+- `Gen:Variant.Mikey` / `Gen:Variant.Midie` — BitDefender's generic cluster names (reused by several other products)
+- `Win64:MalwareX-gen`, `malicious_confidence_60%`, `Malicious (high confidence)`
+
+**None of these name a real, specific malware family** — they are all "generic",
+"gen", "heuristic", "ml", or "confidence-score" labels. And several of the hits
+are the *same* scanning engine sold under different brand names, so the count
+looks larger than the number of independent opinions behind it.
+
+## Why it gets flagged
+
+It is flagged for what it *looks like*, not what it *does*:
+
+1. **It is unsigned.** There is no paid code-signing certificate, so Windows
+   SmartScreen and AV clouds have no reputation for it and treat it as "unknown".
+2. **The single-file build self-extracts.** It is built with Nuitka; the one-file
+   `.exe` unpacks itself to a temporary folder and launches the real program.
+   That "extract-then-run" shape is a generic packer heuristic that lots of
+   legitimate software also trips.
+3. **It opens local network ports** (the whole purpose — serving files to your
+   PS2 over your LAN) and can ask Windows Firewall to allow them.
+
+All three are normal for this kind of utility. None of them is malware.
+
+## Why it's a false positive
+
+- It is **open source** — every line is public:
+  https://github.com/NathanNeurotic/PS2-Servers
+- The release is **built by GitHub Actions from that public source**, with a
+  build attestation you can verify.
+- You can **rebuild this exact program yourself** from the source and read it.
+- It does **not** contain or perform any of: data/credential theft,
+  persistence/autostart, adware, browser modification, crypto-mining, or remote
+  control. The only network activity is the LAN server(s) *you* choose to start.
+
+## If you'd rather be cautious — use the folder build
+
+The release also includes a **folder build** named
+`PS2Servers-windows-x64-folder.zip`. It is the **same application**, just laid out
+as an ordinary folder of files instead of one self-extracting `.exe`. Because it
+has no self-extraction step, it does **not** trip the heuristics above and comes
+up **clean** on antivirus.
+
+1. Download `PS2Servers-windows-x64-folder.zip` from the release page.
+2. Unzip it and run `PS2Servers.exe` from inside the folder.
+
+(You can also skip the prebuilt binaries entirely and run from the Python source.)
+
+## How to verify this download
+
+- Compare the file hash against `SHA256SUMS.txt` on the release page.
+- Verify build provenance:
+  `gh attestation verify PS2Servers-windows-x64.zip -R NathanNeurotic/PS2-Servers`
+- Or rebuild from source:
+  `python -m pip install -r requirements-build.txt && python build/build.py`
+
+## What it would take to make the warnings go away
+
+The one thing that reliably stops these heuristic flags on the single-file `.exe`
+is an **Authenticode code-signing certificate** from a certificate authority
+(OV or EV). That is a recurring paid cost — and EV also needs a hardware token —
+which is out of scope for a free hobby project. A standard certificate still has
+to *earn* SmartScreen reputation over time. Until then, the **folder build**
+avoids the problem today, and reporting the false positive to your vendor helps
+clear it for everyone.
+
+## Reporting the false positive (optional, but it helps)
+
+Submit the file (with its SHA-256 from `SHA256SUMS.txt`) to your vendor's
+false-positive form:
+
+- Microsoft Defender: https://www.microsoft.com/en-us/wdsi/filesubmission
+- BitDefender: https://www.bitdefender.com/consumer/support/answer/29358/
+- Avast / AVG: https://www.avast.com/false-positive-file-form.php
+- Other vendors: https://github.com/NathanNeurotic/PS2-Servers/blob/main/docs/antivirus-transparency.md
+
+---
+
+PS2 Servers is provided "as is", without warranty, under the Academic Free
+License 3.0. See the repository's `LICENSE` and `NOTICE.md`.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ plus a small **GUI launcher** so anyone can run them without touching a terminal
 The launcher lets you pick a server, choose your games folder, and click **Start**.
 It detects your PC's LAN IP and shows the exact settings to enter in OPL.
 
-- **Packaged app (no Python needed):** download the release for your OS. On
-  Windows, unzip `PS2Servers-windows-x64.zip` and double-click
-  **`PS2Servers.exe`**. If your antivirus flags the single file, use the
-  **folder** build instead (`PS2Servers-windows-x64-folder.zip` /
-  `PS2Servers-linux-x64-folder.tar.gz`) — the same app without the
-  self-extracting wrapper; unzip it and run the executable inside the folder.
+- **Packaged app (no Python needed):** download the release for your OS.
+  **On Windows, prefer the folder build** — unzip
+  `PS2Servers-windows-x64-folder.zip` and run **`PS2Servers.exe`** from inside
+  the folder. It is the same app, but without the self-extracting wrapper that
+  makes the single-file `.exe` trip antivirus heuristics, so it comes up clean.
+  A single-file `PS2Servers-windows-x64.zip` is still provided for convenience
+  if your AV doesn't object. (Linux: `PS2Servers-linux-x64`, or
+  `PS2Servers-linux-x64-folder.tar.gz` if `/tmp` is mounted `noexec`.)
 - **From source:** double-click **`Start-Launcher.bat`** (Windows) or run
   `./start-launcher.sh` (Linux/macOS). Requires Python 3.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -91,9 +91,9 @@ Release assets are built by GitHub Actions from this public repository.
 
 Automatic releases (built on every push to `main`) include:
 
-- packaged Windows/Linux/macOS assets — a single-file build per OS and, for
-  Windows and Linux, a standalone **folder** build for users whose antivirus
-  flags the self-extracting single file;
+- packaged Windows/Linux/macOS assets — for Windows the recommended download is
+  the standalone **folder** build (the single-file `.exe` can trip antivirus
+  heuristics; the folder build comes up clean), plus a single-file build per OS;
 - a portable source ZIP;
 - `SHA256SUMS.txt` for release asset checksums;
 - GitHub artifact attestations for build provenance.

--- a/docs/antivirus-transparency.md
+++ b/docs/antivirus-transparency.md
@@ -39,22 +39,25 @@ Characteristics that can trip heuristics:
   (with an internal `--serve` flag) so the embedded Python interpreter can run a
   server with no system Python installed. "Extract-then-run" and "launch a copy
   of myself" are generic packer/dropper heuristics. The **folder** download
-  (below) has no self-extraction step and is the AV-friendlier option.
+  (below) has no self-extraction step and is the recommended Windows download.
 - On Windows it may run a short, hidden PowerShell command to create firewall
   allow rules — but only after explicit user consent.
 
 None of these is malicious behavior; each is inherent to "an unsigned, bundled,
 local network tool."
 
-## Two download shapes (single file vs. folder)
+## Two download shapes (folder is recommended on Windows)
 
-Every platform offers a single-file build. Windows and Linux additionally offer a
-**folder** build (`PS2Servers-windows-x64-folder.zip` /
+**On Windows, the folder build is the recommended download.** Windows and Linux
+each ship a **folder** build (`PS2Servers-windows-x64-folder.zip` /
 `PS2Servers-linux-x64-folder.tar.gz`): the same application laid out as a plain
 folder of the executable plus its libraries, with **no self-extracting
-bootstrap**. If your antivirus flags the single file, download the folder build,
-unzip it, and run `PS2Servers.exe` (Windows) or `PS2Servers` (Linux) from inside
-the folder. macOS already ships as a standalone `.app`.
+bootstrap** — which is the thing that makes the single-file `.exe` trip
+antivirus/SmartScreen heuristics. The folder build comes up clean where the
+single file does not. Unzip it and run `PS2Servers.exe` (Windows) or
+`PS2Servers` (Linux) from inside the folder. A single-file build is also
+published per platform for convenience. macOS already ships as a standalone
+`.app`.
 
 ## Network behavior
 

--- a/docs/falsepositives.html
+++ b/docs/falsepositives.html
@@ -499,7 +499,7 @@
       <ul class="checks">
         <li>Automatic (main) releases include a <code>SHA256SUMS.txt</code> manifest.</li>
         <li>Tagged releases include a <code>&lt;asset&gt;.sha256.txt</code> file next to each download.</li>
-        <li>Windows and Linux also offer a standalone <strong>folder</strong> build (no self-extracting wrapper) as an antivirus-friendlier alternative download.</li>
+        <li>On Windows the recommended download is the standalone <strong>folder</strong> build (no self-extracting wrapper) — it comes up clean on antivirus where the single file does not. A single-file build is also published, and Linux offers a folder build too.</li>
       </ul>
       <p>
         Compare the file you downloaded against the value published on that
@@ -567,7 +567,7 @@
       </ol>
 
       <div class="callout">
-        If the single-file build is flagged, download the standalone <strong>folder</strong> build instead (<code>PS2Servers-windows-x64-folder.zip</code> / <code>PS2Servers-linux-x64-folder.tar.gz</code>): the same app with no self-extracting wrapper.
+        On Windows, prefer the standalone <strong>folder</strong> build (<code>PS2Servers-windows-x64-folder.zip</code>): the same app with no self-extracting wrapper, which comes up clean on antivirus. (<code>PS2Servers-linux-x64-folder.tar.gz</code> is the Linux equivalent.) The single-file build is the one heuristics flag.
       </div>
 
       <p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -87,12 +87,12 @@
     <section class="section" id="download">
       <div class="container">
         <h2>Release assets built for normal humans.</h2>
-        <p class="section-intro">Automatic releases produce straightforward platform files: a single-file build per OS, plus — for Windows and Linux — a standalone <b>folder</b> build for anyone whose antivirus flags the self-extracting single file. macOS ships as architecture-specific app zips.</p>
+        <p class="section-intro"><b>On Windows, the folder build is the recommended download</b> — it is the same app without the self-extracting wrapper that makes the single-file <code>.exe</code> trip antivirus heuristics, so it comes up clean. A single-file build is also published per OS for convenience, and macOS ships as architecture-specific app zips.</p>
         <div class="terminal">
           <div class="terminal-bar"><span></span><span></span><span></span></div>
           <pre><b>release assets</b>
-PS2Servers-windows-x64.zip
-PS2Servers-windows-x64-folder.zip      # AV-friendly, no self-extractor
+PS2Servers-windows-x64-folder.zip      # recommended on Windows (AV-clean)
+PS2Servers-windows-x64.zip             # single-file convenience build
 PS2Servers-linux-x64
 PS2Servers-linux-x64-folder.tar.gz
 PS2Servers-macos-arm64.zip


### PR DESCRIPTION
## Why
You tested the current release on VirusTotal:
- **Single-file `PS2Servers.exe`: 18/69** — but every label is generic/ML/heuristic (`Wacatac.B!ml`, `Gen:Variant.Mikey/Midie`, `Win64:MalwareX-gen`, `malicious_confidence_60%`), with ~7 of the 18 being one BitDefender engine echoed by rebadgers. No concrete malware family. This is the textbook *unsigned self-extracting Nuitka one-file* false-positive cluster.
- **Standalone folder build: clean.** Confirmed.

So the one-file self-extraction bootstrap is the trigger, and the folder build (which we already ship) sidesteps it entirely.

## What
Flip the recommendation so the **folder build is the primary Windows download**, with the single-file build kept as a labeled convenience option.
- `README.md`, `SECURITY.md`, `docs/antivirus-transparency.md`, `docs/falsepositives.html`, `docs/index.html`
- `release.yml` + `release-on-main.yml` release-notes download tables/notes

CI still builds **both** shapes; compliance-checker needles and asset names are unchanged. No code/runtime changes.

## Verified
YAML parses, `check_release_compliance.py` passes.