### PR TITLE
udpfs: --modulo-mode, parity with the server bundled in Modulo's own repo

### DIFF
--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -195,8 +195,9 @@ def _udpfs_argv(v):
         args.append("--read-only")
     if v.get("enable_compression"):
         args.append("--enable-compression")
-    if v.get("single_port"):
-        args.append("--single-port")
+    if v.get("modulo_mode"):
+        # Implies --single-port server-side; passing both would be redundant.
+        args.append("--modulo-mode")
     if v.get("verbose"):
         args.append("--verbose")
     return args
@@ -262,11 +263,12 @@ UDPFS = ServerDef(
               "are simply left as-is). Untick to serve files without decompression."),
         # Deliberately NOT advanced: the users who need this are the least likely
         # to go looking under a disclosure triangle for it.
-        Field("single_port", "Check this if you are using Modulo", "bool",
+        Field("modulo_mode", "Check this if you are using Modulo", "bool",
               default=False,
-              help="Only tick this for Modulo. Modulo uses improper UDPFS protocol "
-                   "— it can't switch to the server's data port — so everything runs "
-                   "on one port (0xF5F6 by default, set under Advanced). Modulo's "
+              help="Only tick this for Modulo. Modulo uses improper UDPFS protocol, "
+                   "and only ever worked against the patched server bundled in its "
+                   "own repo — so this serves everything on one port (0xF5F6, under "
+                   "Advanced) and answers exactly the way that server does. Modulo's "
                    "bug: NHDDL, RiptOPL, POPSTARTER, POPSLOADER and wLaunchELF-R3Z "
                    "all work without it."),
         Field("read_only", "Read-only", "bool", default=False, advanced=True),

--- a/launcher/windows_setup.py
+++ b/launcher/windows_setup.py
@@ -117,8 +117,9 @@ def _server_ports(key, values):
         # "PS2 Servers - App" rule. When the user pins it, allow it by port too so
         # the setting is usable behind manual/port-based firewall rules. Skipped in
         # single-port mode, where the server ignores data_port entirely -- a rule
-        # there would open a port nothing ever listens on.
-        if not values.get("single_port"):
+        # there would open a port nothing ever listens on. Modulo mode implies
+        # single-port, so it takes the same branch.
+        if not values.get("modulo_mode"):
             data_port = _parse_port(values.get("data_port"), 0)
             if data_port:
                 ports.append(("UDP", data_port, "UDPFS data"))

--- a/udpfs_server/multiclient_selftest.py
+++ b/udpfs_server/multiclient_selftest.py
@@ -26,6 +26,10 @@ import time
 
 import udpfs_server as srv  # sys.path[0] is this dir when run as a script
 
+# The reap test never waits this out (it backdates the clocks instead); it only
+# has to be a value the server's own clamp accepts unchanged.
+SESSION_TIMEOUT_TEST = 60.0
+
 
 # --------------------------------------------------------------------------- #
 # Minimal in-process UDPFS/UDPRDMA client
@@ -104,8 +108,11 @@ class UdpfsTestClient:
             return dh, data[6:6 + payload_size]
 
     # -- protocol operations ----------------------------------------------
-    def discover(self):
-        pkt = (srv.Header(srv.PacketType.DISCOVERY, 0).pack()
+    def discover(self, seq=0):
+        """DISCOVERY -> INFORM. seq lets a test pose as a peer whose counter did
+        not start at 0 (Modulo does exactly that); it does not touch self.tx_seq,
+        because a conformant peer still opens its data stream at 0."""
+        pkt = (srv.Header(srv.PacketType.DISCOVERY, seq).pack()
                + srv.DiscHeader(srv.UDPRDMA_SVC_UDPFS, 0).pack())
         self.sock.sendto(pkt, self.disc_addr)
         deadline = time.monotonic() + 5.0
@@ -117,7 +124,10 @@ class UdpfsTestClient:
             if hdr.packet_type != srv.PacketType.INFORM:
                 continue
             disc = srv.DiscHeader.unpack(data[2:6])
-            self.data_addr = (self.disc_addr[0], disc.port)
+            # A zeroed port field means "use the INFORM's UDP source port", which is
+            # what udpfsd documents and what --modulo-mode sends.
+            self.data_addr = ((self.disc_addr[0], disc.port) if disc.port
+                              else addr)
             return
         raise UdpfsError("no INFORM reply to DISCOVERY")
 
@@ -191,10 +201,12 @@ def _free_udp_port():
     return port
 
 
-def _start_server(root_dir, disc_port, block_device=None, single_port=False):
+def _start_server(root_dir, disc_port, block_device=None, single_port=False,
+                  peer_timeout=srv.SESSION_TIMEOUT, modulo_compat=False):
     server = srv.UdpfsServer(root_dir=root_dir, block_device=block_device,
                              port=disc_port, bind_ip='127.0.0.1',
-                             single_port=single_port)
+                             single_port=single_port, peer_timeout=peer_timeout,
+                             modulo_compat=modulo_compat)
     t = threading.Thread(target=server.run, daemon=True)
     t.start()
     time.sleep(0.4)  # let the select loop come up
@@ -264,6 +276,164 @@ def test_single_port(root, files):
         server._shutdown = True
         time.sleep(0.3)
     print("  SINGLE-PORT PASSED" if ok else "  SINGLE-PORT FAILED")
+    return ok
+
+
+def test_modulo_mode(root, files):
+    """--modulo-mode: parity with the patched server bundled in Modulo's own repo.
+
+    Modulo's client keeps ONE monotonic sequence for its whole life and never
+    restarts it at 0 -- observed on hardware climbing 8,9,10,11,12 straight across
+    a full server restart. Our conformant path (and udpfsd's) only resets on seq 0,
+    so it NACKs such a peer forever. Modulo's server resyncs off the DISCOVERY, and
+    this mode does the same. Asserted both ways: a seq-8 peer must connect here, and
+    must still be refused by default, or the deviation has leaked into the five
+    clients that work today.
+    """
+    print("Modulo compatibility mode:")
+    name, expected = next(iter(files.items()))
+    ok = True
+
+    for modulo, want_ok in ((True, True), (False, False)):
+        disc_port = _free_udp_port()
+        server = _start_server(root, disc_port, single_port=True, modulo_compat=modulo)
+        try:
+            c = UdpfsTestClient(('127.0.0.1', disc_port))
+            try:
+                # Pose as Modulo: DISCOVERY at 7, data stream carrying on at 8.
+                # Its counter never was 0, so the reset-on-seq-0 path cannot save it.
+                c.discover(seq=7)
+                c.tx_seq = 8
+                if modulo:
+                    # Modulo's INFORM is packet 0 of the server's OWN tx stream (it
+                    # informs at tx_seq_nr, then increments), so the first reply back
+                    # is seq 1 -- unlike the conformant INFORM, which is a constant 1
+                    # outside the stream and leaves the server's first reply at 0.
+                    c.rx_expected = 1
+                try:
+                    got = c.read_file(name, len(expected)) == expected
+                except Exception:
+                    got = False
+            finally:
+                c.close()
+        finally:
+            server._shutdown = True
+            time.sleep(0.3)
+
+        label = "--modulo-mode" if modulo else "default"
+        if got == want_ok:
+            print("  %-14s seq-8 peer %s  ok" % (
+                label, "served" if got else "refused (udpfsd parity kept)"))
+        else:
+            print("  %-14s FAIL: seq-8 peer %s, expected %s" % (
+                label, "served" if got else "refused",
+                "served" if want_ok else "refused"))
+            ok = False
+
+    print("  MODULO-MODE PASSED" if ok else "  MODULO-MODE FAILED")
+    return ok
+
+
+def test_peer_timeout_clamp():
+    """--peer-timeout is clamped, never obeyed blindly. 0 is the one that matters:
+    it reads as 'off' but the sweep would reap every peer within 5s, so it must
+    clamp UP. nan is the other: every comparison with it is False, so an unclamped
+    nan would silently disable reaping."""
+    print("Peer-timeout clamp:")
+    cases = [
+        (3600.0, 3600.0), (60.0, 60.0), (86400.0, 86400.0),   # in range, untouched
+        (600.0, 600.0),                                        # R3Z3N's value
+        (0.0, 60.0), (-1.0, 60.0), (5.0, 60.0),                # would reap live peers
+        (1e9, 86400.0), (float('inf'), 86400.0),               # "never" in all but name
+        (float('nan'), 3600.0),                                # would disable the sweep
+    ]
+    ok = True
+    for given, want in cases:
+        got = srv._clamp_peer_timeout(given, warn=False)
+        if got != want:
+            print(f"  FAIL: peer_timeout={given!r} clamped to {got!r}, expected {want!r}")
+            ok = False
+    if ok:
+        print(f"  CLAMP ok: {len(cases)} values held inside "
+              f"{srv.SESSION_TIMEOUT_MIN:g}-{srv.SESSION_TIMEOUT_MAX:g}s "
+              f"(0/-1/nan cannot disable or over-tighten the reap)")
+    print("  CLAMP PASSED" if ok else "  CLAMP FAILED")
+    return ok
+
+
+def test_peer_timeout_reap(root, files):
+    """The idle reap, asserted without waiting a timeout out.
+
+    The sweep decides from two clocks -- the session's last_activity and the
+    server's _last_sweep -- so backdating both drives the REAL
+    _sweep_idle_sessions() to the same decision it would reach after peer_timeout
+    seconds of silence. Sleeping it out is not an option: the default is an hour,
+    and SESSION_TIMEOUT_MIN forbids configuring one short enough to wait for.
+    """
+    print("Idle-session reap (--peer-timeout):")
+    ok = True
+    disc_port = _free_udp_port()
+    server = _start_server(root, disc_port, peer_timeout=SESSION_TIMEOUT_TEST)
+    try:
+        name = next(iter(files))
+        c = UdpfsTestClient(('127.0.0.1', disc_port))
+        try:
+            c.discover()
+            handle, _size = c.open(name)
+            with server.sessions_lock:
+                live = list(server.sessions.items())
+            # Not a formality: a sweep that reaps unconditionally empties this
+            # before the assertions below, and StopIteration here would crash the
+            # suite instead of reporting which behaviour broke.
+            if len(live) != 1:
+                print(f"  SETUP FAIL: expected 1 session after OPEN, got {len(live)}"
+                      f" -- the sweep is reaping peers it should not")
+                return False
+            addr, sess = live[0]
+            fh = sess.handles.get(handle)
+            if fh is None or fh.obj.closed:
+                print("  SETUP FAIL: no open file handle to observe")
+                return False
+
+            # A peer inside its window must survive an otherwise-identical sweep.
+            # Without this, a reap test passes even if the sweep reaps everything.
+            server._last_sweep -= srv.SESSION_SWEEP_INTERVAL
+            server._sweep_idle_sessions()
+            with server.sessions_lock:
+                kept = addr in server.sessions
+            if kept:
+                print("  KEEP  ok: a peer inside its window survives a sweep")
+            else:
+                print("  KEEP  FAIL: an active session was reaped")
+                ok = False
+
+            # Age it past the timeout: the same sweep must now drop it.
+            with server.sessions_lock:
+                sess.last_activity -= (server.session_timeout + 1.0)
+            server._last_sweep -= srv.SESSION_SWEEP_INTERVAL
+            server._sweep_idle_sessions()
+            with server.sessions_lock:
+                reaped = addr not in server.sessions
+            sess._thread.join(timeout=2.0)
+            if reaped and not sess._thread.is_alive():
+                print(f"  REAP  ok: peer idle > {server.session_timeout:g}s dropped,"
+                      f" worker thread exited")
+            else:
+                print(f"  REAP  FAIL: reaped={reaped},"
+                      f" worker_alive={sess._thread.is_alive()}")
+                ok = False
+
+            # The point of the reap: the files the peer held are released.
+            if fh.obj.closed and not sess.handles:
+                print("  FREE  ok: reaped session closed the file it had open")
+            else:
+                print(f"  FREE  FAIL: closed={fh.obj.closed}, handles={sess.handles}")
+                ok = False
+        finally:
+            c.close()
+    finally:
+        server._shutdown = True
+    print("  REAP PASSED" if ok else "  REAP FAILED")
     return ok
 
 
@@ -388,6 +558,12 @@ def main():
     ok = test_block_concurrency(disc_port, image_bytes, sector_size) and ok
     print()
     ok = test_single_port(tmp, {"fileA.bin": files["fileA.bin"]}) and ok
+    print()
+    ok = test_modulo_mode(tmp, {"fileA.bin": files["fileA.bin"]}) and ok
+    print()
+    ok = test_peer_timeout_clamp() and ok
+    print()
+    ok = test_peer_timeout_reap(tmp, {"fileA.bin": files["fileA.bin"]}) and ok
 
     print()
     print("ALL UDPFS TESTS PASSED" if ok else "UDPFS TESTS FAILED")

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -383,7 +383,13 @@ class UdpfsServer:
                  metrics: bool = False,
                  metrics_period: float = 60.0,
                  single_port: bool = False,
+                 modulo_compat: bool = False,
                  data_port: int = 0):
+        # Modulo's client only ever talked to Modulo's own bundled server, which is
+        # single-socket, so the two always travel together.
+        if modulo_compat:
+            single_port = True
+        self.modulo_compat = modulo_compat
         self.root_dir = os.path.realpath(root_dir) if root_dir else None
         self.port = port
         self.bind_ip = bind_ip
@@ -401,6 +407,11 @@ class UdpfsServer:
         self.metrics = metrics
         self.metrics_period = metrics_period
         self.single_port = single_port
+        # Only ever sent in modulo_compat: its server advertises a friendly name in
+        # the INFORM so its loader can label the source. Shares stay empty, matching
+        # its CLI server (only its GUI wrapper ever fills them in).
+        self.server_name = socket.gethostname().split('.')[0]
+        self.share_names: List[str] = []
         self._last_metrics = time.monotonic()
 
         if self.root_dir and not os.path.isdir(self.root_dir):
@@ -993,9 +1004,17 @@ class UdpfsServer:
         self.stats['discovery'] += 1
 
         # Ensure a per-client session (and its worker thread) exists for this peer.
-        self._get_or_create_session(addr)
+        sess = self._get_or_create_session(addr)
+        if self.modulo_compat:
+            # Modulo's client keeps one monotonic sequence for its whole life -- it
+            # never restarts at 0, not even across a server restart -- so the
+            # reset-on-seq-0 path below never fires for it and every packet is NACKed
+            # forever. Its own server resyncs off the DISCOVERY instead, so do that.
+            # Assigned on the session, not through the _session_prop proxies: we are
+            # on the demux thread, where _local.session is unset.
+            sess.rx_seq_nr_expected = (hdr.seq_nr + 1) & 0xFFF
         self._print_event(f"[{addr[0]}:{addr[1]}] DISCOVERY -> INFORM")
-        self._send_inform(addr)
+        self._send_inform(addr, sess)
 
     def _handle_data(self, data: bytes, addr: Tuple[str, int]):
         """Handle DATA packet containing UDPFS message"""
@@ -1707,8 +1726,35 @@ class UdpfsServer:
 
     # --- Send helpers ---
 
-    def _send_inform(self, addr: Tuple[str, int]):
+    def _info_payload(self) -> bytes:
+        """Name + shares trailer that Modulo's server appends to its INFORM.
+
+        Byte-for-byte parity with it: length-prefixed name, length-prefixed shares,
+        padded to a multiple of 4 because the PS2 reads the SMAP RX FIFO in 32-bit
+        words. Only sent in modulo_compat -- udpfsd and every conformant client
+        expect a bare 6-byte INFORM.
+        """
+        name = (self.server_name or '')[:31].encode('utf-8', 'ignore')
+        shares_str = ', '.join(self.share_names) if self.share_names else ''
+        shares = shares_str[:95].encode('utf-8', 'ignore')
+        payload = bytes([len(name)]) + name + bytes([len(shares)]) + shares
+        if len(payload) % 4:
+            payload += b'\x00' * (4 - len(payload) % 4)
+        return payload
+
+    def _send_inform(self, addr: Tuple[str, int], sess=None):
         """Send INFORM packet"""
+        if self.modulo_compat and sess is not None:
+            # Modulo's server informs from its running tx_seq_nr, leaves the second
+            # DiscHeader field 0 (its client takes the data port from the INFORM's
+            # UDP source port, as udpfsd documents), and appends the name trailer.
+            hdr = Header(packet_type=PacketType.INFORM, seq_nr=sess.tx_seq_nr)
+            disc = DiscHeader(service_id=UDPRDMA_SVC_UDPFS, port=0)
+            self._sendto(hdr.pack() + disc.pack() + self._info_payload(), addr)
+            sess.tx_seq_nr = (sess.tx_seq_nr + 1) & 0xFFF
+            sess.tx_seq_nr_acked = (sess.tx_seq_nr - 1) & 0xFFF  # the INFORM we just sent
+            return
+
         hdr = Header(packet_type=PacketType.INFORM, seq_nr=1) # INFORM sequence number is always 1
         disc = DiscHeader(service_id=UDPRDMA_SVC_UDPFS, port = self.dsock.getsockname()[1])
 
@@ -2257,6 +2303,15 @@ def main():
              'cannot follow the standard two-port UDPFS handshake (env: SINGLE_PORT)'
     )
     parser.add_argument(
+        '--modulo-mode', action='store_true', default=_env_bool('MODULO_MODE'),
+        help='Compatibility mode for Modulo, whose client only ever worked against '
+             'the patched single-socket server bundled in its own repo: serve on one '
+             'port, resync the peer sequence off its DISCOVERY, and send that '
+             "server's INFORM (running seq_nr, zeroed port field, name trailer). "
+             'Implies --single-port. Deviates from udpfsd on purpose -- leave it off '
+             'for every other client (env: MODULO_MODE)'
+    )
+    parser.add_argument(
         '--peer-timeout', type=float, default=_env_float('PEER_TIMEOUT', SESSION_TIMEOUT),
         help=f'Seconds of client inactivity before its session is reaped, closing '
              f'the files it had open. Clamped to '
@@ -2309,6 +2364,7 @@ def main():
         metrics=args.metrics,
         metrics_period=args.metrics_period,
         single_port=args.single_port,
+        modulo_compat=args.modulo_mode,
         data_port=args.data_port
     )
     server.run()

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -409,8 +409,13 @@ class UdpfsServer:
         self.single_port = single_port
         # Only ever sent in modulo_compat: its server advertises a friendly name in
         # the INFORM so its loader can label the source. Shares stay empty, matching
-        # its CLI server (only its GUI wrapper ever fills them in).
-        self.server_name = socket.gethostname().split('.')[0]
+        # its CLI server (only its GUI wrapper ever fills them in). gethostname can
+        # raise on a container or a host with no resolvable name, and this runs for
+        # everyone -- a cosmetic label must not stop a server nobody asked to name.
+        try:
+            self.server_name = socket.gethostname().split('.')[0]
+        except OSError:
+            self.server_name = 'UDPFS'
         self.share_names: List[str] = []
         self._last_metrics = time.monotonic()
 
@@ -1734,9 +1739,15 @@ class UdpfsServer:
         words. Only sent in modulo_compat -- udpfsd and every conformant client
         expect a bare 6-byte INFORM.
         """
+        # Sliced in chars like Modulo's, but shares is sliced AFTER encoding: 95
+        # chars of 4-byte UTF-8 is 380 bytes and bytes([380]) raises. Modulo's has
+        # that landmine too (its GUI wrapper is what fills shares in), and matching
+        # a crash is not parity worth having. name needs no such guard -- 31 chars
+        # cannot exceed 124 bytes -- and byte-slicing it would only add a way to
+        # split a character mid-sequence.
         name = (self.server_name or '')[:31].encode('utf-8', 'ignore')
         shares_str = ', '.join(self.share_names) if self.share_names else ''
-        shares = shares_str[:95].encode('utf-8', 'ignore')
+        shares = shares_str.encode('utf-8', 'ignore')[:95]
         payload = bytes([len(name)]) + name + bytes([len(shares)]) + shares
         if len(payload) % 4:
             payload += b'\x00' * (4 - len(payload) % 4)


### PR DESCRIPTION
## `--modulo-mode`: parity with the server bundled in Modulo's own repo

Modulo's repo ships the server its client was actually built against
(`udpfs_server/udpfs_server.py`). It's an old fork of **ours** — none of
`single_port`, `peer_timeout`, or `COMPRESSED_EXTENSIONS` — patched in two places
to accommodate a non-conformant client. Reading it alongside pcm720's udpfsd ends
the guesswork:

| `_handle_discovery` | INFORM sent from | DISCOVERY syncs seq? |
|---|---|---|
| **udpfsd** (upstream) | `s.dataConn` | **no** — `ProcessDiscoveryPacket` is a pure function |
| **ours** | data socket | **no** |
| **Modulo's bundled server** | its one socket | **yes** — `rx_seq_nr_expected = hdr.seq_nr + 1` |

**Modulo's client would fail against pcm720's udpfsd too**, not just ours. It keeps
one monotonic sequence for its whole life — hardware shows `8, 9, 10, 11, 12`
climbing straight across a **full server restart** — and every conformant server
resets only on `seq == 0`, so it gets NACKed forever. Its dev patched the server
instead of the client. `git log -S` confirms that sync line never existed here; we
didn't regress it.

### Both earlier diagnoses were right; neither was sufficient alone

`--single-port` genuinely fixed the port handoff — which is *why* hardware finally
reached DATA — and that exposed the sequence lockout hiding behind it.

### What `--modulo-mode` does

Parity with that bundled server, all five deviations:

- resync `rx_seq_nr_expected` off the DISCOVERY
- INFORM at the running `tx_seq_nr`, not the conformant constant `1`
- INFORM's second `DiscHeader` field zeroed (its client takes the data port from the
  INFORM's UDP **source port**, as udpfsd documents)
- INFORM carries the name trailer: length-prefixed name + shares, padded to 4 —
  the PS2 reads the SMAP RX FIFO in 32-bit words
- `tx_seq_nr_acked` left at the INFORM it just sent

It implies `--single-port`, since that server only ever had one socket.

### Deliberately NOT folded into `--single-port`

That flag stays protocol-neutral for NAT/PCSX2/firewall users who want one
predictable port with a **normal** handshake — handing them Modulo's quirks would
break their conformant clients. The GUI checkbox maps to `--modulo-mode`;
`--single-port` remains available standalone.

*Side effect:* the field key changed `single_port` → `modulo_mode`, so an existing
ticked box comes back unticked once.

### Implementation note

Discovery writes the session object directly rather than through the
`_session_prop` proxies — it runs on the demux thread, where `_local.session` is
unset and the proxies wouldn't resolve.

## Verification

`multiclient_selftest` now runs a peer that DISCOVERYs at 7 and opens its stream at
8 — never 0, exactly like Modulo on hardware:

```
--modulo-mode  seq-8 peer served  ok
default        seq-8 peer refused (udpfsd parity kept)  ok
```

**Both directions asserted**, so the deviation cannot leak into the five clients
that work today (wLaunchELF-R3Z is proven healthy in the very log that motivated
this). Default INFORM stays byte-identical: 6 bytes, `seq=1`, data port, no payload.

Also verified: INFORM payload matches Modulo's byte-for-byte (`034d534900000000`);
`modulo_compat` implies `single_port`; no phantom data-port firewall rule; argv
long-flags-only (Nuitka guard); auto-discovery argv still bare `--root-dir`.

Suite green: compliance, multiclient, compression, pathguard.

**Caveat:** this is parity with their server *as read from source*, verified against
a test client modelling Modulo's behaviour. Whether their actual ELF agrees is the
hardware test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
