### PR TITLE
Address gemini review: ip_custom must use the pick-list, not a fresh probe

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -1033,10 +1033,12 @@ class LauncherApp:
             card.set_values(servers.get(key, {}))
         # An auto-detected IP is only restored if this host still has it, so moving
         # between networks re-detects instead of showing a stale address. A typed
-        # one is restored unconditionally -- it is not in all_ipv4() by definition,
-        # so the same check would throw it away on every launch.
+        # one is restored unconditionally -- it is not in the detected list by
+        # definition, so the same check would throw it away on every launch.
+        # The combo's values are what _build already detected; re-running
+        # all_ipv4() here would block the startup path on getaddrinfo for nothing.
         ip = self.saved.get("ip")
-        if ip and (ip in netinfo.all_ipv4() or self.saved.get("ip_custom")):
+        if ip and (ip in self.ip_combo["values"] or self.saved.get("ip_custom")):
             self.ip_var.set(ip)
         self.close_to_tray_var.set(
             self._saved_bool("close_to_tray", self.close_to_tray_var.get()))
@@ -1047,8 +1049,13 @@ class LauncherApp:
               pending_firewall_allow=False):
         data = {"servers": {key: card.values() for key, card in self.cards.items()},
                 "ip": self.ip_var.get(),
-                # Not one of ours => the user typed it. See _restore.
-                "ip_custom": self.ip_var.get() not in netinfo.all_ipv4(),
+                # Not in the pick-list => the user typed it. See _restore.
+                # Must be the combo's values, not a fresh all_ipv4(): _save runs on
+                # every minimize/close-to-tray, so it would block the UI on
+                # getaddrinfo -- and worse, an address that vanished since startup
+                # (roamed, DHCP, cable out) would be misread as hand-typed and then
+                # persist forever, defeating the stale check above.
+                "ip_custom": self.ip_var.get() not in self.ip_combo["values"],
                 "close_to_tray": bool(self.close_to_tray_var.get()),
                 "minimize_to_tray": bool(self.minimize_to_tray_var.get())}
         if pending_start:


### PR DESCRIPTION
## Address gemini-code-assist review on #79: `ip_custom` must use the pick-list

Two findings on the custom-IP code from #79, both flagging `netinfo.all_ipv4()`
doing blocking I/O (DNS via `getaddrinfo`, plus a UDP routing probe) on the Tk
main thread. Both valid — and the first hides a correctness bug Gemini didn't name.

### The perf argument (Gemini's, valid)

`_save()` runs on `_hide_to_tray`, `_on_unmap` (**every minimize-to-tray**), every
start/stop, and every tray toggle — routine interaction paths, not just exit. A
blocking `getaddrinfo` there can stall the UI. `_restore()`'s call was outright
redundant: `_build_scroll_body()` (line 327) already detected and populated the
combo before `_restore()` (line 330) runs.

### The correctness bug (the real reason to take it)

`ip_custom` was computed from a **fresh** probe at save time. So:

1. user **picks** `192.168.1.160` from the dropdown — not custom
2. network changes (DHCP / roam / cable out)
3. user minimizes → `_save()` re-probes → `.160` is gone → `ip_custom=True`
4. a **picked** address is now permanently misfiled as hand-typed and restored
   unconditionally forever — defeating the stale-address check that guard exists
   to preserve

Proven before fixing:

```
old: picked 192.168.1.160 -> {'ip_custom': True}  -> restart: '192.168.1.160'  (stale, sticks)
new: picked 192.168.1.160 -> {'ip_custom': False} -> restart: '<re-detected>'   (correct)
     typed  10.77.77.5    -> {'ip_custom': True}  -> restart: '10.77.77.5'      (persists)
```

`self.ip_combo["values"]` is also the *semantically* correct source: `ip_custom`
asks "typed or picked?", and the pick-list is definitionally what could be picked.

## Verification

- no `all_ipv4()` left on `_save` / `_restore`; detection stays in `_build` / `_refresh_ips`
- picked-then-stale IP now re-detects; typed IP still survives a restart
- dropdown intact: list, preselect, selection, Refresh
- all 14 help strings still render, none crosses the 1000px edge
- suite green: compliance, multiclient, compression, pathguard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
