### PR TITLE
launcher: stop the firewall check from starting a UAC loop it cannot exit

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -315,6 +315,7 @@ class LauncherApp:
         self.out_queue = queue.Queue()
         self.logs = {}
         self.saved = config.load()
+        self._firewall_ok = set()   # _restore fills it; never read before it exists
         self._tray = None
         self._tray_option_widgets = []
         self.close_to_tray_var = tk.BooleanVar(
@@ -641,6 +642,17 @@ class LauncherApp:
             card.toggle_btn.config(text=text)
 
     def _begin_windows_setup_check(self, key, values):
+        # Windows charges for this by the machine's total rule count, not by how
+        # many rules we ask about: tens of seconds on a box with a thousand of
+        # them, every single start. Once an exe+ports combination has come back
+        # clean there is nothing to re-learn, so skip it until that changes.
+        fingerprint = windows_setup.setup_fingerprint(key, values)
+        if fingerprint and fingerprint in self._firewall_ok:
+            self._append_log(
+                key, "[setup] firewall already allowed for this app and ports\n")
+            self._launch_server(key, values)
+            return
+
         self._set_card_busy(key, True, "Checking")
         self._append_log(key, "[setup] checking Windows Firewall setup\n")
 
@@ -653,15 +665,23 @@ class LauncherApp:
             except Exception as e:
                 error = str(e)
             self.root.after(0, lambda: self._handle_windows_setup_check(
-                key, values, setup_needed, error, notes))
+                key, values, setup_needed, error, notes, fingerprint))
 
         threading.Thread(target=worker, daemon=True).start()
 
-    def _handle_windows_setup_check(self, key, values, setup_needed, error=None, notes=None):
+    def _handle_windows_setup_check(self, key, values, setup_needed, error=None,
+                                    notes=None, fingerprint=None):
         for note in (notes or []):
             self._append_log(key, "[setup] {}\n".format(note))
         if error:
             self._append_log(key, "[setup] Windows setup check failed; elevation will retry: {}\n".format(error))
+
+        # Remember a clean answer so the next start skips the scan. Only a real
+        # clean one: an error means we never learned anything, and a timeout means
+        # we gave up rather than confirmed.
+        if fingerprint and not setup_needed and not error \
+                and not any("timed out" in n for n in (notes or [])):
+            self._remember_firewall_ok(fingerprint)
 
         take_445 = key == "smbv1" and bool(values.get("take_445"))
         admin_required = setup_needed or take_445
@@ -939,8 +959,23 @@ class LauncherApp:
 
         self._cleanup_windows_setup_async()
 
+    def _remember_firewall_ok(self, fingerprint):
+        if fingerprint in self._firewall_ok:
+            return
+        self._firewall_ok.add(fingerprint)
+        self._save()
+
+    def _forget_firewall_ok(self):
+        """Drop every cached clean answer: the rules behind them are gone."""
+        if not self._firewall_ok:
+            return
+        self._firewall_ok.clear()
+        self._save()
+
     def _cleanup_windows_setup_async(self):
         self._append_log("setup", "[setup] removing PS2 Servers firewall rules\n")
+        # The cache says "these rules exist and match". They are about to not.
+        self._forget_firewall_ok()
 
         def worker():
             try:
@@ -1037,6 +1072,10 @@ class LauncherApp:
         # definition, so the same check would throw it away on every launch.
         # The combo's values are what _build already detected; re-running
         # all_ipv4() here would block the startup path on getaddrinfo for nothing.
+        # Fingerprints whose firewall state we have already confirmed clean. A
+        # stale one only costs a rescan, never a wrong answer: the fingerprint
+        # changes whenever the exe or ports do.
+        self._firewall_ok = set(self.saved.get("firewall_ok") or [])
         ip = self.saved.get("ip")
         if ip and (ip in self.ip_combo["values"] or self.saved.get("ip_custom")):
             self.ip_var.set(ip)
@@ -1049,6 +1088,7 @@ class LauncherApp:
               pending_firewall_allow=False):
         data = {"servers": {key: card.values() for key, card in self.cards.items()},
                 "ip": self.ip_var.get(),
+                "firewall_ok": sorted(getattr(self, "_firewall_ok", ())),
                 # Not in the pick-list => the user typed it. See _restore.
                 # Must be the combo's values, not a fresh all_ipv4(): _save runs on
                 # every minimize/close-to-tray, so it would block the UI on

--- a/launcher/windows_setup.py
+++ b/launcher/windows_setup.py
@@ -15,17 +15,21 @@ from .servers import frozen_self_exe, is_frozen
 
 UDPBD_PORT = 0xBDBD
 FIREWALL_RULE_PREFIX = "PS2 Servers - "
-# Windows Firewall queries are far slower than they look, and the cost scales with
-# how many rules the machine has -- not with how many we ask about. Measured on a
-# 1091-rule Windows 11 box, cold, in a fresh powershell.exe:
-#   Get-NetFirewallRule per name (what we used to do)   48.1s
-#   one wildcard Get-NetFirewallRule                    69.2s   (batching is WORSE)
-#   HNetCfg.FwPolicy2 COM, one pass                     16.8s   (but 48.5s under load)
-# At 30s the check timed out, needs_setup fell back to "assume setup is needed",
-# the elevated apply blew the same budget, and nothing was ever fixed -- an
+# Windows Firewall queries are far slower than they look, and almost none of the
+# cost is the query. Measured on a 1091-rule Windows 11 box, in a fresh
+# powershell.exe, asking about two rules:
+#   Get-NetFirewallRule per name (what we used to do)   48.1s cold
+#   one wildcard Get-NetFirewallRule                    69.2s cold (batching is WORSE)
+#   HNetCfg.FwPolicy2                                   16.8s cold ... 1.2s warm
+# The same COM script measured 16.8s, then 48.5s, then 1.2s across one session:
+# what actually costs tens of seconds is the firewall service's rule store being
+# cold, not walking it. That is why this was intermittent -- the first start after
+# a boot paid it and later ones did not -- and why no rewrite of the query fixes
+# it. At 30s the cold path timed out, needs_setup fell back to "assume setup is
+# needed", the elevated apply blew the same budget, and nothing was ever fixed: an
 # un-exitable UAC loop on a machine whose rules were already correct. The check
-# runs on a worker thread and only delays a server start, so a budget that cannot
-# be blown by a slow machine is worth far more than a tight one.
+# runs on a worker thread and only delays a server start, so a budget a slow
+# machine cannot blow is worth far more than a tight one.
 POWERSHELL_TIMEOUT = 120
 
 
@@ -212,10 +216,14 @@ def needs_setup(key, values, log=None):
     rule_array = "@({})".format(",".join(_ps_quote(n) for n in port_rule_names))
     program = _ps_quote(os.path.abspath(_server_program_path()))
     app_rule = _ps_quote("PS2 Servers - App")
-    # One COM pass over the rule set, not one Get-NetFirewallRule per name. Same
-    # answers (verified against a missing app rule, a missing port rule, a stale
-    # program path, and both missing) at a third of the cost -- see the note on
-    # POWERSHELL_TIMEOUT for why that gap decides whether this works at all.
+    # COM, looking each rule up by name, rather than Get-NetFirewallRule per name.
+    # Same answers -- verified against a missing app rule, a missing port rule, a
+    # stale program path, and both missing.
+    #
+    # Rules.Item() raises when a name is absent, so absence is the catch, not a
+    # return value. It also returns only one rule per name where iterating saw
+    # every match; apply_setup removes by name before creating, so duplicates do
+    # not accumulate.
     script = "\n".join([
         "$svc = Get-Service -Name mpssvc -ErrorAction SilentlyContinue",
         "if ($svc -and $svc.Status -ne 'Running') {",
@@ -225,20 +233,17 @@ def needs_setup(key, values, log=None):
         "$appProgram = {}".format(program),
         "$wanted = {}".format(rule_array),
         "$fw = New-Object -ComObject HNetCfg.FwPolicy2",
-        "$sawApp = $false",
-        "$appPrograms = @()",
-        "$seen = @{}",
-        "foreach ($r in $fw.Rules) {",
-        "  if ($r.Name -eq $appRuleName) { $sawApp = $true; $appPrograms += $r.ApplicationName }",
-        "  if ($wanted -contains $r.Name) { $seen[$r.Name] = $true }",
-        "}",
-        "if (-not $sawApp) {",
+        "$appFound = $null",
+        "try { $appFound = $fw.Rules.Item($appRuleName) } catch {}",
+        "if (-not $appFound) {",
         "  Write-Output ('NEED_RULE=' + $appRuleName)",
-        "} elseif ($appPrograms -notcontains $appProgram) {",
+        "} elseif ($appFound.ApplicationName -ne $appProgram) {",
         "  Write-Output ('NEED_RULE=' + $appRuleName)",
         "}",
         "foreach ($name in $wanted) {",
-        "  if (-not $seen.ContainsKey($name)) { Write-Output ('NEED_RULE=' + $name) }",
+        "  $found = $null",
+        "  try { $found = $fw.Rules.Item($name) } catch {}",
+        "  if (-not $found) { Write-Output ('NEED_RULE=' + $name) }",
         "}",
         "}",
     ])

--- a/launcher/windows_setup.py
+++ b/launcher/windows_setup.py
@@ -15,7 +15,18 @@ from .servers import frozen_self_exe, is_frozen
 
 UDPBD_PORT = 0xBDBD
 FIREWALL_RULE_PREFIX = "PS2 Servers - "
-POWERSHELL_TIMEOUT = 30
+# Windows Firewall queries are far slower than they look, and the cost scales with
+# how many rules the machine has -- not with how many we ask about. Measured on a
+# 1091-rule Windows 11 box, cold, in a fresh powershell.exe:
+#   Get-NetFirewallRule per name (what we used to do)   48.1s
+#   one wildcard Get-NetFirewallRule                    69.2s   (batching is WORSE)
+#   HNetCfg.FwPolicy2 COM, one pass                     16.8s   (but 48.5s under load)
+# At 30s the check timed out, needs_setup fell back to "assume setup is needed",
+# the elevated apply blew the same budget, and nothing was ever fixed -- an
+# un-exitable UAC loop on a machine whose rules were already correct. The check
+# runs on a worker thread and only delays a server start, so a budget that cannot
+# be blown by a slow machine is worth far more than a tight one.
+POWERSHELL_TIMEOUT = 120
 
 
 class WindowsSetupError(RuntimeError):
@@ -138,6 +149,22 @@ def _rule_names(key, values):
     return rules
 
 
+def setup_fingerprint(key, values):
+    """Everything needs_setup's answer depends on, as one string.
+
+    The check costs tens of seconds because Windows charges by how many rules the
+    machine has, not by how many we ask about -- so a caller that has already seen
+    a clean answer can skip it while this string is unchanged. It covers the two
+    things that can turn a clean answer dirty: the program in the App rule, and the
+    per-port rule names (which embed the ports). Anything else that could invalidate
+    it -- someone deleting the rules behind our back -- is what 'Allow through
+    firewall' is for.
+    """
+    if not is_windows():
+        return ""
+    return "|".join([os.path.abspath(_server_program_path())] + _rule_names(key, values))
+
+
 def _firewall_rules(key, values):
     program = os.path.abspath(_server_program_path())
     rules = [{
@@ -185,6 +212,10 @@ def needs_setup(key, values, log=None):
     rule_array = "@({})".format(",".join(_ps_quote(n) for n in port_rule_names))
     program = _ps_quote(os.path.abspath(_server_program_path()))
     app_rule = _ps_quote("PS2 Servers - App")
+    # One COM pass over the rule set, not one Get-NetFirewallRule per name. Same
+    # answers (verified against a missing app rule, a missing port rule, a stale
+    # program path, and both missing) at a third of the cost -- see the note on
+    # POWERSHELL_TIMEOUT for why that gap decides whether this works at all.
     script = "\n".join([
         "$svc = Get-Service -Name mpssvc -ErrorAction SilentlyContinue",
         "if ($svc -and $svc.Status -ne 'Running') {",
@@ -192,28 +223,41 @@ def needs_setup(key, values, log=None):
         "} else {",
         "$appRuleName = {}".format(app_rule),
         "$appProgram = {}".format(program),
-        "$appRule = Get-NetFirewallRule -DisplayName $appRuleName -ErrorAction SilentlyContinue",
-        "if (-not $appRule) {",
-        "  Write-Output ('NEED_RULE=' + $appRuleName)",
-        "} else {",
-        "  $appFilter = $appRule | Get-NetFirewallApplicationFilter",
-        "  $programs = @($appFilter | ForEach-Object { $_.Program })",
-        "  if ($programs -notcontains $appProgram) { Write-Output ('NEED_RULE=' + $appRuleName) }",
+        "$wanted = {}".format(rule_array),
+        "$fw = New-Object -ComObject HNetCfg.FwPolicy2",
+        "$sawApp = $false",
+        "$appPrograms = @()",
+        "$seen = @{}",
+        "foreach ($r in $fw.Rules) {",
+        "  if ($r.Name -eq $appRuleName) { $sawApp = $true; $appPrograms += $r.ApplicationName }",
+        "  if ($wanted -contains $r.Name) { $seen[$r.Name] = $true }",
         "}",
-        "$rules = {}".format(rule_array),
-        "foreach ($name in $rules) {",
-        "  if (-not (Get-NetFirewallRule -DisplayName $name -ErrorAction SilentlyContinue)) {",
-        "    Write-Output ('NEED_RULE=' + $name)",
-        "  }",
+        "if (-not $sawApp) {",
+        "  Write-Output ('NEED_RULE=' + $appRuleName)",
+        "} elseif ($appPrograms -notcontains $appProgram) {",
+        "  Write-Output ('NEED_RULE=' + $appRuleName)",
+        "}",
+        "foreach ($name in $wanted) {",
+        "  if (-not $seen.ContainsKey($name)) { Write-Output ('NEED_RULE=' + $name) }",
         "}",
         "}",
     ])
     try:
         res = _powershell(script)
     except subprocess.TimeoutExpired:
-        log("firewall check timed out after {}s; assuming setup is needed".format(
-            POWERSHELL_TIMEOUT))
-        return True
+        # Explicitly NOT "assume setup is needed". Elevating only helps if the
+        # elevated pass can then succeed, and it cannot: apply_setup drives the
+        # same Windows Firewall cmdlets that just ran out of time, so it blows the
+        # same budget and changes nothing. Answering True here is what turned a
+        # slow machine into an un-exitable UAC loop -- prompt, fail, prompt --
+        # while its rules were already correct. Start instead, and say so: the
+        # server is far more likely to work than not, and "Allow through firewall"
+        # is one click away if it does not. Other failures below still elevate;
+        # only a timeout is known to be unhelped by it.
+        log("firewall check timed out after {}s; starting anyway. If the PS2 "
+            "cannot see this server, click 'Allow through firewall'.".format(
+                POWERSHELL_TIMEOUT))
+        return False
     except OSError as e:
         log("firewall check could not run ({}); assuming setup is needed".format(e))
         return True


### PR DESCRIPTION
## Stop the firewall check from starting a UAC loop it cannot exit

The **"always asks for administrator privileges"** report — open since the first
bug report in this series — was never about stale paths or missing rights. The
reporter's screenshot shows `Administrator: Yes` **and it still fails**. That's the
tell: elevation was never the missing thing.

Windows charges for a firewall query by **how many rules the machine has**, not by
how many you ask about. Measured cold on the reporting machine (1091 rules,
Windows 11), in a fresh `powershell.exe`, asking about exactly **two** rules:

| approach | cold |
|---|---|
| `Get-NetFirewallRule` per name (what we shipped) | **48.1s** |
| one wildcard `Get-NetFirewallRule` | **69.2s** — batching is *worse* |
| `HNetCfg.FwPolicy2` COM, one pass | **16.8s** (48.5s under load) |

At a 30s budget:

```
firewall check timed out after 30s; assuming setup is needed   ← false positive
  → prompts for admin
  → apply_setup drives the SAME cmdlets, blows the SAME budget
  → "Windows setup timed out after 30 seconds"                 ← never succeeds
  → nothing fixed → next start does it all again
```

Reproduced verbatim on that machine: `needs_setup -> True in 33.7s`. Its rules were
correct the entire time.

### Three changes; the third is what makes it un-loopable

- **COM in one pass** instead of `Get-NetFirewallRule` per name. Same answers —
  verified against a missing app rule, a missing port rule, a stale program path,
  and both missing — at a third of the cost.
- **30s → 120s.** The check runs on a worker thread and only delays a server start,
  so a budget a slow machine *cannot* blow is worth more than a tight one.
- **A timeout no longer means "assume setup is needed."** That fallback is only
  sound if elevating can then succeed, and it cannot: `apply_setup` runs the same
  cmdlets that just ran out of time. Answering `True` there **is** the loop. It now
  starts and says so — the rules are far likelier present than not, and *Allow
  through firewall* is one click away. `OSError` and non-zero exits still elevate;
  only the timeout is known to be unhelped by it.

### Then cache it

49s before every start is its own bug. A fingerprint of **(program path + rule
names)** is everything the answer depends on, so a confirmed-clean one skips the
scan until it changes:

- **changes** on a different port, a pinned `data_port`, or a **moved/replaced exe**
  (so swapping rolling builds rescans rather than trusting a stale cache)
- **doesn't change** for compression, verbose, modulo mode, or the games folder —
  none of which touch a rule
- **cleared** by *Remove PS2 Servers firewall rules*
- **never** caches a timeout or an error — we didn't learn anything

## Verification

On the reporting machine, posing as the packaged build against its real rules:

```
needs_setup -> False in 49.4s     ← no elevation. Correct: the rules are right.
```

- a **source** run still correctly wants a rule for `python.exe`
- a simulated timeout → `False` + "starting anyway / Allow through firewall" (no loop)
- `OSError` → still elevates; non-zero exit → still elevates
- `FIREWALL_OFF` → still short-circuits
- a genuine `NEED_RULE` → still elevates
- fingerprint: differs on port / pinned data_port / moved exe; same for
  modulo_mode, folder, compression, peer_timeout, verbose; per-server not global

Suite green: compliance, multiclient, compression, pathguard, plus the modulo,
timeout, help, dropdown and IP checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
