### PR TITLE
udpfs(win): survive spurious UDP ConnectionResetError (Win11 black-screen fix)

### DIFF
--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -348,7 +348,22 @@ class UdpfsServer:
         self.dsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.dsock.bind((bind_ip, 0))
         self.dsock.setblocking(False)
-        
+
+        # Windows: a UDP recvfrom() raises ConnectionResetError (WinError 10054)
+        # when a *previous* sendto() drew an ICMP port-unreachable -- e.g. the PS2
+        # briefly not reading, or a transient network hiccup. UDP is
+        # connectionless, so these resets are spurious; left uncaught they kill the
+        # receive loop and drop the transfer mid-load (a "black screen on load" on
+        # Win11). SIO_UDP_CONNRESET tells Windows to stop reporting them. Harmless
+        # / unavailable no-op elsewhere.
+        if sys.platform == 'win32':
+            SIO_UDP_CONNRESET = 0x9800000C
+            for _s in (self.sock, self.dsock):
+                try:
+                    _s.ioctl(SIO_UDP_CONNRESET, struct.pack('I', 0))
+                except (OSError, AttributeError, ValueError):
+                    pass
+
         # Multi-client state: one Session per peer address, each with its own
         # protocol state (sequence numbers, handle table, write state) and worker
         # thread. The demultiplexer (run) never blocks on protocol work; per-client
@@ -547,13 +562,19 @@ class UdpfsServer:
                         try:
                             data, addr = self.sock.recvfrom(2048)
                             self._handle_discovery(data, addr)
-                        except BlockingIOError:
+                        except OSError:
+                            # BlockingIOError (no datagram) or a spurious Windows
+                            # ConnectionResetError -- never let one datagram's
+                            # error kill the whole server loop.
                             pass
                     elif ready is self.dsock:
                         try:
                             data, addr = self.dsock.recvfrom(4096)
                             self._route_data(data, addr)
-                        except BlockingIOError:
+                        except OSError:
+                            # BlockingIOError (no datagram) or a spurious Windows
+                            # ConnectionResetError -- never let one datagram's
+                            # error kill the whole server loop.
                             pass
                 self._sweep_idle_sessions()
                 self._emit_metrics()


### PR DESCRIPTION
Investigating a report: "udpfs server on win11 don't work — black screen when game loading."

**Root cause found (Windows-specific):** on Windows a UDP `recvfrom()` raises `ConnectionResetError` (WinError 10054) when a *previous* `sendto()` drew an ICMP port-unreachable — the PS2 briefly not reading, a client going away, or a transient hiccup. UDP is connectionless so these are spurious, but the receive loop caught only `BlockingIOError`, so it propagated out of `run()` and **killed the server thread**, dropping every client mid-load. That presents exactly as "black screen on load" on Win11.

**Fix (two layers):**
- `SIO_UDP_CONNRESET` on both UDP sockets so Windows stops raising it.
- Catch `OSError` at both `recvfrom` sites as a backstop.

**Verified:** a client abandoning a transfer mid-stream reproduced the 10054 crash before this change; after it, the server shrugs it off and a fresh client still reads byte-exact. Multi-client self-test still passes. Confirmed via a loopback repro on Windows.

Note: the pure-Python UDPBD server likely shares this pattern and may want the same guard (separate follow-up).