### PR TITLE
udpfs: Modulo UDPFS mode (--single-port) + pinnable data port

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -194,7 +194,10 @@ class ServerCard(ttk.LabelFrame):
         ttk.Label(parent, text=f.label + ":", style="Card.TLabel").grid(
             row=row, column=0, sticky="w", padx=4, pady=2)
         if f.kind == "port":
-            var = tk.StringVar(value=self.server.port_display())
+            # A port field with a falsy default (0/None) means "auto": leave the box
+            # blank. Prefilling the server's own listen port would be wrong, and for
+            # a data port it would collide with the discovery socket.
+            var = tk.StringVar(value=self.server.port_display() if f.default else "")
             ttk.Entry(parent, textvariable=var, width=12).grid(
                 row=row, column=1, sticky="w", padx=6, pady=2)
         elif f.kind in ("folder", "file"):

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -159,12 +159,16 @@ def _udpfs_argv(v):
         args += ["--block-device", v["block_device"]]
     if v.get("port"):
         args += ["--port", str(v["port"])]
+    if v.get("data_port"):
+        args += ["--data-port", str(v["data_port"])]
     if v.get("bind"):
         args += ["--bind", str(v["bind"])]
     if v.get("read_only"):
         args.append("--read-only")
     if v.get("enable_compression"):
         args.append("--enable-compression")
+    if v.get("single_port"):
+        args.append("--single-port")
     if v.get("verbose"):
         args.append("--verbose")
     return args
@@ -228,9 +232,22 @@ UDPFS = ServerDef(
               help="On by default so CHD/CSO/ZSO images appear as playable .iso "
               "(needs lz4 for ZSO, libchdr for CHD; formats without their library "
               "are simply left as-is). Untick to serve files without decompression."),
+        Field("single_port", "Modulo UDPFS mode", "bool", default=False, advanced=True,
+              help="Only needed for Modulo. Modulo's client does not follow the "
+                   "standard UDPFS discovery handshake — it cannot switch to the "
+                   "server's data port — so this serves all UDPFS traffic on the "
+                   "single Port set below (default 0xF5F6) instead. This is a Modulo "
+                   "bug; every other client (NHDDL, RiptOPL, POPSTARTER, POPSLOADER, "
+                   "wLaunchELF-R3Z) works without it. Leave off unless you use Modulo."),
         Field("read_only", "Read-only", "bool", default=False, advanced=True),
         Field("port", "Port", "port", default=0xF5F6, advanced=True,
-              help="UDP port (default 0xF5F6)."),
+              help="UDP port (default 0xF5F6). In Modulo UDPFS mode this single "
+                   "port carries everything."),
+        Field("data_port", "Data port", "port", default=0, advanced=True,
+              help="Leave 0 (auto) unless the data port must be predictable — a "
+                   "manual firewall rule, port forwarding, or a strict NAT can't "
+                   "follow the auto port, which changes every launch. Setting it "
+                   "also adds a matching firewall rule. Ignored in Modulo mode."),
         Field("bind", "Bind address", "text", default="", advanced=True),
         Field("verbose", "Verbose logging", "bool", default=False, advanced=True),
     ],

--- a/launcher/windows_setup.py
+++ b/launcher/windows_setup.py
@@ -112,7 +112,14 @@ def _server_ports(key, values):
         port = 445 if values.get("take_445") else _parse_port(values.get("port"), 1111)
         return [("TCP", port, "SMBv1")]
     if key == "udpfs":
-        return [("UDP", _parse_port(values.get("port"), 0xF5F6), "UDPFS discovery")]
+        ports = [("UDP", _parse_port(values.get("port"), 0xF5F6), "UDPFS discovery")]
+        # The data socket is normally ephemeral and covered by the program-wide
+        # "PS2 Servers - App" rule. When the user pins it, allow it by port too so
+        # the setting is usable behind manual/port-based firewall rules.
+        data_port = _parse_port(values.get("data_port"), 0)
+        if data_port:
+            ports.append(("UDP", data_port, "UDPFS data"))
+        return ports
     if key == "udpbd":
         return [("UDP", UDPBD_PORT, "UDPBD")]
     return []

--- a/udpfs_server/multiclient_selftest.py
+++ b/udpfs_server/multiclient_selftest.py
@@ -191,9 +191,10 @@ def _free_udp_port():
     return port
 
 
-def _start_server(root_dir, disc_port, block_device=None):
+def _start_server(root_dir, disc_port, block_device=None, single_port=False):
     server = srv.UdpfsServer(root_dir=root_dir, block_device=block_device,
-                             port=disc_port, bind_ip='127.0.0.1')
+                             port=disc_port, bind_ip='127.0.0.1',
+                             single_port=single_port)
     t = threading.Thread(target=server.run, daemon=True)
     t.start()
     time.sleep(0.4)  # let the select loop come up
@@ -226,6 +227,43 @@ def test_baseline(root, disc_port, files):
                   f" (equal={got == expected})")
             ok = False
     print("  BASELINE PASSED" if ok else "  BASELINE FAILED")
+    return ok
+
+
+def test_single_port(root, files):
+    """--single-port compatibility mode: DISCOVERY *and* DATA must both work on
+    the one discovery port, and the INFORM must advertise that same port (so a
+    client that never leaves the discovery port still completes the handshake).
+    This is what the launcher's 'Modulo UDPFS mode' turns on."""
+    print("Single-port compatibility mode:")
+    disc_port = _free_udp_port()
+    server = _start_server(root, disc_port, single_port=True)
+    ok = True
+    try:
+        name, expected = next(iter(files.items()))
+        c = UdpfsTestClient(('127.0.0.1', disc_port))
+        try:
+            c.discover()
+            # The whole point: the advertised data port IS the discovery port.
+            if c.data_addr[1] == disc_port:
+                print(f"  INFORM ok: data port == discovery port ({disc_port})")
+            else:
+                print(f"  INFORM FAIL: advertised data port {c.data_addr[1]},"
+                      f" expected discovery port {disc_port}")
+                ok = False
+            got = c.read_file(name, len(expected))
+        finally:
+            c.close()
+        if got == expected:
+            print(f"  READ  ok: '{name}' ({len(expected)} bytes) served entirely"
+                  f" over port {disc_port}")
+        else:
+            print(f"  READ  FAIL: got {len(got)} bytes, expected {len(expected)}")
+            ok = False
+    finally:
+        server._shutdown = True
+        time.sleep(0.3)
+    print("  SINGLE-PORT PASSED" if ok else "  SINGLE-PORT FAILED")
     return ok
 
 
@@ -348,6 +386,8 @@ def main():
                           {k: files[k] for k in ("fileA.bin", "fileB.bin")}) and ok
     print()
     ok = test_block_concurrency(disc_port, image_bytes, sector_size) and ok
+    print()
+    ok = test_single_port(tmp, {"fileA.bin": files["fileA.bin"]}) and ok
 
     print()
     print("ALL UDPFS TESTS PASSED" if ok else "UDPFS TESTS FAILED")

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -345,7 +345,9 @@ class UdpfsServer:
                  compression_cache_size: int = 32,
                  peer_timeout: float = SESSION_TIMEOUT,
                  metrics: bool = False,
-                 metrics_period: float = 60.0):
+                 metrics_period: float = 60.0,
+                 single_port: bool = False,
+                 data_port: int = 0):
         self.root_dir = os.path.realpath(root_dir) if root_dir else None
         self.port = port
         self.bind_ip = bind_ip
@@ -357,10 +359,20 @@ class UdpfsServer:
         self.session_timeout = peer_timeout
         self.metrics = metrics
         self.metrics_period = metrics_period
+        self.single_port = single_port
         self._last_metrics = time.monotonic()
 
         if self.root_dir and not os.path.isdir(self.root_dir):
             print(f"Error: '{root_dir}' is not a directory")
+            sys.exit(1)
+
+        # Two sockets on one port is not a shared-port mode -- SO_REUSEADDR lets
+        # both bind and then splits arriving datagrams between them, which silently
+        # breaks discovery. Refuse it and point at the mode that does this properly.
+        if not single_port and data_port and data_port == port:
+            print(f"Error: --data-port 0x{data_port:04X} is the same as the discovery "
+                  f"port. Pick a different data port, or use --single-port to serve "
+                  f"discovery and data on one port.")
             sys.exit(1)
 
         # Discovery socket, broadcast UDP
@@ -370,11 +382,25 @@ class UdpfsServer:
         self.sock.bind(('', port))
         self.sock.setblocking(False)
 
-        # Data socket
-        self.dsock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self.dsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.dsock.bind((bind_ip, 0))
-        self.dsock.setblocking(False)
+        if single_port:
+            # Compatibility mode: carry DISCOVERY *and* DATA on the one discovery
+            # port instead of handing the client off to a separate ephemeral data
+            # socket. Aliasing dsock to sock makes every send (INFORM included)
+            # leave from the discovery port, and makes _send_inform advertise that
+            # same port as the data port -- so a client that cannot follow the
+            # normal two-port handshake never has to move. Costs nothing but the
+            # per-peer port isolation, which nothing here relies on.
+            self.dsock = self.sock
+        else:
+            # Data socket. Port 0 = ephemeral (the default): fine when the app's
+            # own firewall rule allows the program on any port. Pin it with
+            # --data-port when the data endpoint has to be predictable -- manual
+            # firewall rules, port forwarding, or a restrictive NAT can't follow a
+            # port that changes every launch.
+            self.dsock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            self.dsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.dsock.bind((bind_ip, data_port))
+            self.dsock.setblocking(False)
 
         # Windows: a UDP recvfrom() raises ConnectionResetError (WinError 10054)
         # when a *previous* sendto() drew an ICMP port-unreachable -- e.g. the PS2
@@ -569,7 +595,10 @@ class UdpfsServer:
                   f"sector_size={self.bd_sector_size}")
         print(f"  Discovery bind: 0.0.0.0:{self.port} (0x{self.port:04X})")
         addr, port = self.dsock.getsockname()
-        print(f"  Data bind: {addr}:{port} (0x{port:04X})")
+        if self.single_port:
+            print(f"  Data bind: {addr}:{port} (0x{port:04X}) [single-port mode]")
+        else:
+            print(f"  Data bind: {addr}:{port} (0x{port:04X})")
         print(f"  Mode: {'read-only' if self.read_only else 'read-write'}")
         if self.enable_compression:
             formats = [ext[1:].upper() for ext in COMPRESSED_EXTENSIONS]
@@ -579,12 +608,24 @@ class UdpfsServer:
         print()
         while not self._shutdown:
             try:
-                r, _, _ = select.select([self.sock, self.dsock], [], [], 1.0)
+                socks = [self.sock] if self.single_port else [self.sock, self.dsock]
+                r, _, _ = select.select(socks, [], [], 1.0)
                 for ready in r:
                     if ready is self.sock:
                         try:
-                            data, addr = self.sock.recvfrom(2048)
-                            self._handle_discovery(data, addr)
+                            if self.single_port:
+                                # One socket carries both packet types here, so
+                                # dispatch on the UDPRDMA type instead of on which
+                                # socket it arrived from.
+                                data, addr = self.sock.recvfrom(4096)
+                                if (len(data) >= 2 and Header.unpack(data).packet_type
+                                        == PacketType.DISCOVERY):
+                                    self._handle_discovery(data, addr)
+                                else:
+                                    self._route_data(data, addr)
+                            else:
+                                data, addr = self.sock.recvfrom(2048)
+                                self._handle_discovery(data, addr)
                         except OSError:
                             # BlockingIOError (no datagram) or a spurious Windows
                             # ConnectionResetError -- never let one datagram's
@@ -2153,6 +2194,19 @@ def main():
         help='Number of decompressed blocks to cache per file (default: 32; env: COMPRESSION_CACHE_SIZE)'
     )
     parser.add_argument(
+        '--data-port', type=lambda x: int(x, 0), default=_env_int('DATA_PORT', 0),
+        help='Pin the UDP data port instead of using an ephemeral one (default: 0 = '
+             'auto). Use when the data endpoint must be predictable for a manual '
+             'firewall rule, port forwarding, or NAT. Ignored with --single-port '
+             '(env: DATA_PORT)'
+    )
+    parser.add_argument(
+        '--single-port', action='store_true', default=_env_bool('SINGLE_PORT'),
+        help='Serve DISCOVERY and DATA on the one discovery port instead of handing '
+             'clients off to a separate data port. Compatibility mode for clients that '
+             'cannot follow the standard two-port UDPFS handshake (env: SINGLE_PORT)'
+    )
+    parser.add_argument(
         '--peer-timeout', type=float, default=_env_float('PEER_TIMEOUT', SESSION_TIMEOUT),
         help=f'Seconds of client inactivity before its session is reaped '
              f'(default: {int(SESSION_TIMEOUT)}; env: PEER_TIMEOUT)'
@@ -2199,7 +2253,9 @@ def main():
         compression_cache_size=args.compression_cache_size,
         peer_timeout=args.peer_timeout,
         metrics=args.metrics,
-        metrics_period=args.metrics_period
+        metrics_period=args.metrics_period,
+        single_port=args.single_port,
+        data_port=args.data_port
     )
     server.run()
 


### PR DESCRIPTION
Two **opt-in** UDPFS options. Defaults are byte-identical to v0.2.1 — nothing existing changes.

## Modulo UDPFS mode (`--single-port`)
UDPFS answers DISCOVERY on the discovery port then hands the client to a separate ephemeral data socket, which the client must find via the INFORM's UDP source address. Modulo's client can't do that — it loops DISCOVERY/INFORM and never issues a DOPEN, so its users can't browse a share at all. This mode aliases the data socket to the discovery socket so a client that never leaves the discovery port still completes the handshake.

Not a Modulo-only shim: strict NATs, PCSX2's DEV9 backend, and port-based firewalls all struggle with the two-port dance. The launcher hint names the five clients that work without it (NHDDL, RiptOPL, POPSTARTER, POPSLOADER, wLaunchELF-R3Z) so users know it's a Modulo bug, not a server requirement.

## Data port (`--data-port`)
The data socket was always ephemeral — a manual firewall rule, port forward, or strict NAT could never follow it; it only worked via the program-wide "PS2 Servers - App" rule. Pinning it also adds a matching `UDPFS data` firewall rule.

## Regression fix this exposed
`_add_field` pre-filled **every** port-kind field with the server's own listen port (`port_display()` reads `ServerDef.default_port`, never `Field.default`). The new field would have rendered pre-filled with `0xF5F6` — the discovery port — passing `--data-port 62966` and binding **both sockets to the same port** (SO_REUSEADDR permits it), splitting arriving datagrams and silently breaking discovery for every user on launch. Port fields with a falsy default now render blank (= auto); the two pre-existing fields have truthy defaults and are unchanged. The server also now refuses `data_port == port` instead of binding both.

## Verification
3-agent adversarial pass tried to disprove "defaults are unchanged" and failed on all three lenses. A/B against v0.2.1: INFORM bytes identical (`1100f5f50000`), two-port handshake preserved, 200 KB read sha256 identical across 6 runs, argv + firewall rules unchanged — including upgrading from a saved v0.2.1 config. New selftest covers single-port mode. Full suite green.

⚠️ Merging publishes a rolling **pre-release** for hardware testing. v0.2.1 remains Latest; no version bump until Modulo is confirmed on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)