### PR TITLE
docs: document the UDPFS settings shipped in v0.3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ that tells them apart, and it does so by guessing.
 Default **3600s (1 hour)**, matching udpfsd, bounded 60–86400. Lower it only to
 clear stale consoles faster (handy with several PS2s sharing one address). Too low
 and a long pause loses its game: `0` does **not** disable it and never did, so it
-clamps up like any other out-of-range value.
+clamps up to the 60s minimum like any other out-of-range value.
 
 CLI: `--peer-timeout SECONDS` (env `PEER_TIMEOUT`).
 
@@ -138,7 +138,7 @@ port** in that case and a matching firewall rule is added for it.
 
 `--single-port` serves discovery and data on the one port instead, for clients or
 networks that cannot handle the two-port handshake. Unlike Modulo mode it changes
-no protocol behaviour, so normal clients keep working.
+no protocol behavior, so normal clients keep working.
 
 CLI: `--port`, `--data-port`, `--single-port`.
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,57 @@ false positives on packaged builds)? **[udpfsd](https://github.com/pcm720/udpfsd
 pcm720 is a Go alternative — a single prebuilt binary with the same CHD/CSO/ZSO
 support. See [Credits & thanks](#credits--thanks).
 
+## UDPFS settings worth knowing
+
+Defaults are right for every client we know of. These are the ones you might change.
+
+### "Check this if you are using Modulo"
+
+**Either/or — tick it only while you are actually using Modulo.**
+
+[Modulo](https://github.com/AdityaKumar7209/Modulo-R1-Beta-Preview---PS2)'s client
+does not follow the UDPFS protocol. It never restarts its sequence counter (on
+hardware it climbs straight across a full server restart), and it cannot move to
+the server's data port. That is not specific to us: it fails against
+[pcm720's udpfsd](https://github.com/pcm720/udpfsd) for the same reasons. Modulo's
+own repository ships a patched copy of a server to work around both, which is how
+we established exactly what it expects.
+
+This mode answers the way that patched server does. A correct client cannot follow
+it — its INFORM consumes a sequence number, so the server's first reply arrives one
+ahead of where a conformant client is listening. **While this is on, NHDDL, RiptOPL,
+POPSTARTER, POPSLOADER and wLaunchELF-R3Z will not connect.** Untick it and they are
+back. Nothing is lost either way; it is one at a time.
+
+CLI: `--modulo-mode` (implies `--single-port`; env `MODULO_MODE`).
+
+### Idle timeout
+
+UDPFS drops a console once it goes quiet for this long, **closing whatever files it
+had open**. UDPFS has no disconnect packet — a paused game and an unplugged console
+are identical on the wire, both simply silent — so the timeout is the only thing
+that tells them apart, and it does so by guessing.
+
+Default **3600s (1 hour)**, matching udpfsd, bounded 60–86400. Lower it only to
+clear stale consoles faster (handy with several PS2s sharing one address). Too low
+and a long pause loses its game: `0` does **not** disable it and never did, so it
+clamps up like any other out-of-range value.
+
+CLI: `--peer-timeout SECONDS` (env `PEER_TIMEOUT`).
+
+### Port and Data port
+
+Leave both alone unless something needs them predictable. UDPFS normally serves
+discovery on `0xF5F6` and hands each console off to an ephemeral data port, which a
+manual firewall rule, port forwarding or a strict NAT cannot follow — pin **Data
+port** in that case and a matching firewall rule is added for it.
+
+`--single-port` serves discovery and data on the one port instead, for clients or
+networks that cannot handle the two-port handshake. Unlike Modulo mode it changes
+no protocol behaviour, so normal clients keep working.
+
+CLI: `--port`, `--data-port`, `--single-port`.
+
 ## Minimum system requirements
 
 You need two machines on the **same LAN**: the **PC** that runs PS2 Servers, and

--- a/docs/antivirus-transparency.md
+++ b/docs/antivirus-transparency.md
@@ -65,7 +65,7 @@ PS2 Servers only exposes local server behavior that the user chooses from the
 GUI:
 
 - SMBv1/RiptOPL: built-in SMB/CIFS subset, normally TCP port 1111. (Ports below 1033 are discouraged — Windows can reserve or block low ports.)
-- UDPFS: UDP file/block serving, normally UDP port 0xF5F6 for discovery. Each console is then served on a second UDP port, which the OS assigns at start unless the user pins it ("Data port"); single-port and Modulo modes serve everything on the discovery port instead. All of it is inbound LAN serving — the server never initiates a connection.
+- UDPFS: UDP file/block serving, normally UDP port 0xF5F6 for discovery. Each console is then served on a second UDP port, which the OS assigns on startup unless the user pins it ("Data port"); single-port and Modulo modes serve everything on the discovery port instead. All of it is inbound LAN serving — the server never initiates a connection.
 - UDPBD: UDP block-device serving, normally UDP port 0xBDBD.
 
 The Windows SMB server uses PS2 Servers' own SMB/CIFS implementation. It does not enable Windows SMB1, does not disable Windows SMB1 automatic removal, and does not install or remove Windows optional features.

--- a/docs/antivirus-transparency.md
+++ b/docs/antivirus-transparency.md
@@ -65,7 +65,7 @@ PS2 Servers only exposes local server behavior that the user chooses from the
 GUI:
 
 - SMBv1/RiptOPL: built-in SMB/CIFS subset, normally TCP port 1111. (Ports below 1033 are discouraged — Windows can reserve or block low ports.)
-- UDPFS: UDP file/block serving, normally UDP port 0xF5F6.
+- UDPFS: UDP file/block serving, normally UDP port 0xF5F6 for discovery. Each console is then served on a second UDP port, which the OS assigns at start unless the user pins it ("Data port"); single-port and Modulo modes serve everything on the discovery port instead. All of it is inbound LAN serving — the server never initiates a connection.
 - UDPBD: UDP block-device serving, normally UDP port 0xBDBD.
 
 The Windows SMB server uses PS2 Servers' own SMB/CIFS implementation. It does not enable Windows SMB1, does not disable Windows SMB1 automatic removal, and does not install or remove Windows optional features.

--- a/docs/index.html
+++ b/docs/index.html
@@ -123,7 +123,7 @@ Password          leave blank
           <article class="card">
             <h3>Ports</h3>
             <p>Leave them alone unless something needs them predictable. Discovery is <code>0xF5F6</code>; each console is then handed to an ephemeral data port, which a manual firewall rule or a strict NAT can't follow — pin <strong>Data port</strong> in that case.</p>
-            <p>Single-port mode serves both on one port for networks that can't handle the two-port handshake. Unlike Modulo mode it changes no protocol behaviour, so normal clients keep working.</p>
+            <p>Single-port mode serves both on one port for networks that can't handle the two-port handshake. Unlike Modulo mode it changes no protocol behavior, so normal clients keep working.</p>
             <p><code>--port · --data-port · --single-port</code></p>
           </article>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,6 +19,7 @@
       <nav class="nav-links" aria-label="Primary navigation">
         <a href="#servers">Servers</a>
         <a href="#quickstart">Quick start</a>
+        <a href="#udpfs-settings">UDPFS settings</a>
         <a href="#requirements">Requirements</a>
         <a href="#download">Download</a>
         <a href="falsepositives.html">Antivirus</a>
@@ -98,6 +99,33 @@ Password          leave blank
 <b>UDPBD</b>   select UDPBD in OPL; the PS2 finds the server automatically — no IP or port.</pre>
           </div>
           <p class="section-intro ps2-note">The launcher always prints these exact values while a server is running, so you never have to guess. You'll need a PS2 that boots homebrew and runs Open PS2 Loader (or PCSX2 with a network adapter) on the same LAN.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="udpfs-settings">
+      <div class="container">
+        <h2>UDPFS settings worth knowing.</h2>
+        <p class="section-intro">The defaults are right for every client we know of — NHDDL, RiptOPL, POPSTARTER, POPSLOADER and wLaunchELF-R3Z all work out of the box. These are the ones you might change.</p>
+        <div class="cards">
+          <article class="card">
+            <h3>Using Modulo?</h3>
+            <p>There's a checkbox for it on the UDPFS tab. <strong>It's either/or</strong> — while it's on, the normal clients won't connect. Untick it and they're back.</p>
+            <p><a href="https://github.com/AdityaKumar7209/Modulo-R1-Beta-Preview---PS2">Modulo</a>'s client doesn't follow the UDPFS protocol: it never restarts its sequence counter, and it can't move to the server's data port. That isn't specific to us — it fails against <a href="https://github.com/pcm720/udpfsd">pcm720's udpfsd</a> for the same reasons. Modulo's own repo ships a patched server to work around both, so this mode answers the way that server does. A correct client can't follow it.</p>
+            <p><code>--modulo-mode</code></p>
+          </article>
+          <article class="card">
+            <h3>Idle timeout</h3>
+            <p>UDPFS drops a console once it goes quiet, closing whatever files it had open. There's no disconnect packet in the protocol — a paused game and an unplugged console look identical on the wire — so the timeout is the only thing that tells them apart.</p>
+            <p>Default <strong>1 hour</strong>, matching udpfsd, adjustable 60s–24h under Advanced. Lower it only to clear stale consoles faster; too low and a long pause loses its game.</p>
+            <p><code>--peer-timeout SECONDS</code></p>
+          </article>
+          <article class="card">
+            <h3>Ports</h3>
+            <p>Leave them alone unless something needs them predictable. Discovery is <code>0xF5F6</code>; each console is then handed to an ephemeral data port, which a manual firewall rule or a strict NAT can't follow — pin <strong>Data port</strong> in that case.</p>
+            <p>Single-port mode serves both on one port for networks that can't handle the two-port handshake. Unlike Modulo mode it changes no protocol behaviour, so normal clients keep working.</p>
+            <p><code>--port · --data-port · --single-port</code></p>
+          </article>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Document the UDPFS settings shipped in v0.3.x

Everything added this cycle was **undocumented**. Grepping the README, `docs/` and
`SECURITY.md` for `modulo`, `peer-timeout`, `peer_timeout`, `single-port`,
`idle timeout` and `MODULO_MODE` returned nothing at all.

A setting nobody can find is a setting that doesn't exist — and the one that locks
out every other client is a bad one to leave to a tooltip.

Docs-only. No version bump. **GitHub Pages serves `docs/` from `main`, so the site
doesn't update until this merges.**

### README — new "UDPFS settings worth knowing"

Framed as *defaults are right, here's what you might change*:

- **Modulo mode** leads with **either/or** and names the clients that will not
  connect while it's on — with the reason (its INFORM consumes a sequence number,
  leaving a correct client listening one behind) and the evidence (its own repo
  ships the patched server; it fails against pcm720's udpfsd too).
- **Idle timeout** explains what a reap actually costs — it closes the console's
  open files — and why the number can only be a guess: UDPFS has no disconnect
  packet, so a paused game and an unplugged console are identical on the wire.
  Notes that `0` does **not** disable it.
- **Ports** — leave alone unless a firewall rule or NAT needs them predictable;
  `--single-port` is protocol-neutral where modulo mode is not.

### Site

The same three as cards, reusing the existing `card`/`section-intro` styles (**no
new CSS**), plus a **nav entry** — a section reachable only by knowing the anchor
isn't published.

### antivirus-transparency.md

It listed UDPFS as *"normally UDP port 0xF5F6"* and stopped. That's now incomplete:
UDPFS also opens an OS-assigned data port per console unless pinned. A document
whose entire job is telling AV vendors exactly what we bind cannot omit a port we
bind.

## Verification

- `check_release_compliance` passes — it asserts this file's contents
- HTML parses clean; every nav anchor resolves; no invented CSS classes
- each new flag appears in **both** README and site

🤖 Generated with [Claude Code](https://claude.com/claude-code)
