### PR TITLE
docs: address Gemini review on #58 (Linux folder build + grammar)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -93,7 +93,8 @@ Automatic releases (built on every push to `main`) include:
 
 - packaged Windows/Linux/macOS assets — for Windows the recommended download is
   the standalone **folder** build (the single-file `.exe` can trip antivirus
-  heuristics; the folder build comes up clean), plus a single-file build per OS;
+  heuristics; the folder build comes up clean), plus a single-file build per OS
+  and a standalone **folder** build for Linux (`PS2Servers-linux-x64-folder.tar.gz`);
 - a portable source ZIP;
 - `SHA256SUMS.txt` for release asset checksums;
 - GitHub artifact attestations for build provenance.

--- a/docs/falsepositives.html
+++ b/docs/falsepositives.html
@@ -567,7 +567,7 @@
       </ol>
 
       <div class="callout">
-        On Windows, prefer the standalone <strong>folder</strong> build (<code>PS2Servers-windows-x64-folder.zip</code>): the same app with no self-extracting wrapper, which comes up clean on antivirus. (<code>PS2Servers-linux-x64-folder.tar.gz</code> is the Linux equivalent.) The single-file build is the one heuristics flag.
+        On Windows, prefer the standalone <strong>folder</strong> build (<code>PS2Servers-windows-x64-folder.zip</code>): the same app with no self-extracting wrapper, which comes up clean on antivirus. (<code>PS2Servers-linux-x64-folder.tar.gz</code> is the Linux equivalent.) The single-file build is the one flagged by heuristics.
       </div>
 
       <p>


### PR DESCRIPTION
Two follow-ups from Gemini's review of #58:

- **SECURITY.md** — the release-asset list dropped the Linux standalone folder build (`PS2Servers-linux-x64-folder.tar.gz`), which is still built and released. Restored it for consistency with README and the other docs.
- **docs/falsepositives.html** — minor grammar: "the one heuristics flag" → "the one flagged by heuristics".

Docs-only; compliance passes.