### PR TITLE
udpfs(chd): match udpfsd's CD-format predicate (oracle alignment)

### DIFF
--- a/udpfs_server/compressed_iso/chd.py
+++ b/udpfs_server/compressed_iso/chd.py
@@ -255,12 +255,16 @@ class ChdFileWrapper(CompressedFileWrapper):
         self.block_size  = hunk_size
         self._num_blocks = (logical_bytes + hunk_size - 1) // hunk_size
 
-        # CD-format detection: cdlz/cdzl/cdfl codecs + 2448-byte units
+        # CD-format detection, mirroring udpfsd exactly: a CD unit size OR any CD
+        # codec (cdlz/cdzl/cdfl), AND a hunk that is a whole number of 2448-byte
+        # frames. Folding the hunk check into the flag keeps this size math and the
+        # read/extract path (which keys off _is_cd_format) from ever disagreeing.
         self._is_cd_format = (
-            unit_size == _CD_FRAME_SIZE
-            and any(c in _CD_CODECS for c in compressors if c != 0)
+            (unit_size == _CD_FRAME_SIZE
+             or any(c in _CD_CODECS for c in compressors if c != 0))
+            and hunk_size % _CD_FRAME_SIZE == 0
         )
-        if self._is_cd_format and hunk_size % _CD_FRAME_SIZE == 0:
+        if self._is_cd_format:
             self._frames_per_hunk  = hunk_size // _CD_FRAME_SIZE
             total_frames           = self._num_blocks * self._frames_per_hunk
             self.uncompressed_size = total_frames * _USER_DATA

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -180,7 +180,13 @@ def get_compressed_info(file_path: str) -> Optional[Tuple[int, str]]:
                 # We present as 2048-byte/sector ISO, so correct the size.
                 _CD_FRAME_SIZE = 2448
                 _CD_CODECS = (0x63646c7a, 0x63647a6c, 0x6364666c)  # cdlz, cdzl, cdfl
-                if (any(c in _CD_CODECS for c in compressors if c != 0)
+                unit_size = struct.unpack('>I', header[60:64])[0]
+                # Same predicate as the CHD wrapper (compressed_iso/chd.py) and
+                # udpfsd: a CD unit size OR a CD codec, AND whole 2448-byte-frame
+                # hunks -- so the size reported here can never disagree with what
+                # the read path extracts.
+                if ((unit_size == _CD_FRAME_SIZE
+                     or any(c in _CD_CODECS for c in compressors if c != 0))
                         and hunk_size > 0 and hunk_size % _CD_FRAME_SIZE == 0):
                     frames_per_hunk = hunk_size // _CD_FRAME_SIZE
                     total_hunks = (uncompressed_size + hunk_size - 1) // hunk_size


### PR DESCRIPTION
Follow-up to a UDPFS bug hunt prompted by an unconfirmed (deleted) "UDPFS wasn't working" report.

**No client-affecting bug was found.** I compared our released multi-client UDPFS server against pcm720's `udpfsd` (the proven oracle), the Neutrino protocol spec, and the PS2 client across dir-listing, writes, wire format, and compression — zero divergences that affect a real client. I also validated our decoders **byte-exact against udpfsd's own test vectors**: `test.cso`, `test.zso`, and `test_dvd.chd` all decode identically to `test.iso`, and `test_cd.chd` extracts to a clean 544 × 2048 sectors.

This PR closes the **one** real divergence from the oracle — the CHD CD-format predicate:
- The CHD wrapper required `unit_size==2448 **AND** codec`; udpfsd uses `(unit_size==2448 **OR** codec) AND hunk%2448==0`.
- `get_compressed_info` (the size reported in DREAD/GETSTAT/OPEN) checked only the codec, ignoring `unit_size` — so it could disagree with the wrapper.

Both now use udpfsd's exact predicate, so the reported size and the extracted read stream can never disagree. Also removes a latent crash path (CD codec + hunk not a multiple of 2448 previously fell through to CD extraction with an unset `_frames_per_hunk`).

**Impact on real files: none** — this only changes behavior on malformed CHDs that `chdman` never produces. Verified: post-edit, all four udpfsd vectors still decode correctly and the multi-client self-test still passes. Defensive/consistency alignment, not a functional fix.