### PR TITLE
Add guarded direct-link setup for UDPFS troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ Packaged builds bundle CHD (libchdr) and ZSO (lz4) support, so CHD/CSO/ZSO image
 `libchdr` native library for CHD; CSO always works (Python standard library). See
 [docs/optional-compression-dependencies.md](docs/optional-compression-dependencies.md).
 
+## Direct PS2-to-PC link (no router)
+
+A PS2 cabled straight into the PC has no router on the wire, so nothing hands the
+console an IP address — every network app then fails the same way (empty lists,
+"check cable and DHCP"). Tick **"PS2 is plugged directly into this PC"** at the top
+of the launcher and that whole problem disappears: PS2 Servers finds the right
+network port, gives the PC a fixed address on it (one administrator prompt), and
+runs a tiny DHCP helper on that port only, so the console — which asks for an
+address by itself — just gets one. The LAN IP box fills in with the address to use
+in OPL. Unticking the box undoes all of it.
+
+The helper is deliberately paranoid, because a DHCP server answering on a real
+network could hand bad addresses to everything on it. It binds only to the
+direct-link port, refuses to start if that port reaches a router or already got an
+address from a real DHCP server, serves exactly one address to one console, and
+stops itself if several different devices start asking. Windows-only for now.
+
 ## Run a server on its own (terminal)
 
 Each server still runs standalone, and the launcher can run them too:

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The helper is deliberately paranoid, because a DHCP server answering on a real
 network could hand bad addresses to everything on it. It binds only to the
 direct-link port, refuses to start if that port reaches a router or already got an
 address from a real DHCP server, serves exactly one address to one console, and
-stops itself if several different devices start asking. Windows-only for now.
+stops itself if a second device starts asking. Windows-only for now.
 
 ## Run a server on its own (terminal)
 

--- a/launcher/directlink.py
+++ b/launcher/directlink.py
@@ -1,0 +1,738 @@
+"""Direct PS2-to-PC link mode ("PS2 is plugged directly into this PC").
+
+A PS2 cabled straight into a PC has no router on the wire, so nothing answers
+its DHCP request and it never gets an IP address -- every network client then
+fails identically (empty lists, "check cable and DHCP"). The manual fix is
+static addresses on both ends, which means teaching users subnets. This module
+removes that: it configures the chosen network port with a fixed address and
+runs a tiny single-lease DHCP responder on that port only, so the console --
+which defaults to DHCP -- configures itself.
+
+The one real hazard is answering DHCP on a network that already has a DHCP
+server (a "rogue DHCP server" can hand garbage leases to every device on a
+LAN). Containment is layered:
+
+  * The responder binds to the chosen adapter's own address. Windows delivers
+    broadcasts to specifically-bound sockets (verified empirically), so the
+    socket cannot even hear DHCP traffic arriving on other interfaces. A
+    startup self-probe confirms that delivery works on this machine; if it
+    does not, the responder falls back to a wildcard bind but then sends
+    replies only as subnet-directed broadcasts, which egress the chosen
+    adapter alone.
+  * Hard refusals, re-checked in the elevated context at the moment the
+    adapter is configured and again when the responder starts: never touch an
+    adapter that has a default gateway or holds a DHCP lease -- both mean
+    "this is a real network, not a direct link".
+  * A tripwire while running: a direct link has exactly one device, so seeing
+    several distinct client MACs means this is not a direct link; the
+    responder stops rather than keep answering.
+  * One lease, one address, and rate-limited replies.
+
+Windows ICS does this job too but is flaky across updates, drags internet
+sharing along, and is not ours to debug; this is ~150 lines we can fix.
+"""
+
+import errno
+import json
+import socket
+import struct
+import time
+
+from .windows_setup import (WindowsSetupError, _powershell, is_windows)
+
+DHCP_SERVER_PORT = 67
+DHCP_CLIENT_PORT = 68
+LEASE_SECONDS = 86400
+PREFIX_LENGTH = 24
+SERVER_HOST_NUM = 1   # PC gets .1
+CLIENT_HOST_NUM = 10  # PS2 gets .10
+
+# /24 networks tried in order; the first that overlaps nothing local wins.
+# Deliberately NOT 192.168.0/1.x -- half the home routers in the world use
+# those, and a collision would blackhole the user's real LAN traffic. .137 is
+# what Windows ICS picked for exactly this job, so it is the least likely to
+# be squatted by other software.
+CANDIDATE_SUBNETS = ("192.168.137", "192.168.183", "192.168.73",
+                     "10.213.77", "172.31.213")
+
+MAGIC_COOKIE = b"\x63\x82\x53\x63"
+_BOOTP = struct.Struct("!BBBBIHHIIII16s64s128s")  # fixed header, 236 bytes
+
+MSG_DISCOVER, MSG_OFFER, MSG_REQUEST, MSG_DECLINE = 1, 2, 3, 4
+MSG_ACK, MSG_NAK, MSG_RELEASE, MSG_INFORM = 5, 6, 7, 8
+
+
+class DirectLinkRefused(RuntimeError):
+    """A safety refusal: the situation does not look like a direct PS2 link."""
+
+
+# --------------------------------------------------------------------------- #
+# Small IPv4 math (no ipaddress import: these five lines are the whole need)
+# --------------------------------------------------------------------------- #
+def _ip_to_int(ip):
+    return struct.unpack("!I", socket.inet_aton(ip))[0]
+
+
+def _int_to_ip(n):
+    return socket.inet_ntoa(struct.pack("!I", n & 0xFFFFFFFF))
+
+
+def _network_of(ip, prefixlen):
+    mask = (0xFFFFFFFF << (32 - prefixlen)) & 0xFFFFFFFF if prefixlen else 0
+    return _ip_to_int(ip) & mask
+
+
+def networks_overlap(net1, plen1, net2, plen2):
+    plen = min(plen1, plen2)
+    if plen <= 0:
+        return True
+    shift = 32 - plen
+    return (net1 >> shift) == (net2 >> shift)
+
+
+# --------------------------------------------------------------------------- #
+# Adapter enumeration and classification (Windows)
+# --------------------------------------------------------------------------- #
+_ENUMERATE_SCRIPT = r"""
+$ErrorActionPreference = 'SilentlyContinue'
+$phys = @{}
+foreach ($a in @(Get-NetAdapter -Physical)) { $phys[[int]$a.ifIndex] = $true }
+$gws = @{}
+foreach ($r in @(Get-NetRoute -DestinationPrefix '0.0.0.0/0' -AddressFamily IPv4)) {
+  $gws[[int]$r.InterfaceIndex] = $true
+}
+$addrs = @{}
+foreach ($ip in @(Get-NetIPAddress -AddressFamily IPv4)) {
+  $k = [int]$ip.InterfaceIndex
+  if (-not $addrs.ContainsKey($k)) { $addrs[$k] = @() }
+  $addrs[$k] += ,@{ ip = [string]$ip.IPAddress; prefix = [int]$ip.PrefixLength;
+                    origin = [string]$ip.PrefixOrigin }
+}
+$adapters = @()
+foreach ($a in @(Get-NetAdapter)) {
+  $k = [int]$a.ifIndex
+  $list = @()
+  if ($addrs.ContainsKey($k)) { $list = @($addrs[$k]) }
+  $adapters += ,@{
+    name = [string]$a.Name; ifIndex = $k
+    desc = [string]$a.InterfaceDescription
+    status = [string]$a.Status
+    media = [string]$a.PhysicalMediaType
+    physical = [bool]$phys.ContainsKey($k)
+    gateway = [bool]$gws.ContainsKey($k)
+    ipv4 = $list
+  }
+}
+$routes = @()
+foreach ($r in @(Get-NetRoute -AddressFamily IPv4)) {
+  $routes += ,@{ prefix = [string]$r.DestinationPrefix
+                 ifIndex = [int]$r.InterfaceIndex }
+}
+ConvertTo-Json -InputObject @{ adapters = $adapters; routes = $routes } -Depth 6
+"""
+
+
+def enumerate_adapters():
+    """All adapters plus the IPv4 routing table, as plain dicts.
+
+    Returns {"adapters": [...], "routes": [...]}. Each adapter:
+      name, if_index, desc, status, media, physical, has_gateway,
+      ipv4: [{ip, prefix, origin}, ...]
+    """
+    if not is_windows():
+        raise WindowsSetupError("Direct link mode is only supported on Windows.")
+    res = _powershell(_ENUMERATE_SCRIPT)
+    if res.returncode != 0:
+        raise WindowsSetupError(
+            "Could not list network adapters: {}".format(
+                ((res.stderr or "") + (res.stdout or "")).strip() or "unknown error"))
+    try:
+        data = json.loads((res.stdout or "").strip() or "{}")
+    except ValueError as e:
+        raise WindowsSetupError("Could not parse adapter list: {}".format(e))
+    adapters = data.get("adapters") or []
+    if isinstance(adapters, dict):  # ConvertTo-Json collapses 1-element arrays
+        adapters = [adapters]
+    routes = data.get("routes") or []
+    if isinstance(routes, dict):
+        routes = [routes]
+    out = []
+    for a in adapters:
+        ipv4 = a.get("ipv4") or []
+        if isinstance(ipv4, dict):
+            ipv4 = [ipv4]
+        out.append({
+            "name": a.get("name") or "",
+            "if_index": int(a.get("ifIndex") or 0),
+            "desc": a.get("desc") or "",
+            "status": a.get("status") or "",
+            "media": a.get("media") or "",
+            "physical": bool(a.get("physical")),
+            "has_gateway": bool(a.get("gateway")),
+            "ipv4": [{"ip": i.get("ip") or "",
+                      "prefix": int(i.get("prefix") or 0),
+                      "origin": i.get("origin") or ""} for i in ipv4],
+        })
+    return {"adapters": out, "routes": routes}
+
+
+def classify_adapter(adapter, allow_down=False):
+    """(is_candidate, reason_if_not) -- can this adapter be a direct PS2 link?
+
+    The reasons are user-facing: when nothing qualifies, the launcher shows
+    what was seen and why each port was rejected, which is the difference
+    between a support conversation and a shrug.
+
+    allow_down tolerates a link that is merely not up -- right for re-checking
+    a port that is ALREADY ours (the console being off is the normal state of
+    the world at PC boot, and a down port can receive nothing anyway), wrong
+    for choosing a new one (a dead port tells us nothing about what it is
+    plugged into).
+    """
+    media = (adapter.get("media") or "").lower()
+    if not adapter.get("physical"):
+        return False, "virtual adapter"
+    if "802.11" in media or "wireless" in media or "bluetooth" in media:
+        return False, "wireless (the PS2 needs a wired port)"
+    if not allow_down and (adapter.get("status") or "").lower() != "up":
+        return False, "no link (cable unplugged, or the console is off)"
+    if adapter.get("has_gateway"):
+        return False, "reaches a router (a real network, not a direct link)"
+    if any((i.get("origin") or "").lower() == "dhcp" for i in adapter.get("ipv4", [])):
+        return False, "got its address from a DHCP server (a real network)"
+    return True, ""
+
+
+def find_candidates(enumerated):
+    """(candidates, rejected) where rejected is [(adapter, reason), ...]."""
+    candidates, rejected = [], []
+    for adapter in enumerated["adapters"]:
+        ok, reason = classify_adapter(adapter)
+        if ok:
+            candidates.append(adapter)
+        else:
+            rejected.append((adapter, reason))
+    return candidates, rejected
+
+
+def taken_networks(enumerated, exclude_if_index=None):
+    """Every IPv4 network this host can already reach, as (net_int, prefixlen).
+
+    Both adapter subnets and routing-table entries count: a VPN's remote
+    subnet would collide just as hard as a local one. The chosen adapter's own
+    networks are excluded -- it is about to be reconfigured.
+    """
+    taken = []
+    for adapter in enumerated["adapters"]:
+        if exclude_if_index is not None and adapter["if_index"] == exclude_if_index:
+            continue
+        for entry in adapter["ipv4"]:
+            ip = entry["ip"]
+            if not ip or ip.startswith(("127.", "169.254.")):
+                continue
+            plen = entry["prefix"] or 32
+            taken.append((_network_of(ip, plen), plen))
+    for route in enumerated.get("routes", []):
+        if exclude_if_index is not None and route.get("ifIndex") == exclude_if_index:
+            continue
+        prefix = route.get("prefix") or ""
+        if "/" not in prefix:
+            continue
+        ip, _, plen_s = prefix.partition("/")
+        try:
+            plen = int(plen_s)
+            net = _network_of(ip, plen)
+        except (ValueError, OSError):
+            continue
+        first_octet = _ip_to_int(ip) >> 24 if plen else 0
+        # Skip entries that say nothing about usable unicast space.
+        if plen == 0 or first_octet == 127 or first_octet >= 224:
+            continue
+        if ip.startswith("169.254.") or prefix == "255.255.255.255/32":
+            continue
+        taken.append((net, plen))
+    return taken
+
+
+def choose_subnet(taken):
+    """First candidate /24 that overlaps nothing the host already reaches.
+
+    Returns (server_ip, client_ip) or (None, None) when every candidate
+    collides (five networks from three different RFC1918 blocks -- in
+    practice this means something is very unusual about the host).
+    """
+    for base in CANDIDATE_SUBNETS:
+        net = _ip_to_int(base + ".0")
+        if not any(networks_overlap(net, PREFIX_LENGTH, tn, tp) for tn, tp in taken):
+            return ("{}.{}".format(base, SERVER_HOST_NUM),
+                    "{}.{}".format(base, CLIENT_HOST_NUM))
+    return None, None
+
+
+# --------------------------------------------------------------------------- #
+# Adapter configure / restore (need administrator rights)
+# --------------------------------------------------------------------------- #
+def apply_adapter_config(if_index, server_ip, prefixlen=PREFIX_LENGTH):
+    """Give the chosen adapter the fixed server address (elevated).
+
+    The gateway/lease refusals run again HERE, inside the elevated pass, so a
+    stale answer from the earlier scan (or a cable moved in between) cannot
+    configure the wrong port.
+    """
+    script = "\n".join([
+        "$ErrorActionPreference = 'Stop'",
+        "$idx = {}".format(int(if_index)),
+        "if (@(Get-NetRoute -InterfaceIndex $idx -DestinationPrefix '0.0.0.0/0' "
+        "-AddressFamily IPv4 -ErrorAction SilentlyContinue).Count -gt 0) {",
+        "  throw 'REFUSED: that adapter reaches a router (default gateway); "
+        "it is not a direct PS2 link.'",
+        "}",
+        "if (@(Get-NetIPAddress -InterfaceIndex $idx -AddressFamily IPv4 "
+        "-ErrorAction SilentlyContinue | Where-Object { $_.PrefixOrigin -eq 'Dhcp' "
+        "}).Count -gt 0) {",
+        "  throw 'REFUSED: that adapter holds a DHCP lease from a real network.'",
+        "}",
+        "$name = (Get-NetAdapter -InterfaceIndex $idx -ErrorAction Stop).Name",
+        "Set-NetIPInterface -InterfaceIndex $idx -AddressFamily IPv4 -Dhcp Disabled",
+        "Get-NetIPAddress -InterfaceIndex $idx -AddressFamily IPv4 "
+        "-ErrorAction SilentlyContinue | "
+        "Remove-NetIPAddress -Confirm:$false -ErrorAction SilentlyContinue",
+        "New-NetIPAddress -InterfaceIndex $idx -IPAddress '{}' -PrefixLength {} "
+        "-ErrorAction Stop | Out-Null".format(server_ip, int(prefixlen)),
+        "Set-DnsClientServerAddress -InterfaceIndex $idx -ResetServerAddresses "
+        "-ErrorAction SilentlyContinue",
+        "Write-Output ('CONFIGURED=' + $name)",
+    ])
+    res = _powershell(script)
+    output = ((res.stdout or "") + (res.stderr or "")).strip()
+    if res.returncode != 0 or "CONFIGURED=" not in output:
+        raise WindowsSetupError(output or "Could not configure the adapter.")
+    return output
+
+
+def restore_adapter_dhcp(if_index, expect_ip=None):
+    """Return the adapter to automatic (DHCP) configuration (elevated).
+
+    When expect_ip is given, restore only if the adapter still carries that
+    address: if the user (or another tool) has since given the port its own
+    configuration, it is not ours to clobber.
+    """
+    guard = ""
+    if expect_ip:
+        guard = "\n".join([
+            "$cur = @(Get-NetIPAddress -InterfaceIndex $idx -AddressFamily IPv4 "
+            "-ErrorAction SilentlyContinue | ForEach-Object { [string]$_.IPAddress })",
+            "if (-not ($cur -contains '{}')) {{".format(expect_ip),
+            "  Write-Output 'SKIPPED=the port no longer has the direct-link "
+            "address; leaving it as it is'",
+            "  return",
+            "}",
+        ])
+    script = "\n".join([
+        "$ErrorActionPreference = 'Stop'",
+        "& {",
+        "$idx = {}".format(int(if_index)),
+        guard,
+        "Get-NetIPAddress -InterfaceIndex $idx -AddressFamily IPv4 "
+        "-ErrorAction SilentlyContinue | "
+        "Remove-NetIPAddress -Confirm:$false -ErrorAction SilentlyContinue",
+        "Set-NetIPInterface -InterfaceIndex $idx -AddressFamily IPv4 -Dhcp Enabled",
+        "Set-DnsClientServerAddress -InterfaceIndex $idx -ResetServerAddresses "
+        "-ErrorAction SilentlyContinue",
+        "Write-Output 'RESTORED=automatic (DHCP)'",
+        "}",
+    ])
+    res = _powershell(script)
+    output = ((res.stdout or "") + (res.stderr or "")).strip()
+    if res.returncode != 0:
+        raise WindowsSetupError(output or "Could not restore the adapter.")
+    return output
+
+
+def adapter_state(if_index, name=None):
+    """The adapter as enumerate_adapters sees it now, or None if gone.
+
+    Matched by name first (stable across reboots), then by interface index.
+    """
+    enumerated = enumerate_adapters()
+    by_index = None
+    for adapter in enumerated["adapters"]:
+        if name and adapter["name"] == name:
+            return adapter
+        if adapter["if_index"] == if_index:
+            by_index = adapter
+    return by_index
+
+
+# --------------------------------------------------------------------------- #
+# DHCP packets
+# --------------------------------------------------------------------------- #
+def parse_packet(data):
+    """A BOOTREQUEST as a dict, or None for anything else (junk included)."""
+    if len(data) < 240 or data[236:240] != MAGIC_COOKIE:
+        return None
+    (op, htype, hlen, _hops, xid, _secs, flags, ciaddr, _yiaddr, _siaddr,
+     giaddr, chaddr, _sname, _file) = _BOOTP.unpack(data[:236])
+    if op != 1:  # only client -> server
+        return None
+    options = {}
+    i = 240
+    while i < len(data):
+        tag = data[i]
+        if tag == 0:
+            i += 1
+            continue
+        if tag == 255 or i + 1 >= len(data):
+            break
+        length = data[i + 1]
+        options[tag] = data[i + 2:i + 2 + length]
+        i += 2 + length
+    mac_len = hlen if 1 <= hlen <= 16 else 6
+    return {
+        "htype": htype, "hlen": hlen, "xid": xid, "flags": flags,
+        "ciaddr": ciaddr, "giaddr": giaddr,
+        "mac": chaddr[:mac_len], "chaddr": chaddr,
+        "options": options,
+    }
+
+
+def build_reply(pkt, msg_type, server_ip, client_ip, prefixlen=PREFIX_LENGTH,
+                lease=LEASE_SECONDS):
+    """An OFFER/ACK/NAK for the given request, padded to the BOOTP minimum."""
+    server = _ip_to_int(server_ip)
+    yiaddr = _ip_to_int(client_ip) if msg_type in (MSG_OFFER, MSG_ACK) else 0
+    ciaddr = pkt["ciaddr"] if msg_type == MSG_ACK else 0
+    mask = (0xFFFFFFFF << (32 - prefixlen)) & 0xFFFFFFFF
+    options = bytes([53, 1, msg_type, 54, 4]) + struct.pack("!I", server)
+    if msg_type != MSG_NAK:
+        options += bytes([51, 4]) + struct.pack("!I", lease)
+        options += bytes([1, 4]) + struct.pack("!I", mask)
+        # Router = us. A two-node wire has nowhere to route, but clients that
+        # insist on a gateway (and OPL configs that copy one) get a sane value.
+        options += bytes([3, 4]) + struct.pack("!I", server)
+    options += b"\xff"
+    reply = _BOOTP.pack(
+        2, pkt["htype"], pkt["hlen"], 0, pkt["xid"], 0, pkt["flags"],
+        ciaddr, yiaddr, server, pkt["giaddr"], pkt["chaddr"], b"", b""
+    ) + MAGIC_COOKIE + options
+    if len(reply) < 300:  # some clients drop sub-minimum BOOTP frames
+        reply += b"\x00" * (300 - len(reply))
+    return reply
+
+
+def _mac_text(mac):
+    return ":".join("{:02x}".format(b) for b in mac)
+
+
+# --------------------------------------------------------------------------- #
+# The responder
+# --------------------------------------------------------------------------- #
+class DhcpResponder:
+    """Single-lease DHCP for exactly one directly-attached console."""
+
+    # A direct link has one device on it. Several distinct MACs asking for
+    # addresses means this wire is a real network -- stop, do not adapt.
+    MAX_DISTINCT_MACS = 3
+    REPLY_BURST = 8          # token bucket: at most this many queued replies
+    REPLY_RATE = 4.0         # ...refilled at this many per second
+    IP_RECHECK_SECONDS = 30  # confirm our address still exists this often
+
+    def __init__(self, server_ip, client_ip, prefixlen=PREFIX_LENGTH,
+                 adapter_name="", log=print):
+        self.server_ip = server_ip
+        self.client_ip = client_ip
+        self.prefixlen = prefixlen
+        self.adapter_name = adapter_name
+        self.log = log
+        self.sock = None
+        self.mode = None  # 'specific' | 'wildcard'
+        self.macs_seen = set()
+        self.lease_mac = None
+        self._tokens = float(self.REPLY_BURST)
+        self._token_stamp = time.monotonic()
+        self._server_ip_bytes = struct.pack("!I", _ip_to_int(server_ip))
+        self._client_ip_bytes = struct.pack("!I", _ip_to_int(client_ip))
+
+    # -- sockets ----------------------------------------------------------- #
+    def open_socket(self):
+        """Bind to the adapter's own address; fall back to wildcard if this
+        machine does not deliver broadcasts to specifically-bound sockets
+        (checked with a real self-probe, not an assumption).
+
+        While the link is down Windows parks the address and the bind fails
+        with "address not available" -- the normal state when the PC boots
+        before the console is switched on. That is a reason to wait, not to
+        die: nothing can arrive on a down port, and the PS2's DHCP client
+        retransmits, so coming up a few seconds after the link does is fine.
+        """
+        waiting_logged = False
+        while True:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            try:
+                sock.bind((self.server_ip, DHCP_SERVER_PORT))
+                break
+            except OSError as e:
+                sock.close()
+                not_ready = (e.errno == errno.EADDRNOTAVAIL
+                             or getattr(e, "winerror", None) == 10049)
+                if not not_ready:
+                    raise DirectLinkRefused(
+                        "cannot listen on {}:{} -- {}. Is another DHCP "
+                        "service running (Windows ICS, or a leftover PS2 "
+                        "Servers helper)?".format(
+                            self.server_ip, DHCP_SERVER_PORT, e))
+                if not waiting_logged:
+                    waiting_logged = True
+                    self.log("waiting for the link to come up ({} is not "
+                             "ready -- cable unplugged or console off?)"
+                             .format(self.server_ip))
+                time.sleep(3)
+        if waiting_logged:
+            self.log("link is up")
+        if self._probe_broadcast_delivery(sock):
+            self.sock = sock
+            self.mode = "specific"
+            self.log("listening on {}:{} (isolated to its own port)".format(
+                self.server_ip, DHCP_SERVER_PORT))
+            return
+        sock.close()
+        self.log("this machine does not deliver broadcasts to a "
+                 "specifically-bound socket; using guarded wildcard mode")
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        try:
+            sock.bind(("0.0.0.0", DHCP_SERVER_PORT))
+        except OSError as e:
+            sock.close()
+            raise DirectLinkRefused(
+                "cannot listen on UDP {} -- {}. Is another DHCP service "
+                "(Windows ICS?) running?".format(DHCP_SERVER_PORT, e))
+        self.sock = sock
+        self.mode = "wildcard"
+
+    def _probe_broadcast_delivery(self, sock):
+        """Send one broadcast from the adapter and see if `sock` hears it.
+
+        The probe body is deliberately not a DHCP packet (no magic cookie), so
+        anything else that might be listening ignores it as junk.
+        """
+        probe = b"ps2srv-directlink-probe"
+        tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        tx.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        try:
+            tx.bind((self.server_ip, 0))
+            tx.sendto(probe, ("255.255.255.255", DHCP_SERVER_PORT))
+        except OSError:
+            return False
+        finally:
+            tx.close()
+        sock.settimeout(1.0)
+        try:
+            deadline = time.monotonic() + 1.5
+            while time.monotonic() < deadline:
+                data, _src = sock.recvfrom(2048)
+                if data == probe:
+                    return True
+        except socket.timeout:
+            pass
+        except OSError:
+            return False
+        return False
+
+    def _server_ip_still_present(self):
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.bind((self.server_ip, 0))
+            return True
+        except OSError:
+            return False
+        finally:
+            s.close()
+
+    # -- refusals ---------------------------------------------------------- #
+    def _take_token(self):
+        now = time.monotonic()
+        self._tokens = min(self.REPLY_BURST,
+                           self._tokens + (now - self._token_stamp) * self.REPLY_RATE)
+        self._token_stamp = now
+        if self._tokens >= 1.0:
+            self._tokens -= 1.0
+            return True
+        return False
+
+    def _track_mac(self, mac):
+        if mac not in self.macs_seen:
+            self.macs_seen.add(mac)
+            if len(self.macs_seen) > self.MAX_DISTINCT_MACS:
+                raise DirectLinkRefused(
+                    "{} different devices are asking for addresses -- this "
+                    "wire is a real network, not a direct PS2 link. Stopping "
+                    "so a real network is never disrupted.".format(
+                        len(self.macs_seen)))
+
+    # -- protocol ---------------------------------------------------------- #
+    def handle_packet(self, data, src):
+        """(reply_bytes, (dst_ip, dst_port)) or None. Pure enough to test."""
+        pkt = parse_packet(data)
+        if pkt is None:
+            return None
+        mtype_raw = pkt["options"].get(53)
+        mtype = mtype_raw[0] if mtype_raw else None
+        if mtype not in (MSG_DISCOVER, MSG_REQUEST, MSG_DECLINE, MSG_RELEASE,
+                         MSG_INFORM):
+            return None  # server-to-server chatter or junk
+        self._track_mac(pkt["mac"])
+        mac = _mac_text(pkt["mac"])
+
+        if mtype == MSG_DECLINE:
+            # The client ARP-checked the offered address and someone answered.
+            # On a true two-node wire that cannot happen.
+            self.log("client {} DECLINED {} -- is something else on this "
+                     "wire?".format(mac, self.client_ip))
+            self.lease_mac = None
+            return None
+        if mtype == MSG_RELEASE:
+            self.log("client {} released its address".format(mac))
+            if pkt["mac"] == self.lease_mac:
+                self.lease_mac = None
+            return None
+        if mtype == MSG_INFORM:
+            return None
+
+        if not self._take_token():
+            self.log("reply rate limit hit; dropping a request")
+            return None
+
+        if mtype == MSG_DISCOVER:
+            self.lease_mac = pkt["mac"]
+            self.log("offering {} to {}".format(self.client_ip, mac))
+            return (build_reply(pkt, MSG_OFFER, self.server_ip, self.client_ip,
+                                self.prefixlen),
+                    self._reply_dest(pkt, src))
+
+        # REQUEST. A server id naming someone else means the client chose
+        # another server's offer -- none of our business, stay silent.
+        server_id = pkt["options"].get(54)
+        if server_id and server_id != self._server_ip_bytes:
+            return None
+        requested = pkt["options"].get(50)
+        if requested is None and pkt["ciaddr"]:
+            requested = struct.pack("!I", pkt["ciaddr"])
+        if requested == self._client_ip_bytes:
+            self.lease_mac = pkt["mac"]
+            self.log("acknowledging {} for {}".format(self.client_ip, mac))
+            return (build_reply(pkt, MSG_ACK, self.server_ip, self.client_ip,
+                                self.prefixlen),
+                    self._reply_dest(pkt, src))
+        want = (socket.inet_ntoa(requested) if requested and len(requested) == 4
+                else "?")
+        self.log("client {} asked for {}; sending NAK so it re-discovers"
+                 .format(mac, want))
+        return (build_reply(pkt, MSG_NAK, self.server_ip, self.client_ip,
+                            self.prefixlen),
+                self._reply_dest(pkt, src, nak=True))
+
+    def _reply_dest(self, pkt, src, nak=False):
+        # A renewing client already has an address and expects unicast.
+        if not nak and pkt["ciaddr"] and src and src[0] not in ("0.0.0.0", ""):
+            return (src[0], DHCP_CLIENT_PORT)
+        if self.mode == "wildcard":
+            # Containment: a subnet-directed broadcast routes out the chosen
+            # adapter alone; a limited broadcast from a wildcard socket could
+            # egress the machine's default (real-LAN) interface instead.
+            net = _network_of(self.server_ip, self.prefixlen)
+            bcast = _int_to_ip(net | (0xFFFFFFFF >> self.prefixlen))
+            return (bcast, DHCP_CLIENT_PORT)
+        return ("255.255.255.255", DHCP_CLIENT_PORT)
+
+    # -- main loop ---------------------------------------------------------- #
+    def serve_forever(self):
+        self.sock.settimeout(1.0)
+        last_check = time.monotonic()
+        self.log("waiting for the PS2 to ask for an address "
+                 "(it will get {})".format(self.client_ip))
+        while True:
+            now = time.monotonic()
+            if now - last_check > self.IP_RECHECK_SECONDS:
+                last_check = now
+                if not self._server_ip_still_present():
+                    raise DirectLinkRefused(
+                        "{} is no longer configured on this PC; "
+                        "stopping".format(self.server_ip))
+            try:
+                data, src = self.sock.recvfrom(2048)
+            except socket.timeout:
+                continue
+            except OSError as e:
+                raise DirectLinkRefused("socket error: {}".format(e))
+            result = self.handle_packet(data, src)
+            if result is None:
+                continue
+            reply, dest = result
+            try:
+                self.sock.sendto(reply, dest)
+            except OSError as e:
+                self.log("could not send reply to {}: {}".format(dest, e))
+
+
+# --------------------------------------------------------------------------- #
+# --serve directlink entry point
+# --------------------------------------------------------------------------- #
+def _startup_adapter_check(adapter_name, if_index, server_ip):
+    """Re-verify the refusals in the responder process itself.
+
+    The parent checked, the elevated configure pass checked; this third check
+    covers the daily case -- the responder auto-starting on a later launch,
+    long after those passes ran, onto whatever the port is plugged into NOW.
+    """
+    adapter = adapter_state(if_index, adapter_name or None)
+    if adapter is None:
+        raise DirectLinkRefused(
+            "the direct-link network port is no longer present")
+    # allow_down: the console being off at PC boot is normal; open_socket
+    # waits for the link. Gateway/lease stay hard refusals.
+    ok, reason = classify_adapter(adapter, allow_down=True)
+    if not ok:
+        raise DirectLinkRefused(
+            "refusing to answer DHCP on '{}': {}".format(
+                adapter["name"], reason))
+    if not any(i["ip"] == server_ip for i in adapter["ipv4"]):
+        raise DirectLinkRefused(
+            "'{}' no longer has the direct-link address {} -- tick the "
+            "direct link box again to set it up".format(
+                adapter["name"], server_ip))
+
+
+def run_responder(argv):
+    """`--serve directlink` target. Long flags only (Nuitka self-exec guard)."""
+    import argparse
+    parser = argparse.ArgumentParser(prog="directlink", add_help=False)
+    parser.add_argument("--server-ip", required=True)
+    parser.add_argument("--client-ip", required=True)
+    parser.add_argument("--prefix", type=int, default=PREFIX_LENGTH)
+    parser.add_argument("--adapter", default="")
+    parser.add_argument("--if-index", type=int, default=0)
+    parser.add_argument("--skip-adapter-check", action="store_true",
+                        help="tests only: no PowerShell at startup")
+    args = parser.parse_args(argv)
+
+    def log(msg):
+        print("[direct link] {}".format(msg), flush=True)
+
+    try:
+        if is_windows() and not args.skip_adapter_check:
+            _startup_adapter_check(args.adapter, args.if_index, args.server_ip)
+        responder = DhcpResponder(args.server_ip, args.client_ip, args.prefix,
+                                  adapter_name=args.adapter, log=log)
+        responder.open_socket()
+        responder.serve_forever()
+    except DirectLinkRefused as e:
+        log("REFUSED: {}".format(e))
+        return 3
+    except WindowsSetupError as e:
+        log("cannot start: {}".format(e))
+        return 2
+    except KeyboardInterrupt:
+        return 0
+    return 0

--- a/launcher/directlink.py
+++ b/launcher/directlink.py
@@ -24,7 +24,7 @@ LAN). Containment is layered:
     adapter that has a default gateway or holds a DHCP lease -- both mean
     "this is a real network, not a direct link".
   * A tripwire while running: a direct link has exactly one device, so seeing
-    several distinct client MACs means this is not a direct link; the
+    a second distinct client MAC means this is not a direct link; the
     responder stops rather than keep answering.
   * One lease, one address, and rate-limited replies.
 
@@ -33,6 +33,7 @@ sharing along, and is not ours to debug; this is ~150 lines we can fix.
 """
 
 import errno
+import ipaddress
 import json
 import socket
 import struct
@@ -67,8 +68,16 @@ class DirectLinkRefused(RuntimeError):
 
 
 # --------------------------------------------------------------------------- #
-# Small IPv4 math (no ipaddress import: these five lines are the whole need)
+# Small IPv4 helpers
 # --------------------------------------------------------------------------- #
+def _canonical_ipv4(value, label="IPv4 address"):
+    try:
+        return str(ipaddress.IPv4Address(str(value)))
+    except (ipaddress.AddressValueError, ValueError):
+        raise WindowsSetupError(
+            "Invalid {}: {!r}".format(label, value)) from None
+
+
 def _ip_to_int(ip):
     return struct.unpack("!I", socket.inet_aton(ip))[0]
 
@@ -279,6 +288,11 @@ def apply_adapter_config(if_index, server_ip, prefixlen=PREFIX_LENGTH):
     stale answer from the earlier scan (or a cable moved in between) cannot
     configure the wrong port.
     """
+    server_ip = _canonical_ipv4(server_ip, "direct-link server address")
+    prefixlen = int(prefixlen)
+    if not 1 <= prefixlen <= 32:
+        raise WindowsSetupError(
+            "Invalid direct-link prefix length: {}".format(prefixlen))
     script = "\n".join([
         "$ErrorActionPreference = 'Stop'",
         "$idx = {}".format(int(if_index)),
@@ -293,7 +307,10 @@ def apply_adapter_config(if_index, server_ip, prefixlen=PREFIX_LENGTH):
         "  throw 'REFUSED: that adapter holds a DHCP lease from a real network.'",
         "}",
         "$name = (Get-NetAdapter -InterfaceIndex $idx -ErrorAction Stop).Name",
+        "$mutationStarted = $false",
+        "try {",
         "Set-NetIPInterface -InterfaceIndex $idx -AddressFamily IPv4 -Dhcp Disabled",
+        "$mutationStarted = $true",
         "Get-NetIPAddress -InterfaceIndex $idx -AddressFamily IPv4 "
         "-ErrorAction SilentlyContinue | "
         "Remove-NetIPAddress -Confirm:$false -ErrorAction SilentlyContinue",
@@ -302,6 +319,19 @@ def apply_adapter_config(if_index, server_ip, prefixlen=PREFIX_LENGTH):
         "Set-DnsClientServerAddress -InterfaceIndex $idx -ResetServerAddresses "
         "-ErrorAction SilentlyContinue",
         "Write-Output ('CONFIGURED=' + $name)",
+        "} catch {",
+        "  $originalError = $_",
+        "  if ($mutationStarted) {",
+        "    Get-NetIPAddress -InterfaceIndex $idx -AddressFamily IPv4 "
+        "-ErrorAction SilentlyContinue | Remove-NetIPAddress -Confirm:$false "
+        "-ErrorAction SilentlyContinue",
+        "    Set-NetIPInterface -InterfaceIndex $idx -AddressFamily IPv4 "
+        "-Dhcp Enabled -ErrorAction SilentlyContinue",
+        "    Set-DnsClientServerAddress -InterfaceIndex $idx "
+        "-ResetServerAddresses -ErrorAction SilentlyContinue",
+        "  }",
+        "  throw $originalError",
+        "}",
     ])
     res = _powershell(script)
     output = ((res.stdout or "") + (res.stderr or "")).strip()
@@ -319,6 +349,8 @@ def restore_adapter_dhcp(if_index, expect_ip=None):
     """
     guard = ""
     if expect_ip:
+        expect_ip = _canonical_ipv4(
+            expect_ip, "expected direct-link server address")
         guard = "\n".join([
             "$cur = @(Get-NetIPAddress -InterfaceIndex $idx -AddressFamily IPv4 "
             "-ErrorAction SilentlyContinue | ForEach-Object { [string]$_.IPAddress })",
@@ -430,9 +462,9 @@ def _mac_text(mac):
 class DhcpResponder:
     """Single-lease DHCP for exactly one directly-attached console."""
 
-    # A direct link has one device on it. Several distinct MACs asking for
+    # A direct link has one device on it. A second distinct MAC asking for
     # addresses means this wire is a real network -- stop, do not adapt.
-    MAX_DISTINCT_MACS = 3
+    MAX_DISTINCT_MACS = 1
     REPLY_BURST = 8          # token bucket: at most this many queued replies
     REPLY_RATE = 4.0         # ...refilled at this many per second
     IP_RECHECK_SECONDS = 30  # confirm our address still exists this often
@@ -720,17 +752,19 @@ def run_responder(argv):
     parser.add_argument("--prefix", type=int, default=PREFIX_LENGTH)
     parser.add_argument("--adapter", default="")
     parser.add_argument("--if-index", type=int, default=0)
-    parser.add_argument("--skip-adapter-check", action="store_true",
-                        help="tests only: no PowerShell at startup")
     args = parser.parse_args(argv)
 
     def log(msg):
         print("[direct link] {}".format(msg), flush=True)
 
     try:
-        if is_windows() and not args.skip_adapter_check:
-            _startup_adapter_check(args.adapter, args.if_index, args.server_ip)
-        responder = DhcpResponder(args.server_ip, args.client_ip, args.prefix,
+        if not is_windows():
+            raise DirectLinkRefused(
+                "direct-link DHCP is supported only on Windows")
+        server_ip = _canonical_ipv4(args.server_ip, "direct-link server address")
+        client_ip = _canonical_ipv4(args.client_ip, "direct-link client address")
+        _startup_adapter_check(args.adapter, args.if_index, server_ip)
+        responder = DhcpResponder(server_ip, client_ip, args.prefix,
                                   adapter_name=args.adapter, log=log)
         responder.open_socket()
         responder.serve_forever()

--- a/launcher/directlink.py
+++ b/launcher/directlink.py
@@ -665,6 +665,13 @@ class DhcpResponder:
             except socket.timeout:
                 continue
             except OSError as e:
+                # Windows reports an ICMP "port unreachable" for an earlier
+                # UDP reply as WSAECONNRESET on the next recvfrom().  That says
+                # nothing about the health of this listening socket: the PS2
+                # may simply have moved between DHCP states.  Keep serving.
+                if (isinstance(e, ConnectionResetError)
+                        or getattr(e, "winerror", None) == 10054):
+                    continue
                 raise DirectLinkRefused("socket error: {}".format(e))
             result = self.handle_packet(data, src)
             if result is None:

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -16,9 +16,9 @@ import tkinter as tk
 import webbrowser
 from tkinter import filedialog, messagebox, ttk
 
-from . import config, elevate, netinfo, tray, windows_setup
+from . import config, directlink, elevate, netinfo, tray, windows_setup
 from .process import ServerProcess
-from .servers import REGISTRY, REPO_ROOT, frozen_self_exe, is_frozen
+from .servers import REGISTRY, REPO_ROOT, frozen_self_exe, is_frozen, serve_command
 
 DOT_RUNNING = "●"  # filled circle
 # Tab-header state. Filled = up, hollow = down, on the tab you can see without
@@ -93,6 +93,12 @@ Use "Remove PS2 Servers firewall rules" to delete only rules whose display names
 
 Removing those rules returns Windows to having no PS2 Servers-specific firewall rules. It does not add block rules. It does not change Windows SMB1. It does not remove unrelated firewall rules.
 
+Direct PS2-to-PC link
+
+A PS2 cabled straight into the PC has no router on the wire, so nothing hands the console an IP address and every network app fails the same way. Ticking "PS2 is plugged directly into this PC" fixes that: PS2 Servers gives the chosen network port a fixed address (one administrator prompt), allows DHCP through the firewall, and runs a small DHCP helper that answers only on that port, so the console configures itself.
+
+The helper is deliberately paranoid, because a DHCP server answering on a real network could disrupt every device on it. It binds to the direct-link port alone, refuses to run if that port reaches a router or holds a DHCP lease, hands out exactly one address to one console, and stops itself if several different devices start asking. Unticking the box stops the helper and returns the port to automatic (DHCP); "Remove PS2 Servers firewall rules" also undoes it. Direct link mode is currently Windows-only.
+
 No terminal required
 
 The buttons in the launcher footer are the normal way to manage PS2 Servers' Windows changes. Use "Allow through firewall" to add or refresh the rules. Use "Remove PS2 Servers firewall rules" to undo them. Use "Stop all" to shut down every running PS2 Servers process from the GUI.
@@ -119,6 +125,7 @@ TAB_TITLES = {
     "udpfs": "UDPFS",
     "udpbd": "UDPBD",
     "setup": "SETUP",
+    "directlink": "DIRECT",
 }
 
 
@@ -351,6 +358,9 @@ class LauncherApp:
         self.logs = {}
         self.saved = config.load()
         self._firewall_ok = set()   # _restore fills it; never read before it exists
+        self._direct_proc = None            # the DHCP helper child, when running
+        self._direct_expected = False       # we started it and expect it alive
+        self._direct_busy = False           # an enable/disable flow is mid-flight
         self._tray = None
         self._tray_option_widgets = []
         self.close_to_tray_var = tk.BooleanVar(
@@ -394,8 +404,16 @@ class LauncherApp:
             self.root.after(350, self._allow_pending)
         elif self.saved.get("pending_cleanup"):
             self.root.after(350, self._cleanup_pending)
+        elif self.saved.get("pending_direct_link"):
+            self.root.after(350, self._direct_link_pending)
+        elif self.saved.get("pending_direct_link_off"):
+            self.root.after(350, self._direct_link_off_pending)
         elif self.saved.get("pending_start"):
             self.root.after(350, self._start_pending)
+        elif (self.saved.get("direct_link") or {}).get("enabled"):
+            # Re-arm the DHCP helper for an already-configured direct link.
+            # Skipped while any pending flow runs: those flows own the state.
+            self.root.after(600, self._direct_link_startup)
 
     def _configure_window(self):
         screen_height = self.root.winfo_screenheight()
@@ -525,6 +543,27 @@ class LauncherApp:
                   style="TopStripHint.TLabel", wraplength=420).grid(
             row=0, column=3, sticky="w", padx=(12, 0))
 
+        # direct PS2-to-PC link: adapter setup + DHCP helper behind one checkbox.
+        # Windows-only for now -- adapter configuration is per-OS plumbing.
+        if windows_setup.is_windows():
+            direct = ttk.Frame(parent, style="TopStrip.TFrame", padding=(12, 8))
+            direct.pack(fill="x", padx=16, pady=(0, 8))
+            direct.columnconfigure(1, weight=1)
+            self.direct_link_var = tk.BooleanVar(value=False)
+            self._direct_check = ttk.Checkbutton(
+                direct, text="PS2 is plugged directly into this PC",
+                variable=self.direct_link_var, style="Card.TCheckbutton",
+                command=self._on_direct_link_toggle)
+            self._direct_check.grid(row=0, column=0, sticky="w")
+            self._direct_status = ttk.Label(
+                direct, text=self._DIRECT_STATUS_OFF,
+                style="TopStripHint.TLabel", wraplength=640)
+            self._direct_status.grid(row=0, column=1, sticky="w", padx=(12, 0))
+        else:
+            self.direct_link_var = None
+            self._direct_check = None
+            self._direct_status = None
+
         # main tabs: one server per tab, plus a shared terminal tab
         self.nb = ttk.Notebook(parent)
         self.nb.pack(fill="x", padx=16, pady=(0, 12))
@@ -556,6 +595,7 @@ class LauncherApp:
         for server in REGISTRY.values():
             self.logs[server.key] = self.terminal
         self.logs["setup"] = self.terminal
+        self.logs["directlink"] = self.terminal
 
         self._build_about_tab()
 
@@ -676,6 +716,427 @@ class LauncherApp:
         self.ip_var.set(netinfo.best_lan_ip())
         for key in self.procs:
             self.cards[key].refresh_status(self.is_running(key))
+
+    # -- direct PS2-to-PC link -------------------------------------------- #
+    _DIRECT_STATUS_OFF = (
+        "Tick this if there is no router between the PS2 and this PC. It sets "
+        "up the network port and gives the console its address automatically.")
+
+    def _set_direct_status(self, text):
+        if self._direct_status is not None:
+            self._direct_status.config(text=text)
+
+    def _set_direct_checkbox(self, ticked, busy=False):
+        """Reflect state without re-entering the toggle handler (ttk fires the
+        command only on clicks, so programmatic var changes are safe)."""
+        self._direct_busy = busy
+        if self.direct_link_var is not None:
+            self.direct_link_var.set(bool(ticked))
+        if self._direct_check is not None:
+            self._direct_check.config(state="disabled" if busy else "normal")
+
+    def _direct_ready_status(self, cfg):
+        return ("Ready on '{adapter}': this PC is {server}, the PS2 gets "
+                "{client} by itself. Use {server} wherever an app asks for "
+                "the server IP.".format(adapter=cfg.get("adapter", "?"),
+                                        server=cfg.get("server_ip", "?"),
+                                        client=cfg.get("client_ip", "?")))
+
+    def _on_direct_link_toggle(self):
+        if self._direct_busy:
+            return
+        if self.direct_link_var.get():
+            self._direct_link_begin_enable()
+        else:
+            self._direct_link_begin_disable()
+
+    def _direct_link_begin_enable(self):
+        self._set_direct_checkbox(True, busy=True)
+        self._set_direct_status(
+            "Looking for the network port the PS2 is plugged into…")
+
+        def worker():
+            try:
+                enumerated = directlink.enumerate_adapters()
+            except Exception as e:
+                self.root.after(0, lambda err=e: self._direct_link_fail(
+                    "Could not inspect this PC's network ports:\n\n{}".format(err)))
+                return
+            self.root.after(0, lambda: self._direct_link_choose(enumerated))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _direct_link_fail(self, message, title="Direct link setup failed"):
+        messagebox.showerror(title, message)
+        self._append_log("directlink", "[launcher] {}\n".format(
+            message.replace("\n", " ").strip()))
+        self._set_direct_checkbox(False)
+        self._set_direct_status(self._DIRECT_STATUS_OFF)
+
+    def _direct_link_choose(self, enumerated):
+        candidates, rejected = directlink.find_candidates(enumerated)
+        if not candidates:
+            lines = ["No network port looks like a direct PS2 link right now.",
+                     ""]
+            for adapter, reason in rejected[:8]:
+                lines.append("• {} — {}".format(adapter["name"], reason))
+            lines += ["",
+                      "Plug the PS2 straight into this PC with an ethernet "
+                      "cable, turn the console on, then tick the box again."]
+            messagebox.showinfo("No direct link found", "\n".join(lines))
+            self._set_direct_checkbox(False)
+            self._set_direct_status(self._DIRECT_STATUS_OFF)
+            return
+
+        adapter = (candidates[0] if len(candidates) == 1
+                   else self._pick_adapter_dialog(candidates))
+        if adapter is None:
+            self._set_direct_checkbox(False)
+            self._set_direct_status(self._DIRECT_STATUS_OFF)
+            return
+
+        taken = directlink.taken_networks(enumerated,
+                                          exclude_if_index=adapter["if_index"])
+        server_ip, client_ip = directlink.choose_subnet(taken)
+        if not server_ip:
+            self._direct_link_fail(
+                "Could not find a private network range that does not "
+                "collide with one this PC already uses.")
+            return
+
+        current = [i["ip"] for i in adapter.get("ipv4", [])
+                   if i["ip"] and not i["ip"].startswith("169.254.")]
+        note = ""
+        if current:
+            note = ("\n\nIts current address ({}) will be replaced; unticking "
+                    "the box returns the port to automatic (DHCP), not to "
+                    "that address.".format(", ".join(current)))
+        if not messagebox.askyesno(
+                "Set up the direct PS2 link?",
+                "Use '{name}' ({desc}) as the direct PS2 link?\n\n"
+                "PS2 Servers will:\n"
+                "• give this PC the fixed address {server} on that port\n"
+                "• allow DHCP (UDP 67) through the firewall\n"
+                "• run a small DHCP helper that answers ONLY on that port, "
+                "handing the PS2 {client}\n\n"
+                "This needs one administrator prompt. The helper refuses to "
+                "run if that port turns out to be a real network (router or "
+                "DHCP server present). Untick the box to undo everything."
+                "{note}".format(name=adapter["name"], desc=adapter["desc"],
+                                server=server_ip, client=client_ip,
+                                note=note)):
+            self._set_direct_checkbox(False)
+            self._set_direct_status(self._DIRECT_STATUS_OFF)
+            return
+
+        self.saved["direct_link"] = {
+            "enabled": False,
+            "adapter": adapter["name"],
+            "if_index": adapter["if_index"],
+            "server_ip": server_ip,
+            "client_ip": client_ip,
+            "prefix": directlink.PREFIX_LENGTH,
+        }
+
+        if not elevate.is_admin():
+            if not elevate.can_elevate():
+                self._direct_link_fail(
+                    "Setting a fixed address on the port needs administrator "
+                    "rights, and this environment cannot request them.")
+                return
+            self._save(pending_direct_link=True)
+            if elevate.relaunch_as_admin():
+                self.stop_all()
+                if self._tray:
+                    self._tray.stop()
+                self.root.destroy()
+            else:
+                self.saved.pop("pending_direct_link", None)
+                self._save()
+                self._direct_link_fail("Could not restart as administrator.")
+            return
+
+        self._direct_link_apply_async()
+
+    def _pick_adapter_dialog(self, candidates):
+        win = tk.Toplevel(self.root)
+        win.title("Which port is the PS2 in?")
+        win.transient(self.root)
+        win.grab_set()
+        win.resizable(False, False)
+        ttk.Label(win, justify="left",
+                  text="More than one network port could be the PS2 link.\n"
+                       "Pick the one the PS2 is plugged into:").pack(
+            padx=14, pady=(12, 6), anchor="w")
+        box = tk.Listbox(win, height=max(2, min(6, len(candidates))), width=64,
+                         exportselection=False)
+        for adapter in candidates:
+            box.insert("end", "{}  —  {}".format(adapter["name"], adapter["desc"]))
+        box.selection_set(0)
+        box.pack(padx=14, pady=4)
+        chosen = {"adapter": None}
+        buttons = ttk.Frame(win)
+        buttons.pack(fill="x", padx=14, pady=(6, 12))
+
+        def use():
+            selection = box.curselection()
+            if selection:
+                chosen["adapter"] = candidates[selection[0]]
+            win.destroy()
+
+        ttk.Button(buttons, text="Use this port", command=use).pack(
+            side="right")
+        ttk.Button(buttons, text="Cancel", command=win.destroy).pack(
+            side="right", padx=(0, 8))
+        box.bind("<Double-Button-1>", lambda _e: use())
+        win.wait_window()
+        return chosen["adapter"]
+
+    def _direct_link_apply_async(self):
+        cfg = self.saved.get("direct_link") or {}
+        if not cfg.get("server_ip"):
+            self._direct_link_fail("Direct link settings were lost; please "
+                                   "tick the box again.")
+            return
+        self._set_direct_checkbox(True, busy=True)
+        self._set_direct_status("Setting up '{}'…".format(cfg.get("adapter")))
+        self.nb.select(self.terminal_tab)
+
+        def worker():
+            try:
+                configured = directlink.apply_adapter_config(
+                    cfg["if_index"], cfg["server_ip"],
+                    cfg.get("prefix", directlink.PREFIX_LENGTH))
+                firewall = windows_setup.apply_setup("directlink", {})
+            except Exception as e:
+                self.root.after(0, lambda err=e: self._direct_link_fail(
+                    "Could not set up the direct link:\n\n{}".format(err)))
+                return
+            output = "\n".join(
+                filter(None, [configured, firewall.get("output") or ""]))
+            self.root.after(0, lambda: self._direct_link_enabled(output))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _direct_link_enabled(self, output):
+        if output:
+            self._append_log("directlink", "[setup] {}\n".format(
+                output.replace("\n", "\n[setup] ")))
+        cfg = self.saved.get("direct_link") or {}
+        cfg["enabled"] = True
+        self.saved["direct_link"] = cfg
+        self._start_direct_responder()
+        # The LAN IP box is what every OPL hint shows; the direct link has
+        # exactly one address the PS2 can reach.
+        self.ip_var.set(cfg["server_ip"])
+        self._save()
+        self._set_direct_checkbox(True)
+        self._set_direct_status(self._direct_ready_status(cfg))
+
+    def _start_direct_responder(self):
+        if self._direct_proc is not None and self._direct_proc.is_running():
+            return
+        cfg = self.saved.get("direct_link") or {}
+        args = ["--server-ip", cfg["server_ip"],
+                "--client-ip", cfg["client_ip"],
+                "--prefix", str(cfg.get("prefix", directlink.PREFIX_LENGTH)),
+                "--adapter", cfg.get("adapter", ""),
+                "--if-index", str(cfg.get("if_index", 0))]
+        command = serve_command("directlink", args)
+        self._append_log("directlink",
+                         "[launcher] starting DHCP helper: {}\n".format(
+                             " ".join(command)))
+        proc = ServerProcess("directlink", command, cwd=REPO_ROOT,
+                             on_output=self._on_output)
+        try:
+            proc.start()
+        except OSError as e:
+            self._direct_link_fail("Could not start the DHCP helper: {}".format(e))
+            return
+        self._direct_proc = proc
+        self._direct_expected = True
+
+    def _stop_direct_responder(self):
+        self._direct_expected = False
+        if self._direct_proc is not None:
+            if self._direct_proc.is_running():
+                self._direct_proc.stop()
+                self._append_log("directlink", "[launcher] DHCP helper stopped\n")
+            self._direct_proc = None
+
+    def _direct_link_begin_disable(self):
+        cfg = self.saved.get("direct_link") or {}
+        if not cfg.get("enabled"):
+            self._stop_direct_responder()
+            self._set_direct_checkbox(False)
+            self._set_direct_status(self._DIRECT_STATUS_OFF)
+            return
+        choice = messagebox.askyesnocancel(
+            "Turn off the direct link?",
+            "Return '{}' to automatic (DHCP)?\n\n"
+            "Yes: undo the network setup (one administrator prompt if "
+            "needed).\nNo: stop the DHCP helper but keep the fixed address "
+            "{}.\nCancel: leave the direct link on.".format(
+                cfg.get("adapter", "?"), cfg.get("server_ip", "?")))
+        if choice is None:
+            self._set_direct_checkbox(True)
+            return
+
+        self._stop_direct_responder()
+        cfg["enabled"] = False
+        self.saved["direct_link"] = cfg
+
+        if choice is False:
+            self._save()
+            self._set_direct_checkbox(False)
+            self._set_direct_status(
+                "Off. '{}' keeps the fixed address {}; tick the box to use "
+                "it again.".format(cfg.get("adapter", "?"),
+                                   cfg.get("server_ip", "?")))
+            return
+
+        if not elevate.is_admin():
+            if not elevate.can_elevate():
+                self._save()
+                self._direct_link_fail(
+                    "Returning the port to automatic (DHCP) needs "
+                    "administrator rights, and this environment cannot "
+                    "request them. The DHCP helper is stopped.")
+                return
+            self._save(pending_direct_link_off=True)
+            if elevate.relaunch_as_admin():
+                self.stop_all()
+                if self._tray:
+                    self._tray.stop()
+                self.root.destroy()
+            else:
+                self.saved.pop("pending_direct_link_off", None)
+                self._save()
+                self._direct_link_fail(
+                    "Could not restart as administrator. The DHCP helper is "
+                    "stopped, but '{}' still has the fixed address {} — untick "
+                    "and tick later, or use Windows network settings, to "
+                    "return it to DHCP.".format(cfg.get("adapter", "?"),
+                                                cfg.get("server_ip", "?")))
+            return
+
+        self._save()
+        self._direct_link_restore_async(cfg)
+
+    def _direct_link_restore_async(self, cfg):
+        self._set_direct_checkbox(False, busy=True)
+        self._set_direct_status(
+            "Returning '{}' to automatic (DHCP)…".format(cfg.get("adapter")))
+
+        def worker():
+            try:
+                output = directlink.restore_adapter_dhcp(
+                    cfg.get("if_index", 0), expect_ip=cfg.get("server_ip"))
+            except Exception as e:
+                self.root.after(0, lambda err=e: self._direct_link_fail(
+                    "Could not return the port to automatic (DHCP):\n\n{}"
+                    .format(err), title="Direct link cleanup failed"))
+                return
+            self.root.after(0, lambda: self._direct_link_restored(output))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _direct_link_restored(self, output):
+        if output:
+            self._append_log("directlink", "[setup] {}\n".format(
+                output.replace("\n", "\n[setup] ")))
+        self._set_direct_checkbox(False)
+        self._set_direct_status(self._DIRECT_STATUS_OFF)
+
+    def _direct_link_pending(self):
+        self.saved.pop("pending_direct_link", None)
+        self._save()
+        cfg = self.saved.get("direct_link") or {}
+        if not cfg.get("server_ip"):
+            return
+        self.nb.select(self.terminal_tab)
+        self._append_log("directlink",
+                         "[launcher] continuing direct link setup after "
+                         "administrator restart\n")
+        if not elevate.is_admin():
+            self._direct_link_fail(
+                "Administrator rights were not granted; the direct link was "
+                "not set up.")
+            return
+        self._direct_link_apply_async()
+
+    def _direct_link_off_pending(self):
+        self.saved.pop("pending_direct_link_off", None)
+        self._save()
+        cfg = self.saved.get("direct_link") or {}
+        self.nb.select(self.terminal_tab)
+        self._append_log("directlink",
+                         "[launcher] continuing direct link cleanup after "
+                         "administrator restart\n")
+        if not elevate.is_admin():
+            self._direct_link_fail(
+                "Administrator rights were not granted. '{}' still has the "
+                "fixed address {}.".format(cfg.get("adapter", "?"),
+                                           cfg.get("server_ip", "?")),
+                title="Direct link cleanup failed")
+            return
+        if not cfg.get("if_index"):
+            return
+        self._direct_link_restore_async(cfg)
+
+    def _direct_link_startup(self):
+        """Re-arm an already-configured direct link on launch.
+
+        The adapter's static address survives reboots; the helper does not.
+        Verify the port still looks like ours, then start the helper (which
+        re-checks the refusals itself before answering anything).
+        """
+        cfg = self.saved.get("direct_link") or {}
+        if not cfg.get("enabled") or self.direct_link_var is None:
+            return
+        self._set_direct_checkbox(True, busy=True)
+        self._set_direct_status("Checking the direct-link port…")
+
+        def worker():
+            problem = None
+            try:
+                adapter = directlink.adapter_state(cfg.get("if_index", 0),
+                                                   cfg.get("adapter") or None)
+                if adapter is None:
+                    problem = "the direct-link port is no longer present"
+                elif not any(i["ip"] == cfg.get("server_ip")
+                             for i in adapter["ipv4"]):
+                    problem = ("'{}' no longer has the address {}".format(
+                        adapter["name"], cfg.get("server_ip")))
+                else:
+                    # An unplugged cable is fine -- the helper waits for it.
+                    # A gateway or lease is not: refuse like the helper would.
+                    ok, reason = directlink.classify_adapter(adapter,
+                                                             allow_down=True)
+                    if not ok:
+                        problem = "'{}' {}".format(adapter["name"], reason)
+            except Exception as e:
+                problem = str(e)
+            self.root.after(0, lambda: self._direct_link_startup_done(problem))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _direct_link_startup_done(self, problem):
+        cfg = self.saved.get("direct_link") or {}
+        if problem:
+            cfg["enabled"] = False
+            self.saved["direct_link"] = cfg
+            self._save()
+            self._append_log("directlink",
+                             "[launcher] direct link not re-armed: {}\n".format(problem))
+            self._set_direct_checkbox(False)
+            self._set_direct_status(
+                "Direct link is off: {}. Tick the box to set it up again."
+                .format(problem))
+            return
+        self._start_direct_responder()
+        self._set_direct_checkbox(True)
+        self._set_direct_status(self._direct_ready_status(cfg))
 
     # -- run/stop --------------------------------------------------------- #
     def is_running(self, key):
@@ -940,6 +1401,8 @@ class LauncherApp:
     def _allow_windows_setup_async(self):
         self._append_log("setup", "[setup] allowing PS2 Servers through Windows Firewall\n")
         values = {key: card.values() for key, card in self.cards.items()}
+        if (self.saved.get("direct_link") or {}).get("enabled"):
+            values["directlink"] = {}
 
         def worker():
             try:
@@ -984,12 +1447,16 @@ class LauncherApp:
             self.stop_all()
 
         if require_confirm:
+            message = ("This removes only Windows Firewall rules whose display names "
+                       "start with:\n\nPS2 Servers -\n\n"
+                       "It does not create block rules. After this, Windows returns to "
+                       "having no PS2 Servers-specific firewall rules.")
+            if (self.saved.get("direct_link") or {}).get("server_ip"):
+                message += ("\n\nThe direct PS2 link is also undone: its DHCP "
+                            "helper stops and the port returns to automatic "
+                            "(DHCP).")
             if not messagebox.askyesno(
-                    "Remove PS2 Servers firewall rules?",
-                    "This removes only Windows Firewall rules whose display names "
-                    "start with:\n\nPS2 Servers -\n\n"
-                    "It does not create block rules. After this, Windows returns to "
-                    "having no PS2 Servers-specific firewall rules. Continue?"):
+                    "Remove PS2 Servers firewall rules?", message + "\n\nContinue?"):
                 return
 
         if not elevate.is_admin():
@@ -1054,7 +1521,32 @@ class LauncherApp:
         # The cache says "these rules exist and match". They are about to not.
         self._forget_firewall_ok()
 
+        # Cleanup is the "give me my Windows back" button, so the direct link
+        # goes too: helper stopped here (main thread owns the process), the
+        # port returned to DHCP in the worker (we are already elevated).
+        direct_cfg = dict(self.saved.get("direct_link") or {})
+        if direct_cfg.get("server_ip"):
+            self._stop_direct_responder()
+            self.saved.pop("direct_link", None)
+            self._save()
+            self._set_direct_checkbox(False)
+            self._set_direct_status(self._DIRECT_STATUS_OFF)
+
         def worker():
+            if direct_cfg.get("server_ip"):
+                try:
+                    output = directlink.restore_adapter_dhcp(
+                        direct_cfg.get("if_index", 0),
+                        expect_ip=direct_cfg.get("server_ip"))
+                    self.root.after(0, lambda out=output: self._append_log(
+                        "directlink", "[setup] {}\n".format(
+                            out.replace("\n", "\n[setup] "))))
+                except Exception as e:
+                    # The firewall removal below still matters; report and go on.
+                    self.root.after(0, lambda err=e: self._append_log(
+                        "directlink",
+                        "[setup] could not return the direct-link port to "
+                        "DHCP: {}\n".format(err)))
             try:
                 result = windows_setup.remove_setup()
             except Exception as e:
@@ -1132,6 +1624,20 @@ class LauncherApp:
                 self.cards[key].toggle_btn.config(state="normal")
                 self._append_log(key, "[launcher] server exited (code {})\n".format(
                     proc.returncode))
+        if (self._direct_expected and self._direct_proc is not None
+                and not self._direct_proc.is_running()):
+            code = self._direct_proc.returncode
+            self._direct_expected = False
+            self._append_log("directlink",
+                             "[launcher] DHCP helper exited (code {})\n".format(code))
+            if code == 3:  # a safety refusal; the helper said why in the log
+                self._set_direct_status(
+                    "The DHCP helper stopped itself for safety — see the "
+                    "TERMINAL tab. Untick and tick the box to retry.")
+            else:
+                self._set_direct_status(
+                    "The DHCP helper stopped (code {}) — see the TERMINAL "
+                    "tab. Untick and tick the box to retry.".format(code))
         self.root.after(600, self._poll_status)
 
     # -- config ----------------------------------------------------------- #
@@ -1162,7 +1668,8 @@ class LauncherApp:
             self._saved_bool("minimize_to_tray", self.minimize_to_tray_var.get()))
 
     def _save(self, pending_start=None, pending_cleanup=False,
-              pending_firewall_allow=False):
+              pending_firewall_allow=False, pending_direct_link=False,
+              pending_direct_link_off=False):
         data = {"servers": {key: card.values() for key, card in self.cards.items()},
                 "ip": self.ip_var.get(),
                 "firewall_ok": sorted(getattr(self, "_firewall_ok", ())),
@@ -1175,12 +1682,18 @@ class LauncherApp:
                 "ip_custom": self.ip_var.get() not in self._detected_ips(),
                 "close_to_tray": bool(self.close_to_tray_var.get()),
                 "minimize_to_tray": bool(self.minimize_to_tray_var.get())}
+        if self.saved.get("direct_link"):
+            data["direct_link"] = self.saved["direct_link"]
         if pending_start:
             data["pending_start"] = pending_start
         if pending_cleanup:
             data["pending_cleanup"] = True
         if pending_firewall_allow:
             data["pending_firewall_allow"] = True
+        if pending_direct_link:
+            data["pending_direct_link"] = True
+        if pending_direct_link_off:
+            data["pending_direct_link_off"] = True
         try:
             config.save(data)
         except OSError:
@@ -1227,6 +1740,7 @@ class LauncherApp:
         # look like a frozen window
         self.root.withdraw()
         self.stop_all()
+        self._stop_direct_responder()
         if self._tray:
             self._tray.stop()
         self.root.destroy()

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -97,7 +97,7 @@ Direct PS2-to-PC link
 
 A PS2 cabled straight into the PC has no router on the wire, so nothing hands the console an IP address and every network app fails the same way. Ticking "PS2 is plugged directly into this PC" fixes that: PS2 Servers gives the chosen network port a fixed address (one administrator prompt), allows DHCP through the firewall, and runs a small DHCP helper that answers only on that port, so the console configures itself.
 
-The helper is deliberately paranoid, because a DHCP server answering on a real network could disrupt every device on it. It binds to the direct-link port alone, refuses to run if that port reaches a router or holds a DHCP lease, hands out exactly one address to one console, and stops itself if several different devices start asking. Unticking the box stops the helper and returns the port to automatic (DHCP); "Remove PS2 Servers firewall rules" also undoes it. Direct link mode is currently Windows-only.
+The helper is deliberately paranoid, because a DHCP server answering on a real network could disrupt every device on it. It binds to the direct-link port alone, refuses to run if that port reaches a router or holds a DHCP lease, hands out exactly one address to one console, and stops itself if a second device starts asking. Unticking the box stops the helper and returns the port to automatic (DHCP); "Remove PS2 Servers firewall rules" also undoes it. Direct link mode is currently Windows-only.
 
 No terminal required
 
@@ -903,13 +903,27 @@ class LauncherApp:
         self.nb.select(self.terminal_tab)
 
         def worker():
+            configured = None
             try:
                 configured = directlink.apply_adapter_config(
                     cfg["if_index"], cfg["server_ip"],
                     cfg.get("prefix", directlink.PREFIX_LENGTH))
-                firewall = windows_setup.apply_setup("directlink", {})
+                firewall = windows_setup.apply_setup(
+                    "directlink", {"server_ip": cfg["server_ip"]})
             except Exception as e:
-                self.root.after(0, lambda err=e: self._direct_link_fail(
+                error = e
+                if configured is not None:
+                    try:
+                        rollback = directlink.restore_adapter_dhcp(
+                            cfg["if_index"], expect_ip=cfg["server_ip"])
+                        error = RuntimeError(
+                            "{}\n\nThe adapter was returned to automatic "
+                            "(DHCP).\n{}".format(e, rollback))
+                    except Exception as rollback_error:
+                        error = RuntimeError(
+                            "{}\n\nAutomatic rollback also failed: {}"
+                            .format(e, rollback_error))
+                self.root.after(0, lambda err=error: self._direct_link_fail(
                     "Could not set up the direct link:\n\n{}".format(err)))
                 return
             output = "\n".join(
@@ -923,9 +937,10 @@ class LauncherApp:
             self._append_log("directlink", "[setup] {}\n".format(
                 output.replace("\n", "\n[setup] ")))
         cfg = self.saved.get("direct_link") or {}
+        if not self._start_direct_responder():
+            return
         cfg["enabled"] = True
         self.saved["direct_link"] = cfg
-        self._start_direct_responder()
         # The LAN IP box is what every OPL hint shows; the direct link has
         # exactly one address the PS2 can reach.
         self.ip_var.set(cfg["server_ip"])
@@ -935,7 +950,7 @@ class LauncherApp:
 
     def _start_direct_responder(self):
         if self._direct_proc is not None and self._direct_proc.is_running():
-            return
+            return True
         cfg = self.saved.get("direct_link") or {}
         args = ["--server-ip", cfg["server_ip"],
                 "--client-ip", cfg["client_ip"],
@@ -952,9 +967,10 @@ class LauncherApp:
             proc.start()
         except OSError as e:
             self._direct_link_fail("Could not start the DHCP helper: {}".format(e))
-            return
+            return False
         self._direct_proc = proc
         self._direct_expected = True
+        return True
 
     def _stop_direct_responder(self):
         self._direct_expected = False
@@ -1134,7 +1150,11 @@ class LauncherApp:
                 "Direct link is off: {}. Tick the box to set it up again."
                 .format(problem))
             return
-        self._start_direct_responder()
+        if not self._start_direct_responder():
+            cfg["enabled"] = False
+            self.saved["direct_link"] = cfg
+            self._save()
+            return
         self._set_direct_checkbox(True)
         self._set_direct_status(self._direct_ready_status(cfg))
 
@@ -1401,8 +1421,9 @@ class LauncherApp:
     def _allow_windows_setup_async(self):
         self._append_log("setup", "[setup] allowing PS2 Servers through Windows Firewall\n")
         values = {key: card.values() for key, card in self.cards.items()}
-        if (self.saved.get("direct_link") or {}).get("enabled"):
-            values["directlink"] = {}
+        direct_cfg = self.saved.get("direct_link") or {}
+        if direct_cfg.get("enabled"):
+            values["directlink"] = {"server_ip": direct_cfg.get("server_ip")}
 
         def worker():
             try:
@@ -1527,10 +1548,10 @@ class LauncherApp:
         direct_cfg = dict(self.saved.get("direct_link") or {})
         if direct_cfg.get("server_ip"):
             self._stop_direct_responder()
-            self.saved.pop("direct_link", None)
-            self._save()
-            self._set_direct_checkbox(False)
-            self._set_direct_status(self._DIRECT_STATUS_OFF)
+            self._set_direct_checkbox(bool(direct_cfg.get("enabled")), busy=True)
+            self._set_direct_status(
+                "Returning '{}' to automatic (DHCP)…".format(
+                    direct_cfg.get("adapter", "?")))
 
         def worker():
             if direct_cfg.get("server_ip"):
@@ -1538,15 +1559,13 @@ class LauncherApp:
                     output = directlink.restore_adapter_dhcp(
                         direct_cfg.get("if_index", 0),
                         expect_ip=direct_cfg.get("server_ip"))
-                    self.root.after(0, lambda out=output: self._append_log(
-                        "directlink", "[setup] {}\n".format(
-                            out.replace("\n", "\n[setup] "))))
+                    self.root.after(
+                        0, lambda out=output: self._finish_direct_cleanup(out))
                 except Exception as e:
                     # The firewall removal below still matters; report and go on.
-                    self.root.after(0, lambda err=e: self._append_log(
-                        "directlink",
-                        "[setup] could not return the direct-link port to "
-                        "DHCP: {}\n".format(err)))
+                    self.root.after(
+                        0, lambda err=e: self._fail_direct_cleanup(
+                            err, direct_cfg))
             try:
                 result = windows_setup.remove_setup()
             except Exception as e:
@@ -1555,6 +1574,25 @@ class LauncherApp:
             self.root.after(0, lambda: self._finish_cleanup_success(result))
 
         threading.Thread(target=worker, daemon=True).start()
+
+    def _finish_direct_cleanup(self, output):
+        self._append_log("directlink", "[setup] {}\n".format(
+            output.replace("\n", "\n[setup] ")))
+        self.saved.pop("direct_link", None)
+        self._save()
+        self._set_direct_checkbox(False)
+        self._set_direct_status(self._DIRECT_STATUS_OFF)
+
+    def _fail_direct_cleanup(self, error, cfg):
+        self._append_log(
+            "directlink",
+            "[setup] could not return the direct-link port to DHCP: {}\n"
+            .format(error))
+        self._set_direct_checkbox(bool(cfg.get("enabled")))
+        self._set_direct_status(
+            "Direct-link cleanup failed; the helper is stopped, but '{}' "
+            "may still use {}. Retry cleanup to restore automatic (DHCP)."
+            .format(cfg.get("adapter", "?"), cfg.get("server_ip", "?")))
 
     def _finish_cleanup_success(self, result):
         output = result.get("output") or "No PS2 Servers firewall rules found."
@@ -1579,6 +1617,7 @@ class LauncherApp:
     def stop_all(self):
         for key in list(self.procs):
             self.stop_server(key)
+        self._stop_direct_responder()
 
     # -- logging (thread-safe) ------------------------------------------- #
     def _on_output(self, key, line):
@@ -1740,7 +1779,6 @@ class LauncherApp:
         # look like a frozen window
         self.root.withdraw()
         self.stop_all()
-        self._stop_direct_responder()
         if self._tray:
             self._tray.stop()
         self.root.destroy()

--- a/launcher/serve.py
+++ b/launcher/serve.py
@@ -39,6 +39,13 @@ def run_serve(key, server_args):
         except (AttributeError, ValueError):
             pass
 
+    # Not a REGISTRY server: the direct-link DHCP helper runs as a child the
+    # same way, so its logs flow through the terminal and stop follows the
+    # process, but it has no card of its own.
+    if key == "directlink":
+        from .directlink import run_responder
+        return run_responder(list(server_args))
+
     server = REGISTRY.get(key)
     if server is None:
         raise SystemExit("unknown server: {}".format(key))

--- a/launcher/windows_setup.py
+++ b/launcher/windows_setup.py
@@ -150,9 +150,7 @@ def _server_ports(key, values):
 
 
 def _rule_names(key, values):
-    rules = [
-        "PS2 Servers - App"
-    ]
+    rules = [] if key == "directlink" else ["PS2 Servers - App"]
     for proto, port, purpose in _server_ports(key, values):
         rules.append("PS2 Servers - {} {} {}".format(purpose, proto, port))
     return rules
@@ -171,16 +169,20 @@ def setup_fingerprint(key, values):
     """
     if not is_windows():
         return ""
-    return "|".join([os.path.abspath(_server_program_path())] + _rule_names(key, values))
+    parts = [os.path.abspath(_server_program_path())] + _rule_names(key, values)
+    if key == "directlink":
+        parts.append(str(values.get("server_ip") or ""))
+    return "|".join(parts)
 
 
 def _firewall_rules(key, values):
     program = os.path.abspath(_server_program_path())
-    rules = [{
+    rules = [] if key == "directlink" else [{
         "name": "PS2 Servers - App",
         "protocol": "Any",
         "port": None,
         "program": program,
+        "local_address": None,
     }]
     for proto, port, purpose in _server_ports(key, values):
         rules.append({
@@ -188,6 +190,8 @@ def _firewall_rules(key, values):
             "protocol": proto,
             "port": int(port),
             "program": None,
+            "local_address": (values.get("server_ip")
+                              if key == "directlink" else None),
         })
     return rules
 
@@ -217,7 +221,9 @@ def needs_setup(key, values, log=None):
     if log is None:
         log = lambda msg: None
 
-    port_rule_names = _rule_names(key, values)[1:]
+    all_rule_names = _rule_names(key, values)
+    check_app_rule = key != "directlink"
+    port_rule_names = all_rule_names[1:] if check_app_rule else all_rule_names
     rule_array = "@({})".format(",".join(_ps_quote(n) for n in port_rule_names))
     program = _ps_quote(os.path.abspath(_server_program_path()))
     app_rule = _ps_quote("PS2 Servers - App")
@@ -236,13 +242,14 @@ def needs_setup(key, values, log=None):
         "} else {",
         "$appRuleName = {}".format(app_rule),
         "$appProgram = {}".format(program),
+        "$checkAppRule = {}".format("$true" if check_app_rule else "$false"),
         "$wanted = {}".format(rule_array),
         "$fw = New-Object -ComObject HNetCfg.FwPolicy2",
         "$appFound = $null",
         "try { $appFound = $fw.Rules.Item($appRuleName) } catch {}",
-        "if (-not $appFound) {",
+        "if ($checkAppRule -and -not $appFound) {",
         "  Write-Output ('NEED_RULE=' + $appRuleName)",
-        "} elseif ($appFound.ApplicationName -ne $appProgram) {",
+        "} elseif ($checkAppRule -and $appFound.ApplicationName -ne $appProgram) {",
         "  Write-Output ('NEED_RULE=' + $appRuleName)",
         "}",
         "foreach ($name in $wanted) {",
@@ -322,10 +329,13 @@ def apply_setup(key, values):
                     _ps_quote(rule["program"]))
             )
         else:
+            local_address = rule.get("local_address")
+            local_arg = (" -LocalAddress {}".format(_ps_quote(local_address))
+                         if local_address else "")
             rule_lines.append(
                 "New-NetFirewallRule -DisplayName $ruleName -Direction Inbound -Action Allow "
-                "-Profile Any -Protocol {} -LocalPort {} -ErrorAction Stop | Out-Null".format(
-                    proto, int(rule["port"]))
+                "-Profile Any -Protocol {} -LocalPort {}{} -ErrorAction Stop | Out-Null".format(
+                    proto, int(rule["port"]), local_arg)
             )
         rule_lines.append("$changed = $true")
 

--- a/launcher/windows_setup.py
+++ b/launcher/windows_setup.py
@@ -141,6 +141,11 @@ def _server_ports(key, values):
         return ports
     if key == "udpbd":
         return [("UDP", UDPBD_PORT, "UDPBD")]
+    if key == "directlink":
+        # The direct-link DHCP helper. Rule created only while enabling the
+        # mode (never speculatively), removed with every other "PS2 Servers -"
+        # rule by remove_setup.
+        return [("UDP", 67, "Direct link DHCP")]
     return []
 
 
@@ -404,6 +409,9 @@ def setup_summary(key, values):
         parts.append("create Windows Firewall allow rules for the built-in PS2 Servers SMB server")
         if values.get("take_445"):
             parts.append("temporarily use TCP 445 by pausing Windows file sharing while the server runs")
+    elif key == "directlink":
+        parts.append("set a fixed address on the chosen network port and allow "
+                     "the direct-link DHCP helper (UDP 67) through the firewall")
     else:
         ports = _server_ports(key, values)
         if ports:

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -184,6 +184,41 @@ class HandleTests(unittest.TestCase):
         self.assertIsNone(second)
 
 
+class ServeTests(unittest.TestCase):
+    class StopLoop(Exception):
+        pass
+
+    class FakeSocket:
+        def __init__(self, first_error):
+            self.first_error = first_error
+            self.calls = 0
+
+        def settimeout(self, _seconds):
+            pass
+
+        def recvfrom(self, _size):
+            self.calls += 1
+            if self.calls == 1:
+                raise self.first_error
+            raise ServeTests.StopLoop()
+
+    def assert_reset_is_ignored(self, error):
+        r = responder()
+        r.sock = self.FakeSocket(error)
+        with self.assertRaises(self.StopLoop):
+            r.serve_forever()
+        self.assertEqual(r.sock.calls, 2)
+
+    def test_connection_reset_is_ignored(self):
+        self.assert_reset_is_ignored(
+            ConnectionResetError(10054, "connection reset by peer"))
+
+    def test_windows_udp_reset_is_ignored(self):
+        error = OSError("ICMP port unreachable")
+        error.winerror = 10054
+        self.assert_reset_is_ignored(error)
+
+
 class SubnetTests(unittest.TestCase):
     def test_overlap(self):
         n = _ip_to_int

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -1,0 +1,294 @@
+"""Unit tests for the direct-link DHCP responder and its safety refusals.
+
+Run from the repo root:  python -m unittest tests.test_directlink -v
+
+Everything here is socket-free: handle_packet() is deliberately pure so the
+protocol and the refusals can be tested without a wire.
+"""
+
+import struct
+import unittest
+
+from launcher import directlink
+from launcher.directlink import (
+    DhcpResponder, DirectLinkRefused, MAGIC_COOKIE,
+    MSG_ACK, MSG_DISCOVER, MSG_NAK, MSG_OFFER, MSG_REQUEST,
+    build_reply, choose_subnet, classify_adapter, networks_overlap,
+    parse_packet, taken_networks, _BOOTP, _ip_to_int,
+)
+
+SERVER = "192.168.137.1"
+CLIENT = "192.168.137.10"
+MAC1 = b"\x00\x04\x1f\xaa\xbb\xcc"  # Sony OUI, why not
+
+
+def make_request(msg_type, mac=MAC1, xid=0x1234, ciaddr="0.0.0.0",
+                 options=b"", flags=0x8000):
+    """A client BOOTREQUEST with the given DHCP message type."""
+    chaddr = mac + b"\x00" * (16 - len(mac))
+    header = _BOOTP.pack(1, 1, 6, 0, xid, 0, flags, _ip_to_int(ciaddr),
+                         0, 0, 0, chaddr, b"", b"")
+    opts = bytes([53, 1, msg_type]) + options + b"\xff"
+    return header + MAGIC_COOKIE + opts
+
+
+def opt_ip(tag, ip):
+    return bytes([tag, 4]) + struct.pack("!I", _ip_to_int(ip))
+
+
+def parse_options(reply):
+    assert reply[236:240] == MAGIC_COOKIE
+    options, i = {}, 240
+    while i < len(reply):
+        tag = reply[i]
+        if tag == 0:
+            i += 1
+            continue
+        if tag == 255:
+            break
+        length = reply[i + 1]
+        options[tag] = reply[i + 2:i + 2 + length]
+        i += 2 + length
+    return options
+
+
+def responder(mode="specific"):
+    r = DhcpResponder(SERVER, CLIENT, 24, adapter_name="test",
+                      log=lambda _msg: None)
+    r.mode = mode
+    return r
+
+
+class ParseTests(unittest.TestCase):
+    def test_discover_parses(self):
+        pkt = parse_packet(make_request(MSG_DISCOVER))
+        self.assertIsNotNone(pkt)
+        self.assertEqual(pkt["xid"], 0x1234)
+        self.assertEqual(pkt["mac"], MAC1)
+        self.assertEqual(pkt["options"][53], bytes([MSG_DISCOVER]))
+
+    def test_junk_and_short_are_none(self):
+        self.assertIsNone(parse_packet(b""))
+        self.assertIsNone(parse_packet(b"ps2srv-directlink-probe"))
+        self.assertIsNone(parse_packet(b"\x00" * 300))  # no magic cookie
+
+    def test_server_reply_is_none(self):
+        data = bytearray(make_request(MSG_DISCOVER))
+        data[0] = 2  # BOOTREPLY: never a thing we answer
+        self.assertIsNone(parse_packet(bytes(data)))
+
+
+class ReplyTests(unittest.TestCase):
+    def test_offer_shape(self):
+        pkt = parse_packet(make_request(MSG_DISCOVER))
+        reply = build_reply(pkt, MSG_OFFER, SERVER, CLIENT, 24)
+        self.assertGreaterEqual(len(reply), 300)
+        self.assertEqual(reply[0], 2)  # BOOTREPLY
+        yiaddr = struct.unpack("!I", reply[16:20])[0]
+        self.assertEqual(yiaddr, _ip_to_int(CLIENT))
+        opts = parse_options(reply)
+        self.assertEqual(opts[53], bytes([MSG_OFFER]))
+        self.assertEqual(opts[54], struct.pack("!I", _ip_to_int(SERVER)))
+        self.assertEqual(opts[1], struct.pack("!I", 0xFFFFFF00))  # /24 mask
+        self.assertEqual(opts[3], struct.pack("!I", _ip_to_int(SERVER)))
+        self.assertIn(51, opts)  # lease time
+
+    def test_nak_has_no_address(self):
+        pkt = parse_packet(make_request(MSG_REQUEST))
+        reply = build_reply(pkt, MSG_NAK, SERVER, CLIENT, 24)
+        self.assertEqual(struct.unpack("!I", reply[16:20])[0], 0)
+        opts = parse_options(reply)
+        self.assertEqual(opts[53], bytes([MSG_NAK]))
+        self.assertNotIn(51, opts)
+
+    def test_xid_and_mac_echoed(self):
+        pkt = parse_packet(make_request(MSG_DISCOVER, xid=0xDEADBEEF))
+        reply = build_reply(pkt, MSG_OFFER, SERVER, CLIENT, 24)
+        self.assertEqual(struct.unpack("!I", reply[4:8])[0], 0xDEADBEEF)
+        self.assertEqual(reply[28:34], MAC1)
+
+
+class HandleTests(unittest.TestCase):
+    def test_discover_offer_broadcast(self):
+        r = responder()
+        result = r.handle_packet(make_request(MSG_DISCOVER), ("0.0.0.0", 68))
+        self.assertIsNotNone(result)
+        reply, dest = result
+        self.assertEqual(parse_options(reply)[53], bytes([MSG_OFFER]))
+        self.assertEqual(dest, ("255.255.255.255", 68))
+        self.assertEqual(r.lease_mac, MAC1)
+
+    def test_request_for_our_address_acks(self):
+        r = responder()
+        result = r.handle_packet(
+            make_request(MSG_REQUEST, options=opt_ip(50, CLIENT)),
+            ("0.0.0.0", 68))
+        reply, _dest = result
+        self.assertEqual(parse_options(reply)[53], bytes([MSG_ACK]))
+
+    def test_request_for_other_address_naks(self):
+        r = responder()
+        result = r.handle_packet(
+            make_request(MSG_REQUEST, options=opt_ip(50, "10.0.0.5")),
+            ("0.0.0.0", 68))
+        reply, _dest = result
+        self.assertEqual(parse_options(reply)[53], bytes([MSG_NAK]))
+
+    def test_foreign_server_id_is_silence(self):
+        # The client accepted a different server's offer: not our business.
+        r = responder()
+        result = r.handle_packet(
+            make_request(MSG_REQUEST,
+                         options=opt_ip(54, "192.168.1.1") + opt_ip(50, CLIENT)),
+            ("0.0.0.0", 68))
+        self.assertIsNone(result)
+
+    def test_renewal_is_unicast(self):
+        r = responder()
+        result = r.handle_packet(
+            make_request(MSG_REQUEST, ciaddr=CLIENT),
+            (CLIENT, 68))
+        reply, dest = result
+        self.assertEqual(parse_options(reply)[53], bytes([MSG_ACK]))
+        self.assertEqual(dest, (CLIENT, 68))
+
+    def test_wildcard_mode_uses_subnet_broadcast(self):
+        # Containment: never a limited broadcast from a wildcard socket, which
+        # could egress the machine's default (real-LAN) interface.
+        r = responder(mode="wildcard")
+        _reply, dest = r.handle_packet(make_request(MSG_DISCOVER),
+                                       ("0.0.0.0", 68))
+        self.assertEqual(dest, ("192.168.137.255", 68))
+
+    def test_probe_and_junk_ignored(self):
+        r = responder()
+        self.assertIsNone(r.handle_packet(b"ps2srv-directlink-probe",
+                                          ("0.0.0.0", 68)))
+        self.assertIsNone(r.handle_packet(b"\x01" * 400, ("0.0.0.0", 68)))
+
+    def test_multi_mac_tripwire(self):
+        r = responder()
+        for i in range(r.MAX_DISTINCT_MACS):
+            mac = bytes([0, 0, 0, 0, 0, i + 1])
+            r.handle_packet(make_request(MSG_DISCOVER, mac=mac), ("0.0.0.0", 68))
+        with self.assertRaises(DirectLinkRefused):
+            r.handle_packet(make_request(MSG_DISCOVER, mac=b"\x00\x00\x00\x00\x00\xFF"),
+                            ("0.0.0.0", 68))
+
+    def test_rate_limit_drops(self):
+        r = responder()
+        r._tokens = 1.0
+        first = r.handle_packet(make_request(MSG_DISCOVER), ("0.0.0.0", 68))
+        second = r.handle_packet(make_request(MSG_DISCOVER), ("0.0.0.0", 68))
+        self.assertIsNotNone(first)
+        self.assertIsNone(second)
+
+
+class SubnetTests(unittest.TestCase):
+    def test_overlap(self):
+        n = _ip_to_int
+        self.assertTrue(networks_overlap(n("192.168.137.0"), 24,
+                                         n("192.168.0.0"), 16))
+        self.assertFalse(networks_overlap(n("192.168.137.0"), 24,
+                                          n("192.168.1.0"), 24))
+        self.assertTrue(networks_overlap(n("10.0.0.0"), 8,
+                                         n("10.213.77.0"), 24))
+
+    def test_choose_skips_taken(self):
+        taken = [(_ip_to_int("192.168.137.0"), 24)]
+        server, client = choose_subnet(taken)
+        self.assertEqual((server, client), ("192.168.183.1", "192.168.183.10"))
+
+    def test_choose_default(self):
+        server, client = choose_subnet([])
+        self.assertEqual((server, client), ("192.168.137.1", "192.168.137.10"))
+
+    def test_all_taken_returns_none(self):
+        taken = [(_ip_to_int(base + ".0"), 24)
+                 for base in directlink.CANDIDATE_SUBNETS]
+        self.assertEqual(choose_subnet(taken), (None, None))
+
+    def test_taken_networks_filters(self):
+        enumerated = {
+            "adapters": [
+                {"if_index": 5, "ipv4": [
+                    {"ip": "192.168.1.100", "prefix": 24, "origin": "Dhcp"},
+                    {"ip": "169.254.9.9", "prefix": 16, "origin": "WellKnown"},
+                ]},
+                {"if_index": 7, "ipv4": [
+                    {"ip": "192.168.137.1", "prefix": 24, "origin": "Manual"},
+                ]},
+            ],
+            "routes": [
+                {"prefix": "0.0.0.0/0", "ifIndex": 5},
+                {"prefix": "224.0.0.0/4", "ifIndex": 5},
+                {"prefix": "255.255.255.255/32", "ifIndex": 5},
+                {"prefix": "169.254.0.0/16", "ifIndex": 9},
+                {"prefix": "10.50.0.0/16", "ifIndex": 9},
+                {"prefix": "192.168.137.0/24", "ifIndex": 7},
+            ],
+        }
+        # Excluding adapter 7 (the one being reconfigured) drops both its
+        # address and its route, so its old subnet stays reusable.
+        taken = taken_networks(enumerated, exclude_if_index=7)
+        nets = {(net, plen) for net, plen in taken}
+        self.assertIn((_ip_to_int("192.168.1.0"), 24), nets)
+        self.assertIn((_ip_to_int("10.50.0.0"), 16), nets)
+        self.assertNotIn((_ip_to_int("192.168.137.0"), 24), nets)
+        self.assertNotIn((_ip_to_int("169.254.0.0"), 16), nets)
+        self.assertNotIn((_ip_to_int("224.0.0.0"), 4), nets)
+
+
+class ClassifyTests(unittest.TestCase):
+    def adapter(self, **overrides):
+        base = {"name": "Ethernet", "if_index": 3, "desc": "NIC",
+                "status": "Up", "media": "802.3", "physical": True,
+                "has_gateway": False, "ipv4": []}
+        base.update(overrides)
+        return base
+
+    def test_apipa_port_is_candidate(self):
+        ok, _ = classify_adapter(self.adapter(
+            ipv4=[{"ip": "169.254.10.20", "prefix": 16, "origin": "WellKnown"}]))
+        self.assertTrue(ok)
+
+    def test_gateway_refused(self):
+        ok, reason = classify_adapter(self.adapter(has_gateway=True))
+        self.assertFalse(ok)
+        self.assertIn("router", reason)
+
+    def test_dhcp_lease_refused(self):
+        ok, reason = classify_adapter(self.adapter(
+            ipv4=[{"ip": "192.168.1.50", "prefix": 24, "origin": "Dhcp"}]))
+        self.assertFalse(ok)
+        self.assertIn("DHCP", reason)
+
+    def test_wireless_refused(self):
+        ok, _ = classify_adapter(self.adapter(media="Native 802.11"))
+        self.assertFalse(ok)
+
+    def test_virtual_refused(self):
+        ok, _ = classify_adapter(self.adapter(physical=False))
+        self.assertFalse(ok)
+
+    def test_down_refused(self):
+        ok, reason = classify_adapter(self.adapter(status="Disconnected"))
+        self.assertFalse(ok)
+        self.assertIn("link", reason)
+
+    def test_down_tolerated_for_rechecks(self):
+        # Re-arming an already-ours port: console off at PC boot is normal.
+        ok, _ = classify_adapter(self.adapter(status="Disconnected"),
+                                 allow_down=True)
+        self.assertTrue(ok)
+
+    def test_down_with_gateway_still_refused(self):
+        ok, reason = classify_adapter(
+            self.adapter(status="Disconnected", has_gateway=True),
+            allow_down=True)
+        self.assertFalse(ok)
+        self.assertIn("router", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -8,14 +8,17 @@ protocol and the refusals can be tested without a wire.
 
 import struct
 import unittest
+from unittest import mock
 
-from launcher import directlink
+from launcher import directlink, windows_setup
 from launcher.directlink import (
     DhcpResponder, DirectLinkRefused, MAGIC_COOKIE,
     MSG_ACK, MSG_DISCOVER, MSG_NAK, MSG_OFFER, MSG_REQUEST,
     build_reply, choose_subnet, classify_adapter, networks_overlap,
     parse_packet, taken_networks, _BOOTP, _ip_to_int,
 )
+from launcher.gui import LauncherApp
+from launcher.windows_setup import WindowsSetupError
 
 SERVER = "192.168.137.1"
 CLIENT = "192.168.137.10"
@@ -323,6 +326,116 @@ class ClassifyTests(unittest.TestCase):
             allow_down=True)
         self.assertFalse(ok)
         self.assertIn("router", reason)
+
+
+class ConfigurationSafetyTests(unittest.TestCase):
+    def test_invalid_server_ip_is_rejected_before_powershell(self):
+        with mock.patch.object(directlink, "_powershell") as powershell:
+            with self.assertRaises(WindowsSetupError):
+                directlink.apply_adapter_config(
+                    3, "192.168.137.1'; Remove-Item C:\\ -Recurse; '")
+        powershell.assert_not_called()
+
+    def test_invalid_restore_guard_is_rejected_before_powershell(self):
+        with mock.patch.object(directlink, "_powershell") as powershell:
+            with self.assertRaises(WindowsSetupError):
+                directlink.restore_adapter_dhcp(
+                    3, expect_ip="192.168.137.1'; Write-Output BAD; '")
+        powershell.assert_not_called()
+
+    def test_configuration_script_contains_failure_rollback(self):
+        result = mock.Mock(returncode=0, stdout="CONFIGURED=Ethernet", stderr="")
+        with mock.patch.object(directlink, "_powershell", return_value=result) as ps:
+            directlink.apply_adapter_config(3, SERVER)
+        script = ps.call_args.args[0]
+        self.assertIn("catch {", script)
+        self.assertIn("-Dhcp Enabled", script)
+        self.assertIn("throw $originalError", script)
+
+    def test_responder_refuses_non_windows(self):
+        args = ["--server-ip", SERVER, "--client-ip", CLIENT,
+                "--adapter", "Ethernet", "--if-index", "3"]
+        with mock.patch.object(directlink, "is_windows", return_value=False):
+            self.assertEqual(directlink.run_responder(args), 3)
+
+
+class FirewallSafetyTests(unittest.TestCase):
+    def test_directlink_rule_is_address_scoped_without_app_wildcard(self):
+        rules = windows_setup._firewall_rules(
+            "directlink", {"server_ip": SERVER})
+        self.assertEqual(len(rules), 1)
+        self.assertIsNone(rules[0]["program"])
+        self.assertEqual(rules[0]["local_address"], SERVER)
+
+    def test_directlink_firewall_script_uses_local_address(self):
+        result = mock.Mock(returncode=0, stdout="SETUP_CHANGED=True", stderr="")
+        with (mock.patch.object(windows_setup, "is_windows", return_value=True),
+              mock.patch.object(windows_setup, "_powershell",
+                                return_value=result) as ps):
+            windows_setup.apply_setup("directlink", {"server_ip": SERVER})
+        self.assertIn("-LocalAddress '{}'".format(SERVER), ps.call_args.args[0])
+
+
+class LauncherLifecycleTests(unittest.TestCase):
+    def app(self):
+        app = object.__new__(LauncherApp)
+        app.saved = {"direct_link": {
+            "enabled": False, "server_ip": SERVER, "client_ip": CLIENT,
+            "adapter": "Ethernet", "if_index": 3, "prefix": 24,
+        }}
+        app._append_log = mock.Mock()
+        app._save = mock.Mock()
+        app._set_direct_checkbox = mock.Mock()
+        app._set_direct_status = mock.Mock()
+        return app
+
+    def test_enable_is_not_saved_when_helper_fails_to_start(self):
+        app = self.app()
+        app._start_direct_responder = mock.Mock(return_value=False)
+        app.ip_var = mock.Mock()
+        LauncherApp._direct_link_enabled(app, "")
+        self.assertFalse(app.saved["direct_link"]["enabled"])
+        app._save.assert_not_called()
+        app.ip_var.set.assert_not_called()
+
+    def test_firewall_failure_restores_configured_adapter(self):
+        app = self.app()
+        app.root = mock.Mock()
+        app.root.after.side_effect = lambda _delay, callback: callback()
+        app.nb = mock.Mock()
+        app.terminal_tab = object()
+        app._direct_link_fail = mock.Mock()
+        with (mock.patch.object(directlink, "apply_adapter_config",
+                               return_value="CONFIGURED=Ethernet"),
+              mock.patch.object(windows_setup, "apply_setup",
+                                side_effect=WindowsSetupError("firewall failed")),
+              mock.patch.object(directlink, "restore_adapter_dhcp",
+                                return_value="RESTORED=automatic (DHCP)") as restore,
+              mock.patch("launcher.gui.threading.Thread") as thread):
+            LauncherApp._direct_link_apply_async(app)
+            thread.call_args.kwargs["target"]()
+        restore.assert_called_once_with(3, expect_ip=SERVER)
+        app._direct_link_fail.assert_called_once()
+        self.assertIn("returned to automatic", app._direct_link_fail.call_args.args[0])
+
+    def test_stop_all_also_stops_direct_responder(self):
+        app = self.app()
+        app.procs = {}
+        app._stop_direct_responder = mock.Mock()
+        LauncherApp.stop_all(app)
+        app._stop_direct_responder.assert_called_once_with()
+
+    def test_failed_cleanup_retains_recovery_state(self):
+        app = self.app()
+        cfg = dict(app.saved["direct_link"])
+        LauncherApp._fail_direct_cleanup(app, RuntimeError("busy"), cfg)
+        self.assertEqual(app.saved["direct_link"], cfg)
+
+    def test_successful_cleanup_clears_recovery_state(self):
+        app = self.app()
+        LauncherApp._finish_direct_cleanup(app, "RESTORED=automatic (DHCP)")
+        self.assertNotIn("direct_link", app.saved)
+        app._save.assert_called_once_with()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add a Windows-only direct PS2-to-PC setup flow to the launcher
- configure a collision-avoiding static subnet and run a single-lease DHCP responder on the selected adapter
- add layered safety refusals for routed, DHCP-managed, virtual, wireless, and multi-device networks
- integrate direct-link lifecycle, elevation, firewall setup, cleanup, logging, and restart behavior into the launcher
- document the direct-cable workflow and add focused protocol and safety tests

## Why

A PS2 connected directly to a PC has no router or DHCP server to assign the console an address. UDPFS and other network services then fail with generic cable/DHCP symptoms even when the server itself is configured correctly.

This adds a guided path that configures the PC-side adapter and supplies one console address without requiring users to understand manual subnet setup.

## Safety and impact

The DHCP helper binds to the selected direct-link adapter, refuses adapters that appear connected to a real network, serves a single lease, rate-limits replies, and stops if multiple distinct devices appear. Disabling the mode restores the adapter to DHCP, and the existing firewall cleanup action also removes the direct-link setup.

Existing routed LAN workflows remain unchanged unless the direct-link checkbox is enabled.

## Validation

- `python -m unittest tests.test_directlink -v` — 28 tests passed
- `python -m py_compile launcher\directlink.py launcher\gui.py launcher\serve.py launcher\windows_setup.py tests\test_directlink.py` — passed
- `python -m compileall -q launcher smbv1_server udpbd_server udpfs_server ps2servers.py` — passed
- `python udpfs_server\multiclient_selftest.py` — passed
- `python udpfs_server\compression_selftest.py` — passed
- `python udpfs_server\pathguard_selftest.py` — passed
- `python tools\check_release_compliance.py` — passed
- `git diff --check` — passed

The unrelated UDPBD self-test could not bind its fixed local port in this Windows session (`WinError 10013`); no UDPBD files are changed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Windows “direct PS2-to-PC (no router)” mode with adapter discovery/selection and guided setup.
  - Automatically configures the appropriate network/subnet for the link and starts a DHCP-helper flow with live helper logs.
  - Updated launcher lifecycle handling for enable/disable and cleanup, including best-effort adapter restore.

- **Bug Fixes**
  - Improved safety and scoping so direct-link DHCP/firewall behavior won’t interfere with real network DHCP on shared networks.

- **Documentation**
  - Added a new quick-start section for direct cabling and clarified launcher checkbox behavior and addressing.

- **Tests**
  - Added comprehensive unit tests covering DHCP responder behavior, safety checks, firewall scoping, and launcher lifecycle scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->