### PR TITLE
udpfs: expose the idle timeout, and fix the 300s parity bug

### DIFF
--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -145,6 +145,11 @@ def _parse_seconds(raw):
         value = int(float(text))
     except ValueError:
         return None
+    except OverflowError:
+        # float() takes "inf"/"infinity"/"1e400" happily and int() then refuses
+        # them. Someone reaching for a way to switch the timeout off will type
+        # exactly that, so it must not throw out of build_argv.
+        return None
     return value if value > 0 else None
 
 

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -130,6 +130,24 @@ class ServerDef:
 # --------------------------------------------------------------------------- #
 # Argument builders (values dict -> server CLI args)
 # --------------------------------------------------------------------------- #
+def _parse_seconds(raw):
+    """A whole-second count from a text field, or None to leave it to the server.
+
+    The server clamps the range and owns the default; this only rejects what is
+    not a number at all, so a typo can't become an argv the server must guess at.
+    """
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    try:
+        value = int(float(text))
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
 def _smbv1_argv(v):
     args = ["--share", "games={}".format(v["games_folder"])]
     if v.get("port"):
@@ -163,6 +181,11 @@ def _udpfs_argv(v):
         args += ["--data-port", str(v["data_port"])]
     if v.get("bind"):
         args += ["--bind", str(v["bind"])]
+    # Blank/garbage means "leave it alone" -- the server owns the default and the
+    # clamp, so don't pass a flag we'd only have to second-guess here.
+    timeout = _parse_seconds(v.get("peer_timeout"))
+    if timeout is not None:
+        args += ["--peer-timeout", str(timeout)]
     if v.get("read_only"):
         args.append("--read-only")
     if v.get("enable_compression"):
@@ -251,6 +274,13 @@ UDPFS = ServerDef(
                    "follow the auto port, which changes every launch. Setting it "
                    "also adds a matching firewall rule. Ignored in Modulo mode."),
         Field("bind", "Bind address", "text", default="", advanced=True),
+        Field("peer_timeout", "Idle timeout (seconds)", "text", default="3600",
+              advanced=True,
+              help="Drop a console after this long with no traffic, closing the "
+                   "files it had open (60-86400, default 3600 = 1 hour). UDPFS has "
+                   "no disconnect, so a paused game and an unplugged PS2 look "
+                   "identical — set it too low and a long pause loses its game. "
+                   "Lower it only to clear stale consoles faster."),
         Field("verbose", "Verbose logging", "bool", default=False, advanced=True),
     ],
     _build_argv=_udpfs_argv,

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -326,8 +326,13 @@ def _clamp_peer_timeout(seconds, warn=True):
         value = float(seconds)
     except (TypeError, ValueError):
         value = SESSION_TIMEOUT
-    if value != value:  # NaN: every comparison below would be False, so it would
-        value = SESSION_TIMEOUT  # sail through the clamp and disable reaping.
+    except OverflowError:
+        # An int too big for a float (10**1000) is still a number, just an
+        # unrepresentable one, so clamp it by sign like inf/-inf rather than
+        # silently resetting it to the default and ignoring what was asked for.
+        value = SESSION_TIMEOUT_MAX if seconds > 0 else SESSION_TIMEOUT_MIN
+    if math.isnan(value):  # every comparison against NaN is False, so it would
+        value = SESSION_TIMEOUT  # sail through the clamp and disable reaping
     clamped = min(max(value, SESSION_TIMEOUT_MIN), SESSION_TIMEOUT_MAX)
     if warn and clamped != value:
         print(f"Warning: --peer-timeout {value:g} is outside the supported "

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -130,7 +130,22 @@ MAX_DATA_PAYLOAD = 1408  # Maximum UDPRDMA payload
 MAX_HANDLES = 64  # open handles per client (matches udpfsd; was 32 originally)
 
 # Multi-client session management
-SESSION_TIMEOUT = 300.0          # default seconds of peer inactivity before reaping (see --peer-timeout)
+#
+# A reap closes the peer's open file handles (see Session._run), and UDPFS has no
+# DISCONNECT packet -- DISCOVERY/INFORM/DATA is the whole protocol -- so a paused
+# console and a powered-off one are indistinguishable: both simply go quiet. The
+# timeout is therefore a guess about which one we are looking at, and guessing
+# wrong on a paused game costs the player their handles. Default matches upstream
+# udpfsd (1 hour), which is field-proven and forgiving of idle play and long
+# transfers. It cannot be disabled: without it, every console reboot strands a
+# session (thread + queue + handles) until the server exits.
+SESSION_TIMEOUT = 3600.0         # default seconds of peer inactivity before reaping (see --peer-timeout)
+# Floor: 12x SESSION_SWEEP_INTERVAL (a reap is only ever +/-5s accurate) and 12x
+# the client's own 5s udprdma_recv timeout, so a peer mid-operation can never be
+# reaped. Ceiling: past a day it is "never" in all but name, and each stranded
+# session holds a thread and up to MAX_HANDLES descriptors.
+SESSION_TIMEOUT_MIN = 60.0
+SESSION_TIMEOUT_MAX = 86400.0
 SESSION_SWEEP_INTERVAL = 5.0     # how often the demux loop checks for idle sessions
 HAS_PREAD = hasattr(os, 'pread')     # POSIX: lock-free positional block-device reads
 HAS_PWRITE = hasattr(os, 'pwrite')
@@ -305,6 +320,22 @@ class DataHeader:
         return struct.pack('<I', val)
 
 
+def _clamp_peer_timeout(seconds, warn=True):
+    """Hold --peer-timeout inside [SESSION_TIMEOUT_MIN, SESSION_TIMEOUT_MAX]."""
+    try:
+        value = float(seconds)
+    except (TypeError, ValueError):
+        value = SESSION_TIMEOUT
+    if value != value:  # NaN: every comparison below would be False, so it would
+        value = SESSION_TIMEOUT  # sail through the clamp and disable reaping.
+    clamped = min(max(value, SESSION_TIMEOUT_MIN), SESSION_TIMEOUT_MAX)
+    if warn and clamped != value:
+        print(f"Warning: --peer-timeout {value:g} is outside the supported "
+              f"{SESSION_TIMEOUT_MIN:g}-{SESSION_TIMEOUT_MAX:g}s range; "
+              f"using {clamped:g}.")
+    return clamped
+
+
 class FileHandle:
     """Represents an open file handle on the server"""
     def __init__(self, obj, is_dir: bool = False):
@@ -356,7 +387,12 @@ class UdpfsServer:
         self.verbose = verbose
         self.enable_compression = enable_compression
         self.compression_cache_size = compression_cache_size
-        self.session_timeout = peer_timeout
+        # Clamped here rather than in argparse so the CLI, PEER_TIMEOUT and the
+        # launcher all get the same bounds. Clamp instead of reject: a bad number
+        # should not stop someone from serving their games. 0 is NOT "disabled" --
+        # it would reap every peer at the next sweep -- so it clamps up like any
+        # other out-of-range value.
+        self.session_timeout = _clamp_peer_timeout(peer_timeout)
         self.metrics = metrics
         self.metrics_period = metrics_period
         self.single_port = single_port
@@ -2208,7 +2244,11 @@ def main():
     )
     parser.add_argument(
         '--peer-timeout', type=float, default=_env_float('PEER_TIMEOUT', SESSION_TIMEOUT),
-        help=f'Seconds of client inactivity before its session is reaped '
+        help=f'Seconds of client inactivity before its session is reaped, closing '
+             f'the files it had open. Clamped to '
+             f'{int(SESSION_TIMEOUT_MIN)}-{int(SESSION_TIMEOUT_MAX)}; 0 does not '
+             f'disable it (there is nothing to disable -- a stranded session holds '
+             f'a thread and its handles until the server exits) '
              f'(default: {int(SESSION_TIMEOUT)}; env: PEER_TIMEOUT)'
     )
     parser.add_argument(

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -585,10 +585,19 @@ class UdpfsServer:
             return
         self._last_sweep = now
         with self.sessions_lock:
-            idle = [a for a, s in self.sessions.items()
+            idle = [(a, now - s.last_activity) for a, s in self.sessions.items()
                     if now - s.last_activity > self.session_timeout]
-            for a in idle:
+            for a, quiet in idle:
                 self.sessions.pop(a).shutdown()
+                # Not verbose-gated. A reap tells the client nothing (no packet
+                # exists to tell it with) and takes its open handles and their
+                # read positions with it, so if that console was only paused, its
+                # next read fails against a session that no longer knows it. This
+                # line is the sole trace anyone gets of why.
+                self._print_event(
+                    f"[{a[0]}:{a[1]}] idle {quiet:.0f}s > peer-timeout "
+                    f"{self.session_timeout:.0f}s -- dropped, its open files "
+                    f"closed (raise --peer-timeout if it was only paused)")
 
     def _emit_metrics(self):
         """Periodically log transfer/op stats when --metrics is enabled."""


### PR DESCRIPTION
## Expose the UDPFS idle timeout, and fix the 300s parity bug

Requested by R3Z3N (author of wLaunchELF-R3Z): let users drop consoles that have
gone quiet. He had pcm720 add the same knob to udpfsd, and runs 600s himself
because he has 4 PS2s sharing one IP.

The server **already** reaped idle sessions (`--peer-timeout`, `PEER_TIMEOUT`) —
the launcher just never exposed it, so nobody could set it. Now it's a field:
always present, no toggle.

### The 300s default was a bug, not a decision

`056335c` — titled **"UDPFS: complete udpfsd parity"** — ported upstream's
constants. It got `MAX_HANDLES` right (`64  # matches udpfsd; was 32 originally`)
and set the timeout to **300 where udpfsd uses 3600**. Nothing in the code,
comments, or history ever justified 300. Raising it finishes what that commit
meant to do.

*(Upstream's hour is per R3Z3N, who had pcm720 add the feature — secondhand, not
read from udpfsd source.)*

| implementation | timeout |
|---|---|
| pcm720 udpfsd | 3600s |
| R3Z3N runs | 600s (deliberately lowered, for stale cleanup) |
| **ours, before this** | **300s — tightest of the three** |

### Why it mattered: the reap is auto-forget, not auto-disconnect

A reap closes the peer's open handles and resets its sequence state, and **sends
the client nothing** — no FIN, no reset, no error. There is no packet in the
protocol to send. So a game paused past the timeout doesn't reconnect; it fails
on the next read against a session that no longer knows it.

It's unrecoverable by design: `_handle_read` is `fh.obj.read(size)` with **no
offset** — the READ packet carries only `handle, size`, and the seek position
lives solely on the server (mutated by LSEEK). A reap destroys the only copy of
the stream position, and the protocol cannot rebuild it. `next_handle` restarts
at 1, so a re-OPEN can return *the same handle number that just died*, masking
the failure. Partial buffered writes are dropped with no WRITE_DONE.

Block-device mode is largely immune (handle 0 is re-seeded from the shared
`bd_fh`; BREAD/BWRITE are positional). **UDPFS file mode — RiptOPL loading by
path — is the exposed case.** That is the reporter's configuration.

### Why it can't be turned off

UDPFS is `DISCOVERY`/`INFORM`/`DATA` end to end. No disconnect packet, no
keepalive. A paused console and an unplugged one are byte-identical to us — both
just go quiet. Without a timeout, every reboot strands a session until the server
exits. So it's bounded at both ends instead of optional:

- **min 60s** — 12× `SESSION_SWEEP_INTERVAL` (the effective deadline is
  `peer_timeout` → `peer_timeout+5s`, since the sweep is what notices) and 12× the
  client's own 5s `udprdma_recv` timeout, so a peer mid-operation can never be
  reaped. R3Z3N's 600 passes straight through.
- **max 86400** — past a day it's "never" in all but name.

`0` is **not** "disabled" and never was: `session_timeout=0` reaps every peer at
the next sweep. It clamps up like any other out-of-range value. Nothing in the
repo passed 0, so no caller changes meaning.

Clamping lives in `__init__`, **not** `argparse`'s `type=` — that would silently
skip the `PEER_TIMEOUT` env path. It warns rather than exits: a bad number
shouldn't stop someone serving their games. NaN is special-cased — every
comparison against it is False, so it would sail through the clamp and silently
disable reaping.

### The reap now says so

It was silent in both directions — the client can't be told, and the operator got
no log line either, so the failure had no trace anywhere. Not verbose-gated; the
person who needs it is the one who doesn't know the setting exists.

```
[192.168.1.100:5678] idle 4000s > peer-timeout 3600s -- dropped, its open files
closed (raise --peer-timeout if it was only paused)
```

## Verification

- clamp table: `0 / -5 / 1 / 59.9 / 60 / 600 / 3600 / 86400 / 999999 / inf / NaN / "abc" / None`
- clamp is reached via `__init__`, not just argparse
- argv omits the flag when blank/garbage/≤0, so the server keeps ownership of the default
- a real sweep reaps a 120s-idle session and spares a 5s-idle one at `timeout=60`
- the log line fires once, naming peer + idle + timeout + flag; silent for the active peer
- **auto-discovery untouched** — default argv still bare `--root-dir R`
- long flags only (Nuitka self-execution guard)
- suite green: compliance, multiclient, compression, pathguard
- all 15 help strings render, none crosses the 1000px edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
