### PR TITLE
launcher: typeable LAN IP, and unhide the Modulo checkbox

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -467,8 +467,13 @@ class LauncherApp:
         ttk.Label(header, text="LAN IP", font=("", 10, "bold"),
                   style="TopStripTitle.TLabel").grid(row=0, column=0, sticky="w")
         self.ip_var = tk.StringVar(value=netinfo.best_lan_ip())
+        # Editable, not readonly: detection leans on getaddrinfo(gethostname()),
+        # which misses or mis-ranks addresses on hosts with VPN/Hyper-V/WSL/Docker
+        # adapters or a second NIC. When the right address is not in the list the
+        # user has to be able to type it. This value only feeds the OPL hint text
+        # -- what a server binds to is its own Bind address field.
         self.ip_combo = ttk.Combobox(header, textvariable=self.ip_var, width=18,
-                                     values=netinfo.all_ipv4(), state="readonly")
+                                     values=netinfo.all_ipv4(), state="normal")
         self.ip_combo.grid(row=0, column=1, sticky="w", padx=(10, 6))
         ttk.Button(header, text="Refresh", command=self._refresh_ips).grid(
             row=0, column=2, sticky="w")
@@ -1026,8 +1031,12 @@ class LauncherApp:
         servers = self.saved.get("servers", {})
         for key, card in self.cards.items():
             card.set_values(servers.get(key, {}))
+        # An auto-detected IP is only restored if this host still has it, so moving
+        # between networks re-detects instead of showing a stale address. A typed
+        # one is restored unconditionally -- it is not in all_ipv4() by definition,
+        # so the same check would throw it away on every launch.
         ip = self.saved.get("ip")
-        if ip and ip in netinfo.all_ipv4():
+        if ip and (ip in netinfo.all_ipv4() or self.saved.get("ip_custom")):
             self.ip_var.set(ip)
         self.close_to_tray_var.set(
             self._saved_bool("close_to_tray", self.close_to_tray_var.get()))
@@ -1038,6 +1047,8 @@ class LauncherApp:
               pending_firewall_allow=False):
         data = {"servers": {key: card.values() for key, card in self.cards.items()},
                 "ip": self.ip_var.get(),
+                # Not one of ours => the user typed it. See _restore.
+                "ip_custom": self.ip_var.get() not in netinfo.all_ipv4(),
                 "close_to_tray": bool(self.close_to_tray_var.get()),
                 "minimize_to_tray": bool(self.minimize_to_tray_var.get())}
         if pending_start:

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -232,12 +232,15 @@ UDPFS = ServerDef(
               help="On by default so CHD/CSO/ZSO images appear as playable .iso "
               "(needs lz4 for ZSO, libchdr for CHD; formats without their library "
               "are simply left as-is). Untick to serve files without decompression."),
-        Field("single_port", "Modulo UDPFS mode", "bool", default=False, advanced=True,
-              help="Tick this only for Modulo. Modulo's client ignores the UDPFS "
-                   "discovery handshake and can't switch to the server's data port, "
-                   "so this serves everything on the single Port below. Modulo's bug "
-                   "— NHDDL, RiptOPL, POPSTARTER, POPSLOADER and wLaunchELF-R3Z all "
-                   "work without it."),
+        # Deliberately NOT advanced: the users who need this are the least likely
+        # to go looking under a disclosure triangle for it.
+        Field("single_port", "Check this if you are using Modulo", "bool",
+              default=False,
+              help="Only tick this for Modulo. Modulo uses improper UDPFS protocol "
+                   "— it can't switch to the server's data port — so everything runs "
+                   "on one port (0xF5F6 by default, set under Advanced). Modulo's "
+                   "bug: NHDDL, RiptOPL, POPSTARTER, POPSLOADER and wLaunchELF-R3Z "
+                   "all work without it."),
         Field("read_only", "Read-only", "bool", default=False, advanced=True),
         Field("port", "Port", "port", default=0xF5F6, advanced=True,
               help="UDP port (default 0xF5F6). In Modulo UDPFS mode this single "


### PR DESCRIPTION
## Two user requests: typeable LAN IP, and Modulo out of hiding

### Custom LAN IP — the box was `state="readonly"`

You could only pick an address auto-detection found. Detection leans on
`getaddrinfo(gethostname())` plus a UDP-connect probe, which misses or mis-ranks
addresses on any host with a VPN, Hyper-V, WSL, Docker, or a second NIC. The dev
box alone reports `172.22.48.1` (virtual), `192.168.1.100`, and `192.168.1.160`.
When the right address isn't in the list, there was no way to say so — the OPL
hint then tells the user to type an IP that doesn't work.

**Nothing is removed — typing is additive.** `readonly` and `normal` are the same
dropdown with one restriction lifted:

| | dropdown | typing |
|---|---|---|
| `readonly` (before) | yes | **no** |
| `normal` (now) | yes | **yes** |

Verified the list still populates, still preselects `best_lan_ip()` (correctly
skipping the `172.22.x` virtual adapter), still selects, and Refresh still
re-detects.

**The `_restore` guard was the real work.** It restored a saved IP only if it was
still in `all_ipv4()` — which a typed address never is, by definition. An editable
box *alone* would have looked implemented and silently reverted to auto-detect on
every launch. Saved IPs now carry `ip_custom`, so typed addresses persist while
auto-detected ones keep the stale-address check that re-detects on network change.

Scope: this value only feeds the OPL hint text. It does **not** change what a
server binds to — that's the per-server Bind address field — so it cannot affect
discovery.

### Modulo checkbox out of Advanced

The users who need it are the least likely to find it behind a disclosure
triangle. Now on the main UDPFS card as **"Check this if you are using Modulo"**,
still default-off. Its hint names the port outright (`0xF5F6`) since Port itself
stays under Advanced.

## Verification

- `single_port` is primary, default-off; hint renders at 2 lines, doesn't clip
- typed `10.77.77.5` round-trips a restart; stale auto IP still re-detects
- dropdown intact: list, preselect, selection, Refresh
- all 14 help strings still render, none crosses the 1000px edge
- suite green: compliance, multiclient, compression, pathguard
- **auto-discovery untouched** — default argv still bare `--root-dir R`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
