### PR TITLE
docs: show SMB login as User: guest / Password: blank

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -90,7 +90,8 @@ Address type      IP address      (turn NetBIOS off)
 PC IP Address     the LAN IP the launcher shows after you press Start
 Port              1111
 Share             games
-User / Password   blank (guest)
+User              guest
+Password          leave blank
 
 <b>UDPFS</b>   select UDPFS in OPL; enter the shown server IP only if OPL asks.
 <b>UDPBD</b>   select UDPBD in OPL; the PS2 finds the server automatically — no IP or port.</pre>

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -112,7 +112,7 @@ def opl_hint(key, ip, values):
     if key == "smbv1":
         port = "445" if values.get("take_445") else str(values.get("port") or 1111)
         return ("In OPL → Network:  IP {}  ·  Port {}  ·  Share 'games'  "
-                "·  NetBIOS off  ·  user/pass blank".format(ip, port))
+                "·  NetBIOS off  ·  User 'guest'  ·  Password blank".format(ip, port))
     if key == "udpfs":
         return "In OPL → select UDPFS  ·  server IP {} (if prompted)".format(ip)
     if key == "udpbd":

--- a/smbv1_server/README.md
+++ b/smbv1_server/README.md
@@ -41,7 +41,7 @@ It prints something like:
 
 ```
  RiptOPL SMBv1 server -- listening on 0.0.0.0:1111
- In OPL  ->  SMB Server IP: 192.168.1.50   Port: 1111   user/pass: blank (guest)
+ In OPL  ->  SMB Server IP: 192.168.1.50   Port: 1111   User: guest   Password: blank
             Share: games   ->   D:\PS2Games   (writable)
  (writable -- OPL can save settings + VMC-on-SMB here; pass --read-only to lock it)
 ```
@@ -54,7 +54,8 @@ Then in OPL → **Settings → Network**:
 | PC IP Address    | the LAN IP the server printed          |
 | **Port**         | **1111** (the printed port)            |
 | Share            | `games`                                |
-| User / Password  | **blank** (guest)                      |
+| User             | `guest`                                |
+| Password         | **blank** (leave empty)                |
 
 Save, and your network games should populate from the share.
 

--- a/smbv1_server/smbserver_opl.py
+++ b/smbv1_server/smbserver_opl.py
@@ -11,7 +11,7 @@
 #
 #   python smbserver_opl.py --share games=D:/PS2Games
 #   then in OPL: SMB IP = this PC's LAN IP, SMB Port = 1111 (the printed port), Share = games,
-#   user/pass blank (guest). Read-only by default; pass --writable for VMC-on-SMB.
+#   User = guest, Password = blank. Writable by default (OPL saves + VMC-on-SMB); pass --read-only to lock.
 #
 # License: same as the surrounding RiptOPL project.
 
@@ -916,7 +916,7 @@ def main(argv=None):
     ips = _lan_ips()
     print("=" * 64)
     print(" RiptOPL SMBv1 server -- listening on %s:%d" % (args.bind, bound))
-    print(" In OPL set:  SMB Port: %d   |   user/pass: blank (guest)" % bound)
+    print(" In OPL set:  SMB Port: %d   |   User: guest   Password: blank" % bound)
     if len(ips) == 1:
         print("              PC IP Address: %s" % ips[0])
     else:


### PR DESCRIPTION
Small clarity fix requested off community feedback.

`User / Password: blank (guest)` was ambiguous. The RiptOPL server accepts the guest logon **unconditionally and ignores the username** (`h_session_setup`), so the clearer, still-accurate wording is **User: `guest` · Password: blank**. Updated consistently everywhere it appears:
- `docs/index.html` (the PS2-side values block)
- `smbv1_server/README.md` (OPL settings table + printed example)
- `launcher/gui.py` (`opl_hint` — what the app prints)
- `smbv1_server/smbserver_opl.py` (server's printed hint)

Also fixes a **stale header comment** in `smbserver_opl.py` that claimed "Read-only by default; pass `--writable`" — the actual default is **writable**, with a `--read-only` flag (line 860-861, no `--writable` exists).

Verified: compileall + import clean, compliance passes, website block renders correctly.