### PR TITLE
ci: main auto-builds publish as pre-releases (stop the Latest-badge race)

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -274,8 +274,15 @@ jobs:
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: PS2 Servers ${{ steps.tag.outputs.tag }}
+          # Rolling dev builds must never outrank tagged releases: publish as
+          # pre-release so GitHub's "Latest" badge always stays on the newest
+          # tagged vX.Y.Z release (a same-day merge repeatedly stole it).
+          prerelease: true
+          make_latest: false
           body: |
-            Automatic release from `main`.
+            Automatic development build from `main`, published as a
+            **pre-release**. For stable downloads use the
+            [latest tagged release](https://github.com/NathanNeurotic/PS2-Servers/releases/latest).
 
             Commit: ${{ github.sha }}
 


### PR DESCRIPTION
Three tagged releases in a row (v0.1.9, v0.2.0, v0.2.1) had their **Latest** badge stolen by the `main-NN` auto-build published minutes later, because GitHub marks the most recently *created* non-prerelease as Latest and a same-day merge always builds right behind the tag.

- `release-on-main.yml` now publishes with `prerelease: true` + `make_latest: false`, and the release body says it's a rolling dev build pointing users at `releases/latest` for stable downloads.
- All 23 existing `main-*` releases were retroactively flipped to pre-release (done directly; verified `v0.2.1` holds Latest).

Workflow-only change; no shipped code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)