### PR TITLE
Validate direct-link topology and rollback failed startup

### DIFF
--- a/launcher/directlink.py
+++ b/launcher/directlink.py
@@ -78,6 +78,29 @@ def _canonical_ipv4(value, label="IPv4 address"):
             "Invalid {}: {!r}".format(label, value)) from None
 
 
+def _validate_topology(server_ip, client_ip, prefixlen):
+    server_ip = _canonical_ipv4(server_ip, "direct-link server address")
+    client_ip = _canonical_ipv4(client_ip, "direct-link client address")
+    prefixlen = int(prefixlen)
+    # DHCP needs distinct server/client hosts plus network and broadcast.
+    if not 1 <= prefixlen <= 30:
+        raise WindowsSetupError(
+            "Invalid direct-link prefix length: {}".format(prefixlen))
+    network = ipaddress.IPv4Network(
+        "{}/{}".format(server_ip, prefixlen), strict=False)
+    server = ipaddress.IPv4Address(server_ip)
+    client = ipaddress.IPv4Address(client_ip)
+    unusable = {network.network_address, network.broadcast_address, server}
+    if server in (network.network_address, network.broadcast_address):
+        raise WindowsSetupError(
+            "The direct-link server address is not a usable host address.")
+    if client not in network or client in unusable:
+        raise WindowsSetupError(
+            "The direct-link client address must be a different usable host "
+            "in the server subnet.")
+    return server_ip, client_ip, prefixlen
+
+
 def _ip_to_int(ip):
     return struct.unpack("!I", socket.inet_aton(ip))[0]
 
@@ -290,7 +313,7 @@ def apply_adapter_config(if_index, server_ip, prefixlen=PREFIX_LENGTH):
     """
     server_ip = _canonical_ipv4(server_ip, "direct-link server address")
     prefixlen = int(prefixlen)
-    if not 1 <= prefixlen <= 32:
+    if not 1 <= prefixlen <= 30:
         raise WindowsSetupError(
             "Invalid direct-link prefix length: {}".format(prefixlen))
     script = "\n".join([
@@ -761,10 +784,10 @@ def run_responder(argv):
         if not is_windows():
             raise DirectLinkRefused(
                 "direct-link DHCP is supported only on Windows")
-        server_ip = _canonical_ipv4(args.server_ip, "direct-link server address")
-        client_ip = _canonical_ipv4(args.client_ip, "direct-link client address")
+        server_ip, client_ip, prefixlen = _validate_topology(
+            args.server_ip, args.client_ip, args.prefix)
         _startup_adapter_check(args.adapter, args.if_index, server_ip)
-        responder = DhcpResponder(server_ip, client_ip, args.prefix,
+        responder = DhcpResponder(server_ip, client_ip, prefixlen,
                                   adapter_name=args.adapter, log=log)
         responder.open_socket()
         responder.serve_forever()

--- a/launcher/directlink.py
+++ b/launcher/directlink.py
@@ -304,18 +304,16 @@ def choose_subnet(taken):
 # --------------------------------------------------------------------------- #
 # Adapter configure / restore (need administrator rights)
 # --------------------------------------------------------------------------- #
-def apply_adapter_config(if_index, server_ip, prefixlen=PREFIX_LENGTH):
+def apply_adapter_config(if_index, server_ip, client_ip,
+                         prefixlen=PREFIX_LENGTH):
     """Give the chosen adapter the fixed server address (elevated).
 
     The gateway/lease refusals run again HERE, inside the elevated pass, so a
     stale answer from the earlier scan (or a cable moved in between) cannot
     configure the wrong port.
     """
-    server_ip = _canonical_ipv4(server_ip, "direct-link server address")
-    prefixlen = int(prefixlen)
-    if not 1 <= prefixlen <= 30:
-        raise WindowsSetupError(
-            "Invalid direct-link prefix length: {}".format(prefixlen))
+    server_ip, _client_ip, prefixlen = _validate_topology(
+        server_ip, client_ip, prefixlen)
     script = "\n".join([
         "$ErrorActionPreference = 'Stop'",
         "$idx = {}".format(int(if_index)),

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -986,12 +986,18 @@ class LauncherApp:
                 self._append_log("directlink", "[launcher] DHCP helper stopped\n")
             self._direct_proc = None
 
-    def _rollback_failed_direct_responder(self, cfg):
+    def _rollback_failed_direct_responder(self, cfg) -> None:
         cfg["enabled"] = False
         self.saved["direct_link"] = cfg
         self.saved["pending_direct_link_restore"] = True
-        self._save()
-        self._direct_link_restore_async(cfg, clear_saved=True)
+        persisted = self._save()
+        if not persisted:
+            self._append_log(
+                "directlink",
+                "[launcher] WARNING: could not save the pending DHCP "
+                "recovery; waiting for this restore attempt before exit\n")
+        self._direct_link_restore_async(
+            cfg, clear_saved=True, daemon=bool(persisted))
 
     def _direct_link_begin_disable(self):
         cfg = self.saved.get("direct_link") or {}
@@ -1052,7 +1058,7 @@ class LauncherApp:
         self._save()
         self._direct_link_restore_async(cfg)
 
-    def _direct_link_restore_async(self, cfg, clear_saved=False):
+    def _direct_link_restore_async(self, cfg, clear_saved=False, daemon=True):
         self._set_direct_checkbox(False, busy=True)
         self._set_direct_status(
             "Returning '{}' to automatic (DHCP)…".format(cfg.get("adapter")))
@@ -1610,7 +1616,10 @@ class LauncherApp:
                 return
             self.root.after(0, lambda: self._finish_cleanup_success(result))
 
-        threading.Thread(target=worker, daemon=True).start()
+        # A non-daemon worker is used when the crash-recovery marker could not
+        # be saved.  That keeps process shutdown from abandoning the only DHCP
+        # restore attempt that can prevent a stranded static adapter.
+        threading.Thread(target=worker, daemon=daemon).start()
 
     def _finish_direct_cleanup(self, output):
         self._append_log("directlink", "[setup] {}\n".format(
@@ -1749,7 +1758,7 @@ class LauncherApp:
 
     def _save(self, pending_start=None, pending_cleanup=False,
               pending_firewall_allow=False, pending_direct_link=False,
-              pending_direct_link_off=False):
+              pending_direct_link_off=False) -> bool:
         data = {"servers": {key: card.values() for key, card in self.cards.items()},
                 "ip": self.ip_var.get(),
                 "firewall_ok": sorted(getattr(self, "_firewall_ok", ())),
@@ -1779,7 +1788,8 @@ class LauncherApp:
         try:
             config.save(data)
         except OSError:
-            pass
+            return False
+        return True
 
     def on_close(self):
         self.exit_app(confirm=False)

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -906,7 +906,7 @@ class LauncherApp:
             configured = None
             try:
                 configured = directlink.apply_adapter_config(
-                    cfg["if_index"], cfg["server_ip"],
+                    cfg["if_index"], cfg["server_ip"], cfg["client_ip"],
                     cfg.get("prefix", directlink.PREFIX_LENGTH))
                 firewall = windows_setup.apply_setup(
                     "directlink", {"server_ip": cfg["server_ip"]})
@@ -941,10 +941,7 @@ class LauncherApp:
             # The adapter and firewall were already configured. Keep recovery
             # state until an asynchronous DHCP restore succeeds, so a failed
             # cleanup remains retryable instead of stranding a static port.
-            cfg["enabled"] = False
-            self.saved["direct_link"] = cfg
-            self._save()
-            self._direct_link_restore_async(cfg, clear_saved=True)
+            self._rollback_failed_direct_responder(cfg)
             return
         cfg["enabled"] = True
         self.saved["direct_link"] = cfg
@@ -986,6 +983,12 @@ class LauncherApp:
                 self._direct_proc.stop()
                 self._append_log("directlink", "[launcher] DHCP helper stopped\n")
             self._direct_proc = None
+
+    def _rollback_failed_direct_responder(self, cfg):
+        cfg["enabled"] = False
+        self.saved["direct_link"] = cfg
+        self._save()
+        self._direct_link_restore_async(cfg, clear_saved=True)
 
     def _direct_link_begin_disable(self):
         cfg = self.saved.get("direct_link") or {}
@@ -1162,9 +1165,7 @@ class LauncherApp:
                 .format(problem))
             return
         if not self._start_direct_responder():
-            cfg["enabled"] = False
-            self.saved["direct_link"] = cfg
-            self._save()
+            self._rollback_failed_direct_responder(cfg)
             return
         self._set_direct_checkbox(True)
         self._set_direct_status(self._direct_ready_status(cfg))
@@ -1688,6 +1689,9 @@ class LauncherApp:
                 self._set_direct_status(
                     "The DHCP helper stopped (code {}) — see the TERMINAL "
                     "tab. Untick and tick the box to retry.".format(code))
+            cfg = self.saved.get("direct_link") or {}
+            if cfg.get("server_ip"):
+                self._rollback_failed_direct_responder(cfg)
         self.root.after(600, self._poll_status)
 
     # -- config ----------------------------------------------------------- #

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -1075,7 +1075,10 @@ class LauncherApp:
             self.root.after(
                 0, lambda: self._direct_link_restored(output, clear_saved))
 
-        threading.Thread(target=worker, daemon=True).start()
+        # A non-daemon worker is used when the crash-recovery marker could not
+        # be saved.  That keeps process shutdown from abandoning the only DHCP
+        # restore attempt that can prevent a stranded static adapter.
+        threading.Thread(target=worker, daemon=daemon).start()
 
     def _direct_link_restored(self, output, clear_saved=False):
         if output:
@@ -1616,10 +1619,7 @@ class LauncherApp:
                 return
             self.root.after(0, lambda: self._finish_cleanup_success(result))
 
-        # A non-daemon worker is used when the crash-recovery marker could not
-        # be saved.  That keeps process shutdown from abandoning the only DHCP
-        # restore attempt that can prevent a stranded static adapter.
-        threading.Thread(target=worker, daemon=daemon).start()
+        threading.Thread(target=worker, daemon=True).start()
 
     def _finish_direct_cleanup(self, output):
         self._append_log("directlink", "[setup] {}\n".format(

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -938,6 +938,13 @@ class LauncherApp:
                 output.replace("\n", "\n[setup] ")))
         cfg = self.saved.get("direct_link") or {}
         if not self._start_direct_responder():
+            # The adapter and firewall were already configured. Keep recovery
+            # state until an asynchronous DHCP restore succeeds, so a failed
+            # cleanup remains retryable instead of stranding a static port.
+            cfg["enabled"] = False
+            self.saved["direct_link"] = cfg
+            self._save()
+            self._direct_link_restore_async(cfg, clear_saved=True)
             return
         cfg["enabled"] = True
         self.saved["direct_link"] = cfg
@@ -1039,7 +1046,7 @@ class LauncherApp:
         self._save()
         self._direct_link_restore_async(cfg)
 
-    def _direct_link_restore_async(self, cfg):
+    def _direct_link_restore_async(self, cfg, clear_saved=False):
         self._set_direct_checkbox(False, busy=True)
         self._set_direct_status(
             "Returning '{}' to automatic (DHCP)…".format(cfg.get("adapter")))
@@ -1053,14 +1060,18 @@ class LauncherApp:
                     "Could not return the port to automatic (DHCP):\n\n{}"
                     .format(err), title="Direct link cleanup failed"))
                 return
-            self.root.after(0, lambda: self._direct_link_restored(output))
+            self.root.after(
+                0, lambda: self._direct_link_restored(output, clear_saved))
 
         threading.Thread(target=worker, daemon=True).start()
 
-    def _direct_link_restored(self, output):
+    def _direct_link_restored(self, output, clear_saved=False):
         if output:
             self._append_log("directlink", "[setup] {}\n".format(
                 output.replace("\n", "\n[setup] ")))
+        if clear_saved:
+            self.saved.pop("direct_link", None)
+            self._save()
         self._set_direct_checkbox(False)
         self._set_direct_status(self._DIRECT_STATUS_OFF)
 

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -408,6 +408,8 @@ class LauncherApp:
             self.root.after(350, self._direct_link_pending)
         elif self.saved.get("pending_direct_link_off"):
             self.root.after(350, self._direct_link_off_pending)
+        elif self.saved.get("pending_direct_link_restore"):
+            self.root.after(350, self._direct_link_recovery_pending)
         elif self.saved.get("pending_start"):
             self.root.after(350, self._start_pending)
         elif (self.saved.get("direct_link") or {}).get("enabled"):
@@ -987,6 +989,7 @@ class LauncherApp:
     def _rollback_failed_direct_responder(self, cfg):
         cfg["enabled"] = False
         self.saved["direct_link"] = cfg
+        self.saved["pending_direct_link_restore"] = True
         self._save()
         self._direct_link_restore_async(cfg, clear_saved=True)
 
@@ -1072,8 +1075,11 @@ class LauncherApp:
         if output:
             self._append_log("directlink", "[setup] {}\n".format(
                 output.replace("\n", "\n[setup] ")))
+        recovery_was_pending = bool(
+            self.saved.pop("pending_direct_link_restore", None))
         if clear_saved:
             self.saved.pop("direct_link", None)
+        if clear_saved or recovery_was_pending:
             self._save()
         self._set_direct_checkbox(False)
         self._set_direct_status(self._DIRECT_STATUS_OFF)
@@ -1113,6 +1119,31 @@ class LauncherApp:
         if not cfg.get("if_index"):
             return
         self._direct_link_restore_async(cfg)
+
+    def _direct_link_recovery_pending(self):
+        """Resume a DHCP restore that may have been interrupted by exit/crash."""
+        cfg = self.saved.get("direct_link") or {}
+        if not cfg.get("server_ip"):
+            self.saved.pop("pending_direct_link_restore", None)
+            self._save()
+            return
+        self.nb.select(self.terminal_tab)
+        self._append_log(
+            "directlink",
+            "[launcher] resuming interrupted direct-link recovery\n")
+        if not elevate.is_admin():
+            if elevate.can_elevate() and elevate.relaunch_as_admin():
+                self.stop_all()
+                if self._tray:
+                    self._tray.stop()
+                self.root.destroy()
+            else:
+                self._set_direct_checkbox(False)
+                self._set_direct_status(
+                    "Direct-link recovery still needs administrator rights. "
+                    "Restart PS2 Servers or use firewall cleanup to retry.")
+            return
+        self._direct_link_restore_async(cfg, clear_saved=True)
 
     def _direct_link_startup(self):
         """Re-arm an already-configured direct link on launch.
@@ -1154,15 +1185,9 @@ class LauncherApp:
     def _direct_link_startup_done(self, problem):
         cfg = self.saved.get("direct_link") or {}
         if problem:
-            cfg["enabled"] = False
-            self.saved["direct_link"] = cfg
-            self._save()
             self._append_log("directlink",
                              "[launcher] direct link not re-armed: {}\n".format(problem))
-            self._set_direct_checkbox(False)
-            self._set_direct_status(
-                "Direct link is off: {}. Tick the box to set it up again."
-                .format(problem))
+            self._rollback_failed_direct_responder(cfg)
             return
         if not self._start_direct_responder():
             self._rollback_failed_direct_responder(cfg)
@@ -1591,6 +1616,7 @@ class LauncherApp:
         self._append_log("directlink", "[setup] {}\n".format(
             output.replace("\n", "\n[setup] ")))
         self.saved.pop("direct_link", None)
+        self.saved.pop("pending_direct_link_restore", None)
         self._save()
         self._set_direct_checkbox(False)
         self._set_direct_status(self._DIRECT_STATUS_OFF)
@@ -1738,6 +1764,8 @@ class LauncherApp:
                 "minimize_to_tray": bool(self.minimize_to_tray_var.get())}
         if self.saved.get("direct_link"):
             data["direct_link"] = self.saved["direct_link"]
+        if self.saved.get("pending_direct_link_restore"):
+            data["pending_direct_link_restore"] = True
         if pending_start:
             data["pending_start"] = pending_start
         if pending_cleanup:

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -421,7 +421,7 @@ class LauncherLifecycleTests(unittest.TestCase):
         self.assertFalse(app.saved["direct_link"]["enabled"])
         app._save.assert_called_once_with()
         app._direct_link_restore_async.assert_called_once_with(
-            app.saved["direct_link"], clear_saved=True)
+            app.saved["direct_link"], clear_saved=True, daemon=True)
         app.ip_var.set.assert_not_called()
 
     def test_firewall_failure_restores_configured_adapter(self):
@@ -496,7 +496,17 @@ class LauncherLifecycleTests(unittest.TestCase):
         self.assertFalse(cfg["enabled"])
         app._save.assert_called_once_with()
         app._direct_link_restore_async.assert_called_once_with(
-            cfg, clear_saved=True)
+            cfg, clear_saved=True, daemon=True)
+
+    def test_failed_recovery_save_uses_non_daemon_restore(self):
+        app = self.app()
+        app._save.return_value = False
+        app._direct_link_restore_async = mock.Mock()
+        cfg = app.saved["direct_link"]
+        LauncherApp._rollback_failed_direct_responder(app, cfg)
+        app._direct_link_restore_async.assert_called_once_with(
+            cfg, clear_saved=True, daemon=False)
+        self.assertIn("could not save", app._append_log.call_args.args[1])
 
     def test_pending_recovery_resumes_after_restart(self):
         app = self.app()

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -358,6 +358,22 @@ class ConfigurationSafetyTests(unittest.TestCase):
         with mock.patch.object(directlink, "is_windows", return_value=False):
             self.assertEqual(directlink.run_responder(args), 3)
 
+    def test_topology_rejects_invalid_prefix(self):
+        for prefix in (0, 31, 32, 33):
+            with self.subTest(prefix=prefix), self.assertRaises(WindowsSetupError):
+                directlink._validate_topology(SERVER, CLIENT, prefix)
+
+    def test_topology_rejects_invalid_client_addresses(self):
+        for client in (SERVER, "192.168.137.0", "192.168.137.255",
+                       "192.168.138.10"):
+            with self.subTest(client=client), self.assertRaises(WindowsSetupError):
+                directlink._validate_topology(SERVER, client, 24)
+
+    def test_topology_accepts_distinct_hosts_in_same_subnet(self):
+        self.assertEqual(
+            directlink._validate_topology(SERVER, CLIENT, 24),
+            (SERVER, CLIENT, 24))
+
 
 class FirewallSafetyTests(unittest.TestCase):
     def test_directlink_rule_is_address_scoped_without_app_wildcard(self):
@@ -392,10 +408,13 @@ class LauncherLifecycleTests(unittest.TestCase):
     def test_enable_is_not_saved_when_helper_fails_to_start(self):
         app = self.app()
         app._start_direct_responder = mock.Mock(return_value=False)
+        app._direct_link_restore_async = mock.Mock()
         app.ip_var = mock.Mock()
         LauncherApp._direct_link_enabled(app, "")
         self.assertFalse(app.saved["direct_link"]["enabled"])
-        app._save.assert_not_called()
+        app._save.assert_called_once_with()
+        app._direct_link_restore_async.assert_called_once_with(
+            app.saved["direct_link"], clear_saved=True)
         app.ip_var.set.assert_not_called()
 
     def test_firewall_failure_restores_configured_adapter(self):
@@ -434,6 +453,13 @@ class LauncherLifecycleTests(unittest.TestCase):
     def test_successful_cleanup_clears_recovery_state(self):
         app = self.app()
         LauncherApp._finish_direct_cleanup(app, "RESTORED=automatic (DHCP)")
+        self.assertNotIn("direct_link", app.saved)
+        app._save.assert_called_once_with()
+
+    def test_start_failure_restore_clears_recovery_state(self):
+        app = self.app()
+        LauncherApp._direct_link_restored(
+            app, "RESTORED=automatic (DHCP)", clear_saved=True)
         self.assertNotIn("direct_link", app.saved)
         app._save.assert_called_once_with()
 

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -480,10 +480,43 @@ class LauncherLifecycleTests(unittest.TestCase):
 
     def test_start_failure_restore_clears_recovery_state(self):
         app = self.app()
+        app.saved["pending_direct_link_restore"] = True
         LauncherApp._direct_link_restored(
             app, "RESTORED=automatic (DHCP)", clear_saved=True)
         self.assertNotIn("direct_link", app.saved)
+        self.assertNotIn("pending_direct_link_restore", app.saved)
         app._save.assert_called_once_with()
+
+    def test_failed_helper_persists_recovery_before_worker(self):
+        app = self.app()
+        app._direct_link_restore_async = mock.Mock()
+        cfg = app.saved["direct_link"]
+        LauncherApp._rollback_failed_direct_responder(app, cfg)
+        self.assertTrue(app.saved["pending_direct_link_restore"])
+        self.assertFalse(cfg["enabled"])
+        app._save.assert_called_once_with()
+        app._direct_link_restore_async.assert_called_once_with(
+            cfg, clear_saved=True)
+
+    def test_pending_recovery_resumes_after_restart(self):
+        app = self.app()
+        app.saved["pending_direct_link_restore"] = True
+        app.nb = mock.Mock()
+        app.terminal_tab = object()
+        app._direct_link_restore_async = mock.Mock()
+        with mock.patch("launcher.gui.elevate.is_admin", return_value=True):
+            LauncherApp._direct_link_recovery_pending(app)
+        app._direct_link_restore_async.assert_called_once_with(
+            app.saved["direct_link"], clear_saved=True)
+        self.assertTrue(app.saved["pending_direct_link_restore"])
+
+    def test_startup_preflight_failure_enters_recovery(self):
+        app = self.app()
+        app.saved["direct_link"]["enabled"] = True
+        app._rollback_failed_direct_responder = mock.Mock()
+        LauncherApp._direct_link_startup_done(app, "adapter reaches a router")
+        app._rollback_failed_direct_responder.assert_called_once_with(
+            app.saved["direct_link"])
 
 
 if __name__ == "__main__":

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -508,6 +508,14 @@ class LauncherLifecycleTests(unittest.TestCase):
             cfg, clear_saved=True, daemon=False)
         self.assertIn("could not save", app._append_log.call_args.args[1])
 
+    def test_restore_worker_honors_non_daemon_policy(self):
+        app = self.app()
+        with mock.patch("launcher.gui.threading.Thread") as thread:
+            LauncherApp._direct_link_restore_async(
+                app, app.saved["direct_link"], daemon=False)
+        self.assertFalse(thread.call_args.kwargs["daemon"])
+        thread.return_value.start.assert_called_once_with()
+
     def test_pending_recovery_resumes_after_restart(self):
         app = self.app()
         app.saved["pending_direct_link_restore"] = True

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -333,7 +333,7 @@ class ConfigurationSafetyTests(unittest.TestCase):
         with mock.patch.object(directlink, "_powershell") as powershell:
             with self.assertRaises(WindowsSetupError):
                 directlink.apply_adapter_config(
-                    3, "192.168.137.1'; Remove-Item C:\\ -Recurse; '")
+                    3, "192.168.137.1'; Remove-Item C:\\ -Recurse; '", CLIENT)
         powershell.assert_not_called()
 
     def test_invalid_restore_guard_is_rejected_before_powershell(self):
@@ -346,11 +346,18 @@ class ConfigurationSafetyTests(unittest.TestCase):
     def test_configuration_script_contains_failure_rollback(self):
         result = mock.Mock(returncode=0, stdout="CONFIGURED=Ethernet", stderr="")
         with mock.patch.object(directlink, "_powershell", return_value=result) as ps:
-            directlink.apply_adapter_config(3, SERVER)
+            directlink.apply_adapter_config(3, SERVER, CLIENT)
         script = ps.call_args.args[0]
         self.assertIn("catch {", script)
         self.assertIn("-Dhcp Enabled", script)
         self.assertIn("throw $originalError", script)
+
+    def test_invalid_client_topology_is_rejected_before_powershell(self):
+        with mock.patch.object(directlink, "_powershell") as powershell:
+            with self.assertRaises(WindowsSetupError):
+                directlink.apply_adapter_config(
+                    3, SERVER, "192.168.138.10", 24)
+        powershell.assert_not_called()
 
     def test_responder_refuses_non_windows(self):
         args = ["--server-ip", SERVER, "--client-ip", CLIENT,
@@ -436,6 +443,21 @@ class LauncherLifecycleTests(unittest.TestCase):
         restore.assert_called_once_with(3, expect_ip=SERVER)
         app._direct_link_fail.assert_called_once()
         self.assertIn("returned to automatic", app._direct_link_fail.call_args.args[0])
+
+    def test_unexpected_helper_exit_restores_adapter(self):
+        app = self.app()
+        app.saved["direct_link"]["enabled"] = True
+        app.procs = {}
+        app._direct_expected = True
+        app._direct_proc = mock.Mock()
+        app._direct_proc.is_running.return_value = False
+        app._direct_proc.returncode = 3
+        app._rollback_failed_direct_responder = mock.Mock()
+        app.root = mock.Mock()
+        LauncherApp._poll_status(app)
+        app._rollback_failed_direct_responder.assert_called_once_with(
+            app.saved["direct_link"])
+        app.root.after.assert_called_once_with(600, app._poll_status)
 
     def test_stop_all_also_stops_direct_responder(self):
         app = self.app()


### PR DESCRIPTION
## Follow-up to #92

PR #92 merged while its final review fixes were still being completed. This PR contains the remaining single commit.

## Changes

- reject invalid direct-link prefix lengths
- reject client addresses that equal the server, use network/broadcast addresses, or fall outside the server subnet
- automatically restore the adapter to DHCP if the DHCP helper cannot start after static configuration
- retain recovery state until that restoration succeeds
- add focused topology and startup-rollback regression tests

## Validation

- `python -m unittest tests.test_directlink -v` — 45 tests passed
- `python -m py_compile launcher\directlink.py launcher\gui.py tests\test_directlink.py` — passed
- `python -m compileall -q launcher smbv1_server udpbd_server udpfs_server ps2servers.py tools build` — passed
- `python tools\check_release_compliance.py` — passed
- `git diff --check` — passed

The full UDPFS self-test suite also passed on the immediately preceding review-hardening commit; this follow-up only changes the direct-link helper, its GUI rollback path, and focused tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened direct-link DHCP topology validation with stricter prefix-length bounds and server/client host placement checks; the DHCP responder now uses the validated subnet settings consistently.
  - Improved GUI recovery when the DHCP helper fails to start or exits unexpectedly: the system rolls back the adapter, persists recovery state, resumes it after restarts, and clears saved direct-link settings after successful recovery.
- **Tests**
  - Expanded coverage for early input rejection, PowerShell error handling script structure, and detailed recovery/rollback behaviors (including async restore scheduling and daemon handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->