### PR TITLE
launcher: declutter About tab + remove top banner

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -81,7 +81,7 @@ Removing those rules returns Windows to having no PS2 Servers-specific firewall 
 
 No terminal required
 
-The buttons in this About tab and in the launcher footer are the normal way to manage PS2 Servers' Windows changes. Use "Allow through firewall" to add or refresh the rules. Use "Remove PS2 Servers firewall rules" to undo them. Use "Stop all servers" to shut down every running PS2 Servers process from the GUI.
+The buttons in the launcher footer are the normal way to manage PS2 Servers' Windows changes. Use "Allow through firewall" to add or refresh the rules. Use "Remove PS2 Servers firewall rules" to undo them. Use "Stop all" to shut down every running PS2 Servers process from the GUI.
 
 Advanced manual fallback
 
@@ -527,25 +527,6 @@ class LauncherApp:
                    command=lambda: self._open_url(RELEASES_URL)).pack(side="left", padx=(6, 0), pady=6)
         ttk.Button(links, text="Security notes",
                    command=lambda: self._open_url(SECURITY_URL)).pack(side="left", padx=(6, 0), pady=6)
-
-        actions = ttk.LabelFrame(about, text=" No-terminal actions ")
-        actions.grid(row=row, column=0, sticky="ew", padx=8, pady=(8, 0))
-        row += 1
-        allow = ttk.Button(actions, text="Allow through firewall",
-                           command=self.allow_windows_setup)
-        allow.pack(side="left", padx=(6, 0), pady=6)
-        remove = ttk.Button(actions, text="Remove PS2 Servers firewall rules",
-                            command=self.remove_windows_setup)
-        remove.pack(side="left", padx=(6, 0), pady=6)
-        ttk.Button(actions, text="Stop all servers",
-                   command=self.stop_all).pack(side="left", padx=(6, 0), pady=6)
-        ttk.Button(actions, text="Restart app",
-                   command=self.restart_app).pack(side="left", padx=(6, 0), pady=6)
-        ttk.Button(actions, text="Exit app",
-                   command=self.exit_app).pack(side="left", padx=(6, 0), pady=6)
-        if not windows_setup.is_windows():
-            allow.config(state="disabled")
-            remove.config(state="disabled")
 
         behavior = ttk.LabelFrame(about, text=" Window behavior ")
         behavior.grid(row=row, column=0, sticky="ew", padx=8, pady=(8, 0))

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -240,47 +240,6 @@ def _apply_gui_review_fixes(gui):
         widget.bind("<Configure>", update, add="+")
         widget.after_idle(update)
 
-    def draw_banner(canvas, width, height=88):
-        width = max(320, int(width))
-        canvas.delete("all")
-        canvas.create_rectangle(0, 0, width, height, fill=palette["bg"], outline="")
-        canvas.create_rectangle(0, 0, width, height, fill=palette["panel"], outline="#18416f")
-        for y, color in ((12, "#061534"), (42, "#082351"), (78, "#061534")):
-            canvas.create_line(0, y, width, y, fill=color)
-        for x in range(36, width + 96, 96):
-            canvas.create_line(x, 0, x - 38, height, fill="#081f48")
-        canvas.create_line(0, height - 3, width, height - 3, fill=palette["accent"], width=2)
-        for x in (42, 132, max(220, width - 190), max(300, width - 82)):
-            if 0 <= x < width - 28:
-                canvas.create_rectangle(x, 18, x + 18, 36, outline=palette["accent"], width=1)
-                canvas.create_line(x, 18, x + 9, 10, x + 27, 10, x + 18, 18,
-                                   fill="#0b69ff")
-                canvas.create_line(x + 18, 36, x + 27, 28, x + 27, 10, fill="#0848b8")
-        canvas.create_text(24, 25, anchor="w", text="PS2", fill=palette["accent2"],
-                           font=("", 26, "bold"))
-        canvas.create_text(112, 27, anchor="w", text="SERVERS", fill=palette["text"],
-                           font=("", 18, "bold"))
-        canvas.create_text(24, 61, anchor="w",
-                           text="SMBv1  ·  UDPFS  ·  UDPBD  ·  no terminal required",
-                           fill=palette["muted"], font=("", 9))
-
-    def build_banner(self):
-        frame = gui.ttk.Frame(content_parent(self), style="Header.TFrame")
-        frame.pack(fill="x", padx=16, pady=(12, 0))
-        canvas = gui.tk.Canvas(frame, height=88, highlightthickness=0,
-                               bg=palette["bg"], bd=0)
-        canvas.pack(fill="x", expand=True)
-
-        def redraw(event=None):
-            try:
-                draw_banner(canvas, event.width if event else canvas.winfo_width())
-            except gui.tk.TclError:
-                pass
-
-        canvas.bind("<Configure>", redraw)
-        canvas.after_idle(redraw)
-        self._ps2_theme_banner = canvas
-
     def add_admin_panel(self):
         if not gui.windows_setup.is_windows():
             return
@@ -370,7 +329,6 @@ def _apply_gui_review_fixes(gui):
                 child.columnconfigure(2, weight=1)
 
     def launcher_build(self):
-        build_banner(self)
         add_admin_panel(self)
         original_build(self)
         normalize_original_widgets(self)


### PR DESCRIPTION
Addresses two UI notes from testing:

1. **About tab redundancy** — removed the `No-terminal actions` button group (Allow/Remove firewall, Stop all, Restart, Exit); it exactly duplicated the persistent footer, which stays the single home for those actions.
2. **Top banner waste** — removed the decorative app-wide 88px `PS2 SERVERS` canvas banner that sat atop every view.

Also fixed the About text that referenced the removed buttons. Net −61 lines.

Verified: compileall + module import clean, no dangling `build_banner`/`draw_banner`/`_ps2_theme_banner` references, release-compliance passes. (Tkinter layout can't be rendered headless in CI, so a visual once-over on the next build is worth it.)