### PR TITLE
launcher: move control bar to the top (all controls together)

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -476,9 +476,10 @@ class LauncherApp:
 
         self._build_about_tab()
 
-        # footer
+        # Control bar: packed above the notebook (before=self.nb) so all controls
+        # -- LAN IP, admin panel, and these actions -- sit together at the top.
         footer = ttk.Frame(parent, style="Footer.TFrame", padding=(12, 10))
-        footer.pack(fill="x", padx=16, pady=(0, 14))
+        footer.pack(fill="x", padx=16, pady=(0, 8), before=self.nb)
         footer.columnconfigure(2, weight=1)
         allow = ttk.Button(footer, text="Allow through firewall",
                            command=self.allow_windows_setup)


### PR DESCRIPTION
Moves the action bar (Allow through firewall, Remove firewall rules, Stop all, Restart, Exit) from the bottom of the window to the top, above the tabs, so it groups with the LAN-IP selector and the admin panel. Done with `footer.pack(before=self.nb)` — minimal, no relControl logic changed.

Final top-to-bottom layout: admin panel → LAN IP → action bar → tabs (which expand to fill the rest).

Verified: compileall + import clean, compliance passes. (Tkinter layout not renderable headless — worth an eyeball on the next build.)