### PR TITLE
UDPFS: full udpfsd parity (multi-client + env-config/peer-timeout/metrics/64-handles) — NEEDS HARDWARE VALIDATION

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,8 @@ jobs:
       - name: Run UDPBD protocol selftest
         run: python udpbd_server/selftest.py
 
+      - name: Run UDPFS multi-client selftest
+        run: python udpfs_server/multiclient_selftest.py
+
       - name: Smoke build bundled libchdr
         run: python build/build_libchdr.py

--- a/udpfs_server/multiclient_selftest.py
+++ b/udpfs_server/multiclient_selftest.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""UDPFS multi-client self-test (no PS2 hardware needed).
+
+Runs a real UdpfsServer in-process on loopback and drives it with a minimal
+UDPFS/UDPRDMA client implemented here, asserting exact byte-equality of file
+contents read back over the wire. This is the safety net for the multi-client
+refactor:
+
+  * BASELINE      -- single client: DISCOVERY -> OPEN -> READ, byte-verified.
+  * CONCURRENCY   -- two clients read two DIFFERENT files at once; each must
+                     get its own bytes (proves per-session isolation).
+
+Run:  python udpfs_server/multiclient_selftest.py
+
+The client reuses the server module's own Header/DataHeader/MsgType packers, so
+the test speaks the exact wire format the server implements.
+"""
+
+import os
+import socket
+import struct
+import sys
+import tempfile
+import threading
+import time
+
+import udpfs_server as srv  # sys.path[0] is this dir when run as a script
+
+
+# --------------------------------------------------------------------------- #
+# Minimal in-process UDPFS/UDPRDMA client
+# --------------------------------------------------------------------------- #
+class UdpfsError(Exception):
+    pass
+
+
+class UdpfsTestClient:
+    """A tiny UDPFS client good enough to DISCOVERY / OPEN / READ a file.
+
+    Mirrors the IOP side of the handshake: per-connection tx_seq / rx_expected,
+    ACKs every data-bearing packet from the server (which doubles as the window
+    ACK the server's flow control waits for).
+    """
+
+    def __init__(self, disc_addr, timeout=5.0):
+        self.disc_addr = disc_addr           # (ip, discovery_port)
+        self.data_addr = None                # (ip, data_port), learned via INFORM
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.bind(('127.0.0.1', 0))
+        self.sock.settimeout(timeout)
+        self.tx_seq = 0
+        self.rx_expected = 0
+
+    def close(self):
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+    # -- low-level packet helpers -----------------------------------------
+    def _send_request(self, msg: bytes):
+        """Send a data-bearing request; consumes one client sequence number."""
+        hdr = srv.Header(srv.PacketType.DATA, self.tx_seq).pack()
+        dh = srv.DataHeader(
+            seq_nr_ack=(self.rx_expected - 1) & 0xFFF,
+            flags=srv.DataFlags.ACK,
+            hdr_word_count=0,
+            data_byte_count=len(msg),
+        ).pack()
+        self.sock.sendto(hdr + dh + msg, self.data_addr)
+        self.tx_seq = (self.tx_seq + 1) & 0xFFF
+
+    def _send_ack(self):
+        """Pure ACK for the last data-bearing packet we accepted (no seq spend)."""
+        hdr = srv.Header(srv.PacketType.DATA, self.tx_seq).pack()
+        dh = srv.DataHeader(
+            seq_nr_ack=(self.rx_expected - 1) & 0xFFF,
+            flags=srv.DataFlags.ACK,
+            hdr_word_count=0,
+            data_byte_count=0,
+        ).pack()
+        self.sock.sendto(hdr + dh, self.data_addr)
+
+    def _recv_data_packet(self):
+        """Return (data_header, payload) for the next DATA packet, skipping the
+        server's pure immediate-ACKs. Enforces in-order delivery (re-ACKs and
+        skips anything that isn't the expected sequence)."""
+        while True:
+            data, _addr = self.sock.recvfrom(4096)
+            if len(data) < 6:
+                continue
+            hdr = srv.Header.unpack(data)
+            if hdr.packet_type != srv.PacketType.DATA:
+                continue
+            dh = srv.DataHeader.unpack(data[2:6])
+            payload_size = dh.hdr_word_count * 4 + dh.data_byte_count
+            if payload_size == 0:
+                continue  # server's immediate/pure ACK -- nothing to accept
+            if hdr.seq_nr != self.rx_expected:
+                # duplicate/out-of-order: re-ACK what we last accepted, keep waiting
+                self._send_ack()
+                continue
+            self.rx_expected = (self.rx_expected + 1) & 0xFFF
+            return dh, data[6:6 + payload_size]
+
+    # -- protocol operations ----------------------------------------------
+    def discover(self):
+        pkt = (srv.Header(srv.PacketType.DISCOVERY, 0).pack()
+               + srv.DiscHeader(srv.UDPRDMA_SVC_UDPFS, 0).pack())
+        self.sock.sendto(pkt, self.disc_addr)
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            data, addr = self.sock.recvfrom(2048)
+            if len(data) < 6:
+                continue
+            hdr = srv.Header.unpack(data)
+            if hdr.packet_type != srv.PacketType.INFORM:
+                continue
+            disc = srv.DiscHeader.unpack(data[2:6])
+            self.data_addr = (self.disc_addr[0], disc.port)
+            return
+        raise UdpfsError("no INFORM reply to DISCOVERY")
+
+    def open(self, path, flags=0x01):
+        msg = (struct.pack('<BBHi', srv.MsgType.OPEN_REQ, 0, flags, 0)
+               + path.encode('utf-8') + b'\x00')
+        self._send_request(msg)
+        dh, payload = self._recv_data_packet()
+        self._send_ack()  # ack the OPEN_REPLY (server waits for this)
+        mt = payload[0]
+        if mt != srv.MsgType.OPEN_REPLY:
+            raise UdpfsError(f"expected OPEN_REPLY, got 0x{mt:02x}")
+        _, _, _, _, handle, mode, size, hisize = struct.unpack('<BBBBiIII', payload[:20])
+        if handle < 0:
+            raise UdpfsError(f"OPEN failed, handle={handle}")
+        return handle, (size | (hisize << 32))
+
+    def _recv_result_stream(self):
+        """Receive a RESULT_REPLY-headed multi-packet stream (shared by READ/BREAD)."""
+        result = None
+        buf = bytearray()
+        got_fin = False
+        first = True
+        while not got_fin:
+            dh, payload = self._recv_data_packet()
+            hdr_size = dh.hdr_word_count * 4
+            if first:
+                if hdr_size < 8:
+                    raise UdpfsError("first reply packet missing RESULT header")
+                mt, _, _, _, result = struct.unpack('<BBBBi', payload[:8])
+                if mt != srv.MsgType.RESULT_REPLY:
+                    raise UdpfsError(f"expected RESULT_REPLY, got 0x{mt:02x}")
+                buf += payload[hdr_size:hdr_size + dh.data_byte_count]
+                first = False
+            else:
+                buf += payload[:dh.data_byte_count]
+            self._send_ack()  # doubles as the flow-control window ACK
+            if dh.flags & srv.DataFlags.FIN:
+                got_fin = True
+        if result is None or result < 0:
+            raise UdpfsError(f"transfer failed, result={result}")
+        return result, bytes(buf)
+
+    def read(self, handle, size):
+        msg = struct.pack('<BBBBiI', srv.MsgType.READ_REQ, 0, 0, 0, handle, size)
+        self._send_request(msg)
+        result, buf = self._recv_result_stream()
+        return buf[:result]
+
+    def bread(self, sector_nr, sector_count, sector_size=512, handle=0):
+        # BREAD_REQ: msg(1) reserved(1) sector_count(2) handle(4) sec_lo(4) sec_hi(4)
+        msg = struct.pack('<BBHiII', srv.MsgType.BREAD_REQ, 0, sector_count, handle,
+                          sector_nr & 0xFFFFFFFF, (sector_nr >> 32) & 0xFFFFFFFF)
+        self._send_request(msg)
+        result, buf = self._recv_result_stream()
+        return buf[:result]
+
+    def read_file(self, path, expected_len):
+        handle, _size = self.open(path)
+        return self.read(handle, expected_len)
+
+
+# --------------------------------------------------------------------------- #
+# Test scaffolding
+# --------------------------------------------------------------------------- #
+def _free_udp_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind(('127.0.0.1', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _start_server(root_dir, disc_port, block_device=None):
+    server = srv.UdpfsServer(root_dir=root_dir, block_device=block_device,
+                             port=disc_port, bind_ip='127.0.0.1')
+    t = threading.Thread(target=server.run, daemon=True)
+    t.start()
+    time.sleep(0.4)  # let the select loop come up
+    return server
+
+
+def _make_file(root, name, nbytes, seed):
+    import random
+    rnd = random.Random(seed)
+    data = bytes(rnd.getrandbits(8) for _ in range(nbytes))
+    with open(os.path.join(root, name), 'wb') as f:
+        f.write(data)
+    return data
+
+
+def test_baseline(root, disc_port, files):
+    print("Single-client baseline:")
+    ok = True
+    for name, expected in files.items():
+        c = UdpfsTestClient(('127.0.0.1', disc_port))
+        try:
+            c.discover()
+            got = c.read_file(name, len(expected))
+        finally:
+            c.close()
+        if got == expected:
+            print(f"  READ  ok: '{name}' ({len(expected)} bytes) matches on-disk file")
+        else:
+            print(f"  READ  FAIL: '{name}' got {len(got)} bytes, expected {len(expected)}"
+                  f" (equal={got == expected})")
+            ok = False
+    print("  BASELINE PASSED" if ok else "  BASELINE FAILED")
+    return ok
+
+
+def test_concurrency(root, disc_port, files):
+    print("Two-client concurrency (session isolation):")
+    names = list(files.keys())[:2]
+    if len(names) < 2:
+        print("  SKIP: need >=2 files")
+        return True
+    results = {}
+    errors = {}
+    barrier = threading.Barrier(len(names))
+
+    def worker(name):
+        c = UdpfsTestClient(('127.0.0.1', disc_port))
+        try:
+            c.discover()
+            barrier.wait()  # line up the two READ streams to overlap
+            results[name] = c.read_file(name, len(files[name]))
+        except Exception as e:  # noqa: BLE001 - report in the assert below
+            errors[name] = e
+        finally:
+            c.close()
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in names]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    ok = True
+    if errors:
+        for n, e in errors.items():
+            print(f"  ERROR client '{n}': {type(e).__name__}: {e}")
+        ok = False
+    for n in names:
+        if results.get(n) == files[n]:
+            pass
+        else:
+            print(f"  FAIL: client '{n}' did not get its own bytes intact")
+            ok = False
+    if ok:
+        a, b = names
+        print(f"  READ  ok: '{a}' and '{b}' each received their own bytes concurrently")
+        print("  CONCURRENCY PASSED")
+    else:
+        print("  CONCURRENCY FAILED")
+    return ok
+
+
+def test_block_concurrency(disc_port, image_bytes, sector_size=512):
+    print("Two-client block-device concurrency (shared handle 0, positional reads):")
+    total_sectors = len(image_bytes) // sector_size
+    # two clients read interleaved 4-sector ranges of the SAME shared device
+    plan = {
+        'A': [(i, 4) for i in range(0, total_sectors - 4, 8)],
+        'B': [(i, 4) for i in range(4, total_sectors - 4, 8)],
+    }
+    errors = {}
+    barrier = threading.Barrier(2)
+
+    def worker(name):
+        c = UdpfsTestClient(('127.0.0.1', disc_port))
+        try:
+            c.discover()
+            barrier.wait()
+            for sec, cnt in plan[name]:
+                got = c.bread(sec, cnt, sector_size)
+                exp = image_bytes[sec * sector_size:(sec + cnt) * sector_size]
+                if got != exp:
+                    raise UdpfsError(f"sector {sec} x{cnt} mismatch "
+                                     f"({len(got)} vs {len(exp)} bytes)")
+        except Exception as e:  # noqa: BLE001
+            errors[name] = e
+        finally:
+            c.close()
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in ('A', 'B')]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    if errors:
+        for n, e in errors.items():
+            print(f"  ERROR client '{n}': {type(e).__name__}: {e}")
+        print("  BLOCK-DEVICE CONCURRENCY FAILED")
+        return False
+    reads = sum(len(v) for v in plan.values())
+    print(f"  BREAD ok: {reads} interleaved reads across 2 clients, no cross-corruption")
+    print("  BLOCK-DEVICE CONCURRENCY PASSED")
+    return True
+
+
+def main():
+    tmp = tempfile.mkdtemp(prefix="udpfs_selftest_")
+    files = {
+        "small.txt": b"hello ps2 world!!\n",
+        "fileA.bin": _make_file(tmp, "fileA.bin", 200000, seed=1),
+        "fileB.bin": _make_file(tmp, "fileB.bin", 173939, seed=2),
+    }
+    with open(os.path.join(tmp, "small.txt"), "wb") as f:
+        f.write(files["small.txt"])
+
+    # Shared block-device image (256 KB) for the block-concurrency test.
+    import random
+    sector_size = 512
+    image_bytes = bytes(random.Random(7).getrandbits(8) for _ in range(sector_size * 512))
+    image_path = os.path.join(tmp, "disk.img")
+    with open(image_path, "wb") as f:
+        f.write(image_bytes)
+
+    disc_port = _free_udp_port()
+    _start_server(tmp, disc_port, block_device=image_path)
+
+    ok = True
+    ok = test_baseline(tmp, disc_port, files) and ok
+    print()
+    ok = test_concurrency(tmp, disc_port,
+                          {k: files[k] for k in ("fileA.bin", "fileB.bin")}) and ok
+    print()
+    ok = test_block_concurrency(disc_port, image_bytes, sector_size) and ok
+
+    print()
+    print("ALL UDPFS TESTS PASSED" if ok else "UDPFS TESTS FAILED")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/udpfs_server/multiclient_selftest.py
+++ b/udpfs_server/multiclient_selftest.py
@@ -243,7 +243,7 @@ def test_concurrency(root, disc_port, files):
         c = UdpfsTestClient(('127.0.0.1', disc_port))
         try:
             c.discover()
-            barrier.wait()  # line up the two READ streams to overlap
+            barrier.wait(timeout=5.0)  # line up the two READ streams to overlap
             results[name] = c.read_file(name, len(files[name]))
         except Exception as e:  # noqa: BLE001 - report in the assert below
             errors[name] = e
@@ -291,7 +291,7 @@ def test_block_concurrency(disc_port, image_bytes, sector_size=512):
         c = UdpfsTestClient(('127.0.0.1', disc_port))
         try:
             c.discover()
-            barrier.wait()
+            barrier.wait(timeout=5.0)
             for sec, cnt in plan[name]:
                 got = c.bread(sec, cnt, sector_size)
                 exp = image_bytes[sec * sector_size:(sec + cnt) * sector_size]

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -30,10 +30,12 @@ import errno
 import gzip
 import math
 import os
+import queue
 import select
 import socket
 import struct
 import sys
+import threading
 import time
 import zlib
 from collections import OrderedDict
@@ -99,6 +101,12 @@ FIO_S_IFDIR = 0x1000
 # Limits
 MAX_DATA_PAYLOAD = 1408  # Maximum UDPRDMA payload
 MAX_HANDLES = 32
+
+# Multi-client session management
+SESSION_TIMEOUT = 30.0           # seconds of peer inactivity before reaping a session
+SESSION_SWEEP_INTERVAL = 5.0     # how often the demux loop checks for idle sessions
+HAS_PREAD = hasattr(os, 'pread')     # POSIX: lock-free positional block-device reads
+HAS_PWRITE = hasattr(os, 'pwrite')
 
 # Flow control
 SEND_WINDOW = 8           # Max unacked packets in flight
@@ -277,6 +285,20 @@ class FileHandle:
             self.obj.close()
 
 
+def _session_prop(name):
+    """A property that proxies a per-client field to the calling worker thread's
+    Session (server._local.session). This lets every request handler keep using
+    self.tx_seq_nr / self.handles / self.write_* verbatim while the underlying
+    state is actually isolated per client."""
+    def getter(self):
+        return getattr(self._local.session, name)
+
+    def setter(self, value):
+        setattr(self._local.session, name, value)
+
+    return property(getter, setter)
+
+
 class UdpfsServer:
     """UDPFS Server over UDPRDMA - unified file and block device server"""
 
@@ -314,21 +336,26 @@ class UdpfsServer:
         self.dsock.bind((bind_ip, 0))
         self.dsock.setblocking(False)
         
-        # Protocol state
-        self.peer_addr: Optional[Tuple[str, int]] = None
-        self.tx_seq_nr = 0
-        self.tx_seq_nr_acked = 0  # Last ACKed seq (for send window)
-        self.rx_seq_nr_expected = 0
+        # Multi-client state: one Session per peer address, each with its own
+        # protocol state (sequence numbers, handle table, write state) and worker
+        # thread. The demultiplexer (run) never blocks on protocol work; per-client
+        # blocking waits read from that client's own queue. See class Session and
+        # the _session_prop(...) proxies below, which route the per-client fields
+        # the handler methods use (self.tx_seq_nr, self.handles, ...) to the
+        # calling worker thread's Session -- so the handler bodies are unchanged.
+        self._local = threading.local()      # _local.session = current worker's Session
+        self.sessions: Dict[Tuple[str, int], 'Session'] = {}
+        self.sessions_lock = threading.Lock()
+        self.send_lock = threading.Lock()    # serialize sends on the shared data socket
+        self.bd_lock = threading.Lock()      # guards the block-device seek+read fallback
+        self._shutdown = False
+        self._last_sweep = time.monotonic()
 
-        # TX buffer for retransmit
-        self.tx_buffer: List[Tuple[int, bytes]] = []
-        self.tx_start_seq = 0
-
-        # Handle management - dynamic handles start from 1
-        self.handles: Dict[int, FileHandle] = {}
-        self.next_handle = 1
-
-        # Block device setup (handle 0)
+        # Shared block device (handle 0): opened once, shared across all sessions.
+        # Concurrent access uses positional I/O (bd_read/bd_write), never the
+        # object's own file position.
+        self.bd_fh: Optional[FileHandle] = None
+        self.bd_fd: Optional[int] = None
         self.bd_sector_size = sector_size
         self.bd_sector_count = 0
         if block_device:
@@ -342,16 +369,11 @@ class UdpfsServer:
             bd_size = bd_file.tell()
             bd_file.seek(0)
             self.bd_sector_count = bd_size // sector_size
-            self.handles[BLOCK_DEVICE_HANDLE] = FileHandle(bd_file, is_dir=False)
-
-        # Write state (shared between file writes and block writes)
-        self.write_handle = -1
-        self.write_is_block = False
-        self.write_sector_nr = 0
-        self.write_sector_count = 0
-        self.write_data = bytearray()
-        self.write_total_chunks = 0
-        self.write_received_chunks = 0
+            self.bd_fh = FileHandle(bd_file, is_dir=False)
+            try:
+                self.bd_fd = bd_file.fileno()
+            except (OSError, AttributeError):
+                self.bd_fd = None
 
         # Statistics
         self.stats = {
@@ -378,12 +400,93 @@ class UdpfsServer:
         self._last_status_bytes = 0
         self._status_visible = False
 
+    # -- per-client state proxies (route to self._local.session; see Session) --
+    peer_addr = _session_prop('peer_addr')
+    tx_seq_nr = _session_prop('tx_seq_nr')
+    tx_seq_nr_acked = _session_prop('tx_seq_nr_acked')
+    rx_seq_nr_expected = _session_prop('rx_seq_nr_expected')
+    tx_buffer = _session_prop('tx_buffer')
+    tx_start_seq = _session_prop('tx_start_seq')
+    handles = _session_prop('handles')
+    next_handle = _session_prop('next_handle')
+    write_handle = _session_prop('write_handle')
+    write_is_block = _session_prop('write_is_block')
+    write_sector_nr = _session_prop('write_sector_nr')
+    write_sector_count = _session_prop('write_sector_count')
+    write_data = _session_prop('write_data')
+    write_total_chunks = _session_prop('write_total_chunks')
+    write_received_chunks = _session_prop('write_received_chunks')
+
+    # -- shared data-socket send + positional block-device I/O -------------
+    def _sendto(self, packet: bytes, addr):
+        """Send on the shared data socket under a lock (many worker threads)."""
+        sock = self.dsock
+        with self.send_lock:
+            sock.sendto(packet, addr)
+
+    def bd_read(self, offset: int, n: int) -> bytes:
+        """Thread-safe positional read of the shared block device."""
+        if HAS_PREAD and self.bd_fd is not None:
+            return os.pread(self.bd_fd, n, offset)
+        with self.bd_lock:
+            self.bd_fh.obj.seek(offset)
+            return self.bd_fh.obj.read(n)
+
+    def bd_write(self, offset: int, data: bytes) -> int:
+        """Thread-safe positional write to the shared block device."""
+        if HAS_PWRITE and self.bd_fd is not None:
+            return os.pwrite(self.bd_fd, data, offset)
+        with self.bd_lock:
+            self.bd_fh.obj.seek(offset)
+            n = self.bd_fh.obj.write(data)
+            self.bd_fh.obj.flush()
+            return n
+
+    # -- session lifecycle -------------------------------------------------
+    def _get_or_create_session(self, addr):
+        with self.sessions_lock:
+            sess = self.sessions.get(addr)
+            if sess is None:
+                sess = Session(self, addr)
+                self.sessions[addr] = sess
+                sess.start()
+            sess.last_activity = time.monotonic()
+            return sess
+
+    def _route_data(self, data: bytes, addr):
+        """Demux a data datagram to its peer's session queue (demux thread)."""
+        if len(data) < 2:
+            return
+        hdr = Header.unpack(data)
+        if hdr.packet_type != PacketType.DATA:
+            return
+        self._get_or_create_session(addr).queue.put((data, addr))
+
+    def _sweep_idle_sessions(self):
+        now = time.monotonic()
+        if now - self._last_sweep < SESSION_SWEEP_INTERVAL:
+            return
+        self._last_sweep = now
+        with self.sessions_lock:
+            idle = [a for a, s in self.sessions.items()
+                    if now - s.last_activity > SESSION_TIMEOUT]
+            for a in idle:
+                self.sessions.pop(a).shutdown()
+
+    def _shutdown_all_sessions(self):
+        self._shutdown = True
+        with self.sessions_lock:
+            sessions = list(self.sessions.values())
+            self.sessions.clear()
+        for s in sessions:
+            s.shutdown()
+
     def run(self):
         """Main server loop"""
         print(f"UDPFS Server")
         if self.root_dir:
             print(f"  Root: {self.root_dir}")
-        if BLOCK_DEVICE_HANDLE in self.handles:
+        if self.bd_fh is not None:
             print(f"  Block device: handle={BLOCK_DEVICE_HANDLE}, "
                   f"sectors={self.bd_sector_count:,}, "
                   f"sector_size={self.bd_sector_size}")
@@ -401,9 +504,9 @@ class UdpfsServer:
 
         print(f"  Listening...")
         print()
-        while True:
+        while not self._shutdown:
             try:
-                r, _, _ = select.select([self.sock, self.dsock], [], [])
+                r, _, _ = select.select([self.sock, self.dsock], [], [], 1.0)
                 for ready in r:
                     if ready is self.sock:
                         try:
@@ -413,14 +516,16 @@ class UdpfsServer:
                             pass
                     elif ready is self.dsock:
                         try:
-                            data, addr = self.dsock.recvfrom(2048)
-                            self._handle_data(data, addr)
+                            data, addr = self.dsock.recvfrom(4096)
+                            self._route_data(data, addr)
                         except BlockingIOError:
                             pass
+                self._sweep_idle_sessions()
             except KeyboardInterrupt:
                 if self._status_visible:
                     sys.stdout.write(f"\r{'':<79}\r")
                 print("\nShutting down...")
+                self._shutdown_all_sessions()
                 self._cleanup()
                 self._print_stats()
                 break
@@ -475,13 +580,12 @@ class UdpfsServer:
         print(msg)
 
     def _cleanup(self):
-        """Close all open handles"""
-        for handle_id, fh in self.handles.items():
+        """Close the shared block device (each session closes its own handles)."""
+        if self.bd_fh is not None:
             try:
-                fh.close()
+                self.bd_fh.close()
             except Exception:
                 pass
-        self.handles.clear()
 
     def _resolve_path(self, client_path: str) -> Optional[str]:
         """Resolve client path to absolute path within root_dir."""
@@ -650,7 +754,8 @@ class UdpfsServer:
 
         self.stats['discovery'] += 1
 
-        self.peer_addr = addr
+        # Ensure a per-client session (and its worker thread) exists for this peer.
+        self._get_or_create_session(addr)
         self._print_event(f"[{addr[0]}:{addr[1]}] DISCOVERY -> INFORM")
         self._send_inform(addr)
 
@@ -1039,9 +1144,14 @@ class UdpfsServer:
         expected_size = self.write_sector_count * sector_size
 
         try:
-            fh.obj.seek(self.write_sector_nr * sector_size)
-            fh.obj.write(self.write_data[:expected_size])
-            fh.obj.flush()
+            if self.write_handle == BLOCK_DEVICE_HANDLE:
+                # Shared block device: positional write (no shared file position).
+                self.bd_write(self.write_sector_nr * sector_size,
+                              bytes(self.write_data[:expected_size]))
+            else:
+                fh.obj.seek(self.write_sector_nr * sector_size)
+                fh.obj.write(self.write_data[:expected_size])
+                fh.obj.flush()
             self.stats['bytes_written'] += expected_size
 
             if self.verbose:
@@ -1315,8 +1425,12 @@ class UdpfsServer:
             self._print_event(f"[{addr[0]}:{addr[1]}] BREAD handle={handle} sector={sector_nr} count={sector_count} ({total_size} bytes)")
 
         try:
-            fh.obj.seek(sector_nr * sector_size)
-            data = fh.obj.read(total_size)
+            if handle == BLOCK_DEVICE_HANDLE:
+                # Shared block device: positional read (no shared file position).
+                data = self.bd_read(sector_nr * sector_size, total_size)
+            else:
+                fh.obj.seek(sector_nr * sector_size)
+                data = fh.obj.read(total_size)
         except OSError as e:
             self._print_event(f"[{addr[0]}:{addr[1]}] BREAD error: {e}")
             self._send_read_result(addr, -e.errno, b'')
@@ -1376,7 +1490,7 @@ class UdpfsServer:
         disc = DiscHeader(service_id=UDPRDMA_SVC_UDPFS, port = self.dsock.getsockname()[1])
 
         packet = hdr.pack() + disc.pack()
-        self.dsock.sendto(packet, addr)
+        self._sendto(packet, addr)
 
     def _send_ack(self, addr: Tuple[str, int], is_ack: bool = True):
         """Send ACK or NACK packet"""
@@ -1389,7 +1503,7 @@ class UdpfsServer:
         )
 
         packet = hdr.pack() + data_hdr.pack()
-        self.dsock.sendto(packet, addr)
+        self._sendto(packet, addr)
 
     def _send_data(self, addr: Tuple[str, int], payload: bytes):
         """Send DATA packet with payload (single packet, always FIN) and confirm receipt."""
@@ -1406,7 +1520,7 @@ class UdpfsServer:
 
         packet = hdr.pack() + data_hdr.pack() + padded_payload
         self.tx_buffer = [(self.tx_seq_nr, packet)]
-        self.dsock.sendto(packet, addr)
+        self._sendto(packet, addr)
         self.tx_seq_nr = (self.tx_seq_nr + 1) & 0xFFF
         self._wait_for_final_ack(addr)
 
@@ -1433,7 +1547,7 @@ class UdpfsServer:
 
         self.tx_buffer.append((self.tx_seq_nr, packet))
 
-        self.dsock.sendto(packet, addr)
+        self._sendto(packet, addr)
         self.tx_seq_nr = (self.tx_seq_nr + 1) & 0xFFF
 
     def _retransmit_from(self, addr: Tuple[str, int], from_seq: int):
@@ -1442,7 +1556,7 @@ class UdpfsServer:
         for seq, packet in self.tx_buffer:
             seq_diff = (seq - from_seq) & 0xFFF
             if seq_diff < 2048:
-                self.dsock.sendto(packet, addr)
+                self._sendto(packet, addr)
                 count += 1
         if self.verbose and count > 0:
             self._print_event(f"  Retransmitted {count} packets from seq={from_seq}")
@@ -1470,45 +1584,40 @@ class UdpfsServer:
         return best_chunk
 
     def _wait_for_window_ack(self, addr: Tuple[str, int]):
-        """Wait for window ACK/NACK during multi-packet send.
-        Updates tx_seq_nr_acked. On NACK, retransmits."""
-        self.dsock.settimeout(WINDOW_ACK_TIMEOUT)
-        try:
-            while True:
-                pkt, recv_addr = self.dsock.recvfrom(2048)
-                if len(pkt) < 6:
-                    continue
-                hdr = Header.unpack(pkt)
-                if hdr.packet_type != PacketType.DATA:
-                    continue
-                data_hdr = DataHeader.unpack(pkt[2:6])
-                if data_hdr.data_byte_count > 0 or data_hdr.hdr_word_count > 0:
-                    continue  # Not an ACK/NACK packet
-                if data_hdr.flags & DataFlags.ACK:
-                    # Window ACK - advance acked position
-                    self.tx_seq_nr_acked = data_hdr.seq_nr_ack
-                    self.tx_buffer = [
-                        (seq, pkt) for seq, pkt in self.tx_buffer
-                        if ((seq - data_hdr.seq_nr_ack - 1) & 0xFFF) < 2048
-                    ]
-                    return
-                else:
-                    # NACK - retransmit and keep waiting for the ACK that
-                    # confirms the retransmitted packets arrived. Returning
-                    # here would let the outer loop increment window_retries
-                    # on every duplicate NACK before the retransmit lands.
-                    self.tx_seq_nr_acked = (data_hdr.seq_nr_ack - 1) & 0xFFF
-                    self._retransmit_from(addr, data_hdr.seq_nr_ack)
-                    self.dsock.settimeout(WINDOW_ACK_TIMEOUT)  # reset timeout
-        except socket.timeout:
-            # No ACK received - retransmit all unacked
-            self.dsock.settimeout(None)
-            if self.tx_buffer:
-                start_seq = self.tx_buffer[0][0]
-                self._retransmit_from(addr, start_seq)
-            return
-        finally:
-            self.dsock.settimeout(None)
+        """Wait for a window ACK/NACK during a multi-packet send. Reads from this
+        client's session queue (the demux routes the client's ACKs there), so one
+        client's wait never blocks another. Updates tx_seq_nr_acked; retransmits on
+        NACK; retransmits unacked on timeout."""
+        sess = self._local.session
+        while True:
+            try:
+                pkt, _recv_addr = sess.queue.get(timeout=WINDOW_ACK_TIMEOUT)
+            except queue.Empty:
+                if self.tx_buffer:
+                    self._retransmit_from(addr, self.tx_buffer[0][0])
+                return
+            if pkt is None:
+                return  # session shutting down
+            if len(pkt) < 6:
+                continue
+            hdr = Header.unpack(pkt)
+            if hdr.packet_type != PacketType.DATA:
+                continue
+            data_hdr = DataHeader.unpack(pkt[2:6])
+            if data_hdr.data_byte_count > 0 or data_hdr.hdr_word_count > 0:
+                continue  # Not an ACK/NACK packet
+            if data_hdr.flags & DataFlags.ACK:
+                # Window ACK - advance acked position
+                self.tx_seq_nr_acked = data_hdr.seq_nr_ack
+                self.tx_buffer = [
+                    (seq, p) for seq, p in self.tx_buffer
+                    if ((seq - data_hdr.seq_nr_ack - 1) & 0xFFF) < 2048
+                ]
+                return
+            else:
+                # NACK - retransmit and keep waiting for the confirming ACK.
+                self.tx_seq_nr_acked = (data_hdr.seq_nr_ack - 1) & 0xFFF
+                self._retransmit_from(addr, data_hdr.seq_nr_ack)
 
     def _in_flight(self) -> int:
         """Number of unacknowledged packets in flight"""
@@ -1518,39 +1627,38 @@ class UdpfsServer:
         """Wait for ACK that confirms the FIN packet was received.
         Mid-stream window ACKs (seq_nr_ack < fin_seq) are handled but do
         not complete the wait — only an ACK covering the FIN does."""
+        sess = self._local.session
         fin_seq = (self.tx_seq_nr - 1) & 0xFFF
-        self.dsock.settimeout(timeout)
-        try:
-            while True:
-                pkt, recv_addr = self.dsock.recvfrom(2048)
-                if len(pkt) < 6:
-                    continue
-                hdr = Header.unpack(pkt)
-                if hdr.packet_type != PacketType.DATA:
-                    continue
-                data_hdr = DataHeader.unpack(pkt[2:6])
-                if data_hdr.data_byte_count == 0 and data_hdr.hdr_word_count == 0:
-                    if data_hdr.flags & DataFlags.ACK:
-                        # Always advance acked position and prune tx_buffer
-                        self.tx_seq_nr_acked = data_hdr.seq_nr_ack
-                        if self.tx_buffer:
-                            self.tx_buffer = [
-                                (seq, pkt) for seq, pkt in self.tx_buffer
-                                if ((seq - data_hdr.seq_nr_ack - 1) & 0xFFF) < 2048
-                            ]
-                        # Only accept as final ACK if it covers the FIN packet
-                        if data_hdr.seq_nr_ack == fin_seq:
-                            self.tx_buffer = []
-                            return True
-                        # else: mid-stream window ACK — keep waiting
-                    else:
-                        # NACK - retransmit and reset timeout
-                        self._retransmit_from(addr, data_hdr.seq_nr_ack)
-                        self.dsock.settimeout(timeout)
-        except socket.timeout:
-            return False
-        finally:
-            self.dsock.settimeout(None)
+        while True:
+            try:
+                pkt, _recv_addr = sess.queue.get(timeout=timeout)
+            except queue.Empty:
+                return False
+            if pkt is None:
+                return False  # session shutting down
+            if len(pkt) < 6:
+                continue
+            hdr = Header.unpack(pkt)
+            if hdr.packet_type != PacketType.DATA:
+                continue
+            data_hdr = DataHeader.unpack(pkt[2:6])
+            if data_hdr.data_byte_count == 0 and data_hdr.hdr_word_count == 0:
+                if data_hdr.flags & DataFlags.ACK:
+                    # Always advance acked position and prune tx_buffer
+                    self.tx_seq_nr_acked = data_hdr.seq_nr_ack
+                    if self.tx_buffer:
+                        self.tx_buffer = [
+                            (seq, p) for seq, p in self.tx_buffer
+                            if ((seq - data_hdr.seq_nr_ack - 1) & 0xFFF) < 2048
+                        ]
+                    # Only accept as final ACK if it covers the FIN packet
+                    if data_hdr.seq_nr_ack == fin_seq:
+                        self.tx_buffer = []
+                        return True
+                    # else: mid-stream window ACK — keep waiting
+                else:
+                    # NACK - retransmit and keep waiting
+                    self._retransmit_from(addr, data_hdr.seq_nr_ack)
 
     def _wait_for_final_ack(self, addr: Tuple[str, int]):
         """Confirm transfer completion: wait for ACK, retransmit on NACK or timeout.
@@ -1773,6 +1881,78 @@ class UdpfsServer:
             if total_written > 0:
                 rate = total_written / elapsed if elapsed > 0 else 0
                 print(f"  written      {self._format_bytes(total_written):>10s}  ({self._format_bytes(int(rate))}/s)")
+
+
+class Session:
+    """Per-client protocol state plus a worker thread that runs the server's
+    request handlers for exactly one peer. Created on first contact and reaped
+    after SESSION_TIMEOUT of inactivity. All per-client fields mirror the initial
+    values the single-client server used, so handler logic is unchanged."""
+
+    def __init__(self, server: 'UdpfsServer', addr):
+        self.server = server
+        self.addr = addr
+        # per-client protocol state
+        self.peer_addr = addr
+        self.tx_seq_nr = 0
+        self.tx_seq_nr_acked = 0
+        self.rx_seq_nr_expected = 0
+        self.tx_buffer: List[Tuple[int, bytes]] = []
+        self.tx_start_seq = 0
+        # handle 0 = the shared block device (same FileHandle across sessions;
+        # concurrent access uses server.bd_read/bd_write positional I/O).
+        self.handles: Dict[int, FileHandle] = {}
+        if server.bd_fh is not None:
+            self.handles[BLOCK_DEVICE_HANDLE] = server.bd_fh
+        self.next_handle = 1
+        self.write_handle = -1
+        self.write_is_block = False
+        self.write_sector_nr = 0
+        self.write_sector_count = 0
+        self.write_data = bytearray()
+        self.write_total_chunks = 0
+        self.write_received_chunks = 0
+        # concurrency plumbing
+        self.queue: "queue.Queue" = queue.Queue()
+        self.last_activity = time.monotonic()
+        self._closing = False
+        self._thread = threading.Thread(
+            target=self._run, name=f"udpfs-{addr[0]}:{addr[1]}", daemon=True)
+
+    def start(self):
+        self._thread.start()
+
+    def shutdown(self):
+        self._closing = True
+        self.queue.put(None)  # wake the worker if it is blocked on get()
+
+    def _run(self):
+        # Bind this worker thread to its session so the server's _session_prop
+        # proxies resolve self.tx_seq_nr / self.handles / ... to THIS client.
+        self.server._local.session = self
+        while not self._closing and not self.server._shutdown:
+            try:
+                item = self.queue.get(timeout=1.0)
+            except queue.Empty:
+                continue
+            if item is None:
+                break
+            data, addr = item
+            try:
+                self.server._handle_data(data, addr)
+            except Exception as e:  # keep the session alive on a handler error
+                if self.server.verbose:
+                    self.server._print_event(
+                        f"[{addr[0]}:{addr[1]}] session error: {type(e).__name__}: {e}")
+        # Close this session's own file handles (never the shared block device).
+        for hid, fh in list(self.handles.items()):
+            if hid == BLOCK_DEVICE_HANDLE:
+                continue
+            try:
+                fh.close()
+            except Exception:
+                pass
+        self.handles.clear()
 
 
 def main():

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -480,6 +480,10 @@ class UdpfsServer:
             self.sessions.clear()
         for s in sessions:
             s.shutdown()
+        # Wait for worker threads to finish before the caller closes shared
+        # resources (the block device in _cleanup), avoiding a shutdown race.
+        for s in sessions:
+            s._thread.join(timeout=2.0)
 
     def run(self):
         """Main server loop"""
@@ -1941,9 +1945,10 @@ class Session:
             try:
                 self.server._handle_data(data, addr)
             except Exception as e:  # keep the session alive on a handler error
-                if self.server.verbose:
-                    self.server._print_event(
-                        f"[{addr[0]}:{addr[1]}] session error: {type(e).__name__}: {e}")
+                # Always surface handler errors -- silent swallowing makes
+                # multi-client issues very hard to debug.
+                self.server._print_event(
+                    f"[{addr[0]}:{addr[1]}] session error: {type(e).__name__}: {e}")
         # Close this session's own file handles (never the shared block device).
         for hid, fh in list(self.handles.items()):
             if hid == BLOCK_DEVICE_HANDLE:

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -100,10 +100,10 @@ FIO_S_IFDIR = 0x1000
 
 # Limits
 MAX_DATA_PAYLOAD = 1408  # Maximum UDPRDMA payload
-MAX_HANDLES = 32
+MAX_HANDLES = 64  # open handles per client (matches udpfsd; was 32 originally)
 
 # Multi-client session management
-SESSION_TIMEOUT = 30.0           # seconds of peer inactivity before reaping a session
+SESSION_TIMEOUT = 300.0          # default seconds of peer inactivity before reaping (see --peer-timeout)
 SESSION_SWEEP_INTERVAL = 5.0     # how often the demux loop checks for idle sessions
 HAS_PREAD = hasattr(os, 'pread')     # POSIX: lock-free positional block-device reads
 HAS_PWRITE = hasattr(os, 'pwrite')
@@ -309,7 +309,10 @@ class UdpfsServer:
                  sector_size: int = 512,
                  read_only: bool = False, verbose: bool = False,
                  enable_compression: bool = False,
-                 compression_cache_size: int = 32):
+                 compression_cache_size: int = 32,
+                 peer_timeout: float = SESSION_TIMEOUT,
+                 metrics: bool = False,
+                 metrics_period: float = 60.0):
         self.root_dir = os.path.realpath(root_dir) if root_dir else None
         self.port = port
         self.bind_ip = bind_ip
@@ -318,6 +321,10 @@ class UdpfsServer:
         self.verbose = verbose
         self.enable_compression = enable_compression
         self.compression_cache_size = compression_cache_size
+        self.session_timeout = peer_timeout
+        self.metrics = metrics
+        self.metrics_period = metrics_period
+        self._last_metrics = time.monotonic()
 
         if self.root_dir and not os.path.isdir(self.root_dir):
             print(f"Error: '{root_dir}' is not a directory")
@@ -469,9 +476,27 @@ class UdpfsServer:
         self._last_sweep = now
         with self.sessions_lock:
             idle = [a for a, s in self.sessions.items()
-                    if now - s.last_activity > SESSION_TIMEOUT]
+                    if now - s.last_activity > self.session_timeout]
             for a in idle:
                 self.sessions.pop(a).shutdown()
+
+    def _emit_metrics(self):
+        """Periodically log transfer/op stats when --metrics is enabled."""
+        if not self.metrics:
+            return
+        now = time.monotonic()
+        if now - self._last_metrics < self.metrics_period:
+            return
+        self._last_metrics = now
+        with self.sessions_lock:
+            nclients = len(self.sessions)
+        s = self.stats
+        self._print_event(
+            "[metrics] clients=%d read=%s written=%s "
+            "ops(open=%d read=%d bread=%d write=%d bwrite=%d dread=%d)" % (
+                nclients, self._format_bytes(s['bytes_read']),
+                self._format_bytes(s['bytes_written']),
+                s['open'], s['read'], s['bread'], s['write'], s['bwrite'], s['dread']))
 
     def _shutdown_all_sessions(self):
         self._shutdown = True
@@ -525,6 +550,7 @@ class UdpfsServer:
                         except BlockingIOError:
                             pass
                 self._sweep_idle_sessions()
+                self._emit_metrics()
             except KeyboardInterrupt:
                 if self._status_visible:
                     sys.stdout.write(f"\r{'':<79}\r")
@@ -1960,59 +1986,82 @@ class Session:
         self.handles.clear()
 
 
+def _env_bool(name, default=False):
+    v = os.environ.get(name)
+    if v is None:
+        return default
+    return v.strip().lower() in ('1', 'true', 'yes', 'on')
+
+
+def _env_int(name, default):
+    v = os.environ.get(name)
+    return int(v, 0) if v else default
+
+
+def _env_float(name, default):
+    v = os.environ.get(name)
+    return float(v) if v else default
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='UDPFS Server - Unified file and block device server over UDPRDMA',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__
     )
+    # Every option also reads an environment variable (container-friendly, like
+    # udpfsd); the CLI flag overrides the env var, which overrides the default.
     parser.add_argument(
-        '--block-device', '-b',
-        help='Block device or disk image to serve as handle 0'
+        '--block-device', '-b', default=os.environ.get('BDPATH'),
+        help='Block device or disk image to serve as handle 0 (env: BDPATH)'
     )
     parser.add_argument(
-        '--root-dir', '-d',
-        help='Root directory to serve files from'
+        '--root-dir', '-d', default=os.environ.get('FSROOT'),
+        help='Root directory to serve files from (env: FSROOT)'
     )
     parser.add_argument(
-        '--port', '-p',
-        type=lambda x: int(x, 0),
-        default=UDPFS_PORT,
-        help=f'UDP port to listen on (default: 0x{UDPFS_PORT:04X})'
+        '--port', '-p', type=lambda x: int(x, 0),
+        default=_env_int('PORT', UDPFS_PORT),
+        help=f'UDP port to listen on (default: 0x{UDPFS_PORT:04X}; env: PORT)'
     )
     parser.add_argument(
-        '--bind', '-i',
-        default='',
-        metavar='IP',
-        help='IP address to bind/listen on (default: all interfaces)'
+        '--bind', '-i', default=os.environ.get('BIND', ''), metavar='IP',
+        help='IP address to bind/listen on (default: all interfaces; env: BIND)'
     )
     parser.add_argument(
-        '--sector-size', '-s',
-        type=int,
-        default=512,
-        help='Sector size for block device (default: 512)'
+        '--sector-size', '-s', type=int, default=_env_int('SECTOR_SIZE', 512),
+        help='Sector size for block device (default: 512; env: SECTOR_SIZE)'
     )
     parser.add_argument(
-        '--read-only', '-r',
-        action='store_true',
-        help='Serve in read-only mode'
+        '--read-only', '-r', action='store_true', default=_env_bool('RO'),
+        help='Serve in read-only mode (env: RO)'
     )
     parser.add_argument(
-        '--verbose', '-v',
-        action='store_true',
-        help='Verbose output'
+        '--verbose', '-v', action='store_true', default=_env_bool('VERBOSE'),
+        help='Verbose output (env: VERBOSE)'
     )
     parser.add_argument(
-        '--enable-compression', '-c',
-        action='store_true',
-        help='Enable transparent decompression of .zso (LZ4), .cso (zlib), and .chd (CHD v5) files. '
-             'Compressed files appear as .iso in directory listings.'
+        '--enable-compression', '-c', action='store_true',
+        default=_env_bool('ENABLE_COMPRESSION'),
+        help='Enable transparent decompression of .zso (LZ4), .cso (zlib), and .chd (CHD v5) '
+             'files. Compressed files appear as .iso in directory listings. (env: ENABLE_COMPRESSION)'
     )
     parser.add_argument(
-        '--compression-cache-size',
-        type=int,
-        default=32,
-        help='Number of decompressed blocks to cache per file (default: 32)'
+        '--compression-cache-size', type=int, default=_env_int('COMPRESSION_CACHE_SIZE', 32),
+        help='Number of decompressed blocks to cache per file (default: 32; env: COMPRESSION_CACHE_SIZE)'
+    )
+    parser.add_argument(
+        '--peer-timeout', type=float, default=_env_float('PEER_TIMEOUT', SESSION_TIMEOUT),
+        help=f'Seconds of client inactivity before its session is reaped '
+             f'(default: {int(SESSION_TIMEOUT)}; env: PEER_TIMEOUT)'
+    )
+    parser.add_argument(
+        '--metrics', action='store_true', default=_env_bool('METRICS'),
+        help='Periodically log transfer/op statistics (env: METRICS)'
+    )
+    parser.add_argument(
+        '--metrics-period', type=float, default=_env_float('METRICS_PERIOD', 60.0),
+        help='Seconds between metrics log lines (default: 60; env: METRICS_PERIOD)'
     )
 
     args = parser.parse_args()
@@ -2045,7 +2094,10 @@ def main():
         read_only=args.read_only,
         verbose=args.verbose,
         enable_compression=args.enable_compression,
-        compression_cache_size=args.compression_cache_size
+        compression_cache_size=args.compression_cache_size,
+        peer_timeout=args.peer_timeout,
+        metrics=args.metrics,
+        metrics_period=args.metrics_period
     )
     server.run()
 


### PR DESCRIPTION
Brings the built-in Python UDPFS server (Rick Gaiser's Neutrino server) to **complete feature parity with pcm720's Go `udpfsd`**, driven by a definitive capability audit. No wire-protocol change; single-client behavior unchanged.

## Parity matrix (ours vs udpfsd) — now complete
| udpfsd capability | Ours |
|---|---|
| Folder / block-device / both | ✅ |
| UDPFS + UDPBD | ✅ |
| **Multiple concurrent clients (isolated)** | ✅ (this PR) |
| CSO/ZSO/CHD decompression | ✅ |
| Read-only | ✅ |
| Compression cache tuning | ✅ |
| Write support + RO toggle | ✅ |
| Idle-peer auto-cleanup | ✅ (this PR) |
| **Config via env vars** | ✅ (this PR) |
| **Configurable peer timeout** | ✅ `--peer-timeout` (this PR) |
| **64 handles** | ✅ (this PR) |
| **Metrics logging + period** | ✅ `--metrics`/`--metrics-period` (this PR) |

udpfsd has no config-file / multi-device / auth / daemon mode that we'd be missing. IPv6 is moot (PS2 LAN is IPv4).

## How
- **Multi-client:** per-peer `Session` + worker-thread-per-client + a demultiplexer routing datagrams to per-session queues; ACK-waits read from the session queue (not the socket); shared block device uses positional I/O (`os.pread`/`os.pwrite`, Windows lock fallback); `sendto` lock; idle-session reap. A `threading.local` current-session + proxy properties keep the ~30 handler bodies unchanged.
- **Config:** every option now also reads an env var (`FSROOT`/`BDPATH`/`PORT`/`BIND`/`SECTOR_SIZE`/`RO`/`VERBOSE`/`ENABLE_COMPRESSION`/`COMPRESSION_CACHE_SIZE`/`PEER_TIMEOUT`/`METRICS`/`METRICS_PERIOD`); CLI > env > default.
- 64 handles; `--peer-timeout` (default 300s); `--metrics`/`--metrics-period`.

## Verified (all run locally)
Real byte-verifying test `udpfs_server/multiclient_selftest.py` (in CI): single-client baseline, 2-client isolation, shared-block-device concurrency — plus 10/10 stability and an 8-client stress. Env vars take effect; `--help` documents each; `--metrics` emits. UDPBD selftest unchanged. Gemini review addressed (shutdown-join, always-log errors, barrier timeouts).

## ⚠️ NOT hardware-validated
Tests drive an in-process client over loopback. Real PS2/Neutrino timing, packet loss, and idle-reap reconnect semantics still need a real-hardware (or PCSX2 + netadapter) pass before this ships in a release.