### PR TITLE
udpfs(win): non-ASCII filenames no longer crash the log & stall the PS2 (black-screen fix)

### DIFF
--- a/launcher/serve.py
+++ b/launcher/serve.py
@@ -29,7 +29,13 @@ def run_serve(key, server_args):
     # letting Python block-buffer them (works in both source and frozen builds).
     for stream in (sys.stdout, sys.stderr):
         try:
-            stream.reconfigure(line_buffering=True)
+            # line_buffering: prints reach our captured pipe line-by-line.
+            # errors='backslashreplace': never raise UnicodeEncodeError when a
+            # filename/path holds characters outside the console's legacy code
+            # page (e.g. Polish 'l-stroke' on a cp1252 console). Such a crash
+            # mid-handler would drop a directory-listing reply and stall the PS2
+            # -- an empty game list / black screen on Windows.
+            stream.reconfigure(line_buffering=True, errors='backslashreplace')
         except (AttributeError, ValueError):
             pass
 

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -630,11 +630,23 @@ class UdpfsServer:
         self._status_visible = True
 
     def _print_event(self, msg: str):
-        """Print an event message, clearing the status line first"""
+        """Print an event message, clearing the status line first.
+
+        Never raises: a filename/path with characters outside the console's code
+        page (e.g. Polish 'l-stroke' on a cp1252 console) must not abort the
+        calling handler -- doing so would skip the reply sent after this log line
+        and stall the PS2 (empty game list / black screen). Belt-and-suspenders
+        alongside the stream-level errors='backslashreplace' set in serve.py, so
+        standalone runs (python udpfs_server.py ...) are covered too.
+        """
         if self._status_visible:
             sys.stdout.write(f"\r{'':<79}\r")
             self._status_visible = False
-        print(msg)
+        try:
+            print(msg)
+        except UnicodeEncodeError:
+            enc = sys.stdout.encoding or 'ascii'
+            print(msg.encode(enc, 'backslashreplace').decode(enc, 'replace'))
 
     def _cleanup(self):
         """Close the shared block device (each session closes its own handles)."""


### PR DESCRIPTION
**Confirmed on real hardware.** A Polish user (NHDDL couldn't load a gameslist) hit:
```
session error: UnicodeEncodeError: 'charmap' codec can't encode character 'ł' in position 42
```
(`ł` = U+0142, Polish l-stroke.)

**Root cause:** the server logs every directory entry with `print()`, which on Windows encodes to the console's legacy code page (cp1252) with `errors='strict'`. A filename with a character outside that page raised `UnicodeEncodeError` **inside `_handle_dread`, before `_send_dread_reply`** — so the PS2 never got that entry's reply and the listing **stalled** (empty game list / black screen on load). The DREAD reply is fine on the wire (names are UTF-8 encoded); only the console log crashed. This is why NHDDL couldn't build a gameslist while wLaunchELF (browsing differently) got further.

**Fix (two layers):**
- `serve.py`: reconfigure the server process's `stdout`/`stderr` with `errors='backslashreplace'` — no `print` can ever raise. Covers **every** server (SMB, UDPFS, UDPBD).
- `udpfs_server._print_event`: catch `UnicodeEncodeError` and re-emit ASCII-safe, so even a standalone `python udpfs_server.py` run can't have a log line abort a handler.

**Verified:** a cp1252-strict console reproduces the crash on `ł`; both the hardened `_print_event` and the reconfigured stream survive it; multi-client self-test still passes. Builds on the earlier Win11 `ConnectionResetError` fix (#69).