### PR TITLE
launcher: normalise the combobox pick-list (gemini review missed on #80)

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -959,6 +959,20 @@ class LauncherApp:
 
         self._cleanup_windows_setup_async()
 
+    def _detected_ips(self):
+        """The pick-list as plain strings.
+
+        Tk hands ["values"] back as whatever Tcl made of it: a tuple of str here,
+        but a bare '' when the list is empty, and on other builds a tuple of
+        Tcl_Obj. Against Tcl_Obj a str compares unequal, so a PICKED address would
+        read as hand-typed and keep its stale-address check from ever running --
+        silently, and only on someone else's platform.
+        """
+        values = self.ip_combo["values"]
+        if isinstance(values, str):
+            return [values] if values else []
+        return [str(v) for v in values]
+
     def _remember_firewall_ok(self, fingerprint):
         if fingerprint in self._firewall_ok:
             return
@@ -1077,7 +1091,7 @@ class LauncherApp:
         # changes whenever the exe or ports do.
         self._firewall_ok = set(self.saved.get("firewall_ok") or [])
         ip = self.saved.get("ip")
-        if ip and (ip in self.ip_combo["values"] or self.saved.get("ip_custom")):
+        if ip and (ip in self._detected_ips() or self.saved.get("ip_custom")):
             self.ip_var.set(ip)
         self.close_to_tray_var.set(
             self._saved_bool("close_to_tray", self.close_to_tray_var.get()))
@@ -1095,7 +1109,7 @@ class LauncherApp:
                 # getaddrinfo -- and worse, an address that vanished since startup
                 # (roamed, DHCP, cable out) would be misread as hand-typed and then
                 # persist forever, defeating the stale check above.
-                "ip_custom": self.ip_var.get() not in self.ip_combo["values"],
+                "ip_custom": self.ip_var.get() not in self._detected_ips(),
                 "close_to_tray": bool(self.close_to_tray_var.get()),
                 "minimize_to_tray": bool(self.minimize_to_tray_var.get())}
         if pending_start:

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -963,15 +963,14 @@ class LauncherApp:
         """The pick-list as plain strings.
 
         Tk hands ["values"] back as whatever Tcl made of it: a tuple of str here,
-        but a bare '' when the list is empty, and on other builds a tuple of
-        Tcl_Obj. Against Tcl_Obj a str compares unequal, so a PICKED address would
-        read as hand-typed and keep its stale-address check from ever running --
-        silently, and only on someone else's platform.
+        a bare '' when the list is empty, and on other builds Tcl_Obj. Against
+        Tcl_Obj a str compares unequal, so a PICKED address would read as
+        hand-typed and keep its stale-address check from ever running -- silently,
+        and only on someone else's platform. splitlist asks Tcl to unpack its own
+        value rather than guessing at the Python type it arrived as, which also
+        covers a scalar Tcl_Obj that is neither a str nor iterable.
         """
-        values = self.ip_combo["values"]
-        if isinstance(values, str):
-            return [values] if values else []
-        return [str(v) for v in values]
+        return [str(v) for v in self.ip_combo.tk.splitlist(self.ip_combo["values"])]
 
     def _remember_firewall_ok(self, fingerprint):
         if fingerprint in self._firewall_ok:


### PR DESCRIPTION
## Normalise the combobox pick-list (gemini review missed on #80)

Two Gemini comments sat on #80 unread — I checked CI, merged, and moved on. The
process failure is worth noting as much as the fix: the review was there, I just
didn't look. It's the one PR out of seven today where I skipped that step.

### The finding half-holds, and the half that holds is the dangerous one

Tk returns `combobox["values"]` as whatever Tcl made of it. Measured here on
**Tcl 8.6**:

| entries | returns |
|---|---|
| 0 | **bare `''`** (not a tuple) |
| 1 | `('192.168.1.100',)` — tuple of `str` |
| 2 | tuple of `str` |

So the bare-string case is **real but lands at zero entries, not one** as claimed —
and it happens to answer correctly by luck: `ip in ''` is False and `ip not in ''`
is True, which is exactly what both callers want.

**The `Tcl_Obj` half is what matters.** On a build that hands back `Tcl_Obj` rather
than `str`, a `str` compares unequal to every entry — so a **picked** address reads
as hand-typed: `ip_custom` goes `True` and the stale-address check never runs
again. That is precisely the bug `ip_custom` was added in #80 to prevent,
resurrected — silently, and only on someone else's platform.

We ship **Linux and macOS** builds, so "not reproducible on this box" isn't an
argument.

### Fix

`_detected_ips()` normalises all four shapes:

- `''` → `[]`
- bare `str` → `[str]`
- tuple of `str` → list
- tuple of `Tcl_Obj` → list of `str`

## Verification

- all four shapes normalise correctly
- under `Tcl_Obj`, a **picked** address now yields `ip_custom=False`; the raw check
  gave `True` (stale check defeated)
- suite green: compliance, multiclient, compression, pathguard, plus the IP,
  dropdown, help, firewall-cache and modulo-parity checks

Not urgent on its own — the bug it prevents cannot fire on Windows, where
`values` is already a tuple of `str`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
