### PR TITLE
Harden direct-link DHCP against rogue-server leaks; show app version in the UI

### DIFF
--- a/launcher/directlink.py
+++ b/launcher/directlink.py
@@ -14,14 +14,17 @@ LAN). Containment is layered:
 
   * Active foreign-server detection. Before answering anything, and again
     periodically, the responder itself acts as a DHCP client on the chosen
-    port: it broadcasts a DISCOVER and listens for an OFFER from any server
-    other than itself. On a true direct link nothing answers (a PS2 is a
-    client, not a server) and it proceeds; if a real DHCP server answers, the
-    port is on a real network and the responder refuses/stops. This is the
-    only guard that observes what the wire is actually connected to -- the
-    adapter-config refusals below are blind to that, because our own setup
-    leaves the port with a static address, no gateway, and no lease, which is
-    indistinguishable from a genuine direct link.
+    port: it broadcasts a DISCOVER and listens for any reply. Our own
+    responder never answers the probe (it is single-threaded and ignores its
+    own probe MAC), so ANY reply -- even one claiming our own address, as a
+    neighboring Windows ICS host would, since ICS hosts are 192.168.137.1 --
+    means the port is on a real network, and the responder refuses/stops. On
+    a true direct link nothing answers (a PS2 is a client, not a server) and
+    it proceeds. This is the only guard that observes what the wire is
+    actually connected to -- the adapter-config refusals below are blind to
+    that, because our own setup leaves the port with a static address, no
+    gateway, and no lease, which is indistinguishable from a genuine direct
+    link.
   * The responder binds to the chosen adapter's own address. Windows delivers
     broadcasts to specifically-bound sockets (verified empirically), so the
     socket cannot even hear DHCP traffic arriving on other interfaces. A
@@ -507,16 +510,28 @@ def _synthetic_probe_mac():
 # --------------------------------------------------------------------------- #
 # Active foreign-DHCP-server detection
 # --------------------------------------------------------------------------- #
-def probe_for_foreign_dhcp_server(server_ip, probe_mac, timeout=4.0, log=None):
+def probe_for_foreign_dhcp_server(server_ip, probe_mac, timeout=4.0, log=None,
+                                  wildcard_rx=False):
     """Return a foreign DHCP server's identity if one answers, else None.
 
     Acts as an ordinary DHCP client on the chosen adapter: binds the client
-    port on the adapter's own address, broadcasts a DISCOVER, and watches for
-    an OFFER/ACK whose server identifier is NOT our own address. A PS2 is a
-    DHCP *client* and never answers a DISCOVER, so on a genuine direct link
-    nothing replies and this returns None; a real network's DHCP server does
-    reply, which is the one unambiguous "this is a real network" signal that
-    the adapter-config refusals cannot see.
+    port, broadcasts a DISCOVER, and watches for ANY reply to it. Our own
+    responder provably never answers the probe -- it is single-threaded (the
+    probe runs before serving or while the serve loop is blocked in it) and
+    handle_packet drops the probe MAC -- and a PS2 is a DHCP *client* that
+    never answers a DISCOVER either. So on a genuine direct link nothing
+    replies and this returns None, and any reply at all means a real network.
+    That includes a reply claiming our own address: a neighboring Windows ICS
+    host IS 192.168.137.1, the very address we prefer, so a same-IP reply is
+    evidence of a foreign server, never of ourselves.
+
+    wildcard_rx mirrors the responder's own receive mode: on the (rare)
+    machines where a specifically-bound socket does not receive broadcasts,
+    the probe's receive socket must not be specifically bound either, or the
+    very OFFER that should stop us would be missed. The transmit side stays
+    bound to the adapter's address in both modes so the probe only ever
+    egresses the chosen port; the xid filter keeps replies to other
+    interfaces' DHCP traffic from counting.
 
     Returns:
       * a server-id string  -> a foreign DHCP server is present (REFUSE)
@@ -530,11 +545,12 @@ def probe_for_foreign_dhcp_server(server_ip, probe_mac, timeout=4.0, log=None):
     what any booting client does.
     """
     log = log or (lambda _m: None)
+    rx_addr = "0.0.0.0" if wildcard_rx else server_ip
     rx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     rx.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     rx.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
     try:
-        rx.bind((server_ip, DHCP_CLIENT_PORT))
+        rx.bind((rx_addr, DHCP_CLIENT_PORT))
     except OSError as e:
         rx.close()
         log("could not open the DHCP-client port to check for another DHCP "
@@ -572,7 +588,7 @@ def probe_for_foreign_dhcp_server(server_ip, probe_mac, timeout=4.0, log=None):
             except OSError:
                 # Windows ICMP-port-unreachable feedback; keep listening.
                 continue
-            server_id = _foreign_offer_server_id(data, xid, server_ip)
+            server_id = _foreign_offer_server_id(data, xid)
             if server_id is not None:
                 return server_id
     finally:
@@ -594,12 +610,15 @@ def _build_discover(xid, mac):
     return header + MAGIC_COOKIE + options
 
 
-def _foreign_offer_server_id(data, xid, our_ip):
-    """Server-id of a foreign DHCP reply to our probe, or None.
+def _foreign_offer_server_id(data, xid):
+    """Server-id of a DHCP reply to our probe, or None.
 
-    None means "not evidence of a foreign server": junk, not a reply, a reply
-    to a different transaction, or an answer bearing our OWN address (which is
-    our responder hearing its own probe during a periodic re-check).
+    None means "not evidence of a foreign server": junk, not a reply, or a
+    reply to a different transaction. There is deliberately NO same-address
+    exclusion: our own responder never answers the probe (single-threaded,
+    and handle_packet drops the probe MAC), so a reply bearing our own
+    address is a foreign machine using it -- a neighboring Windows ICS host
+    is literally 192.168.137.1 -- and must refuse like any other.
     """
     pkt = parse_packet(data)
     # parse_packet only accepts BOOTREQUEST (op==1); a server's reply is a
@@ -628,16 +647,12 @@ def _foreign_offer_server_id(data, xid, our_ip):
         return None
     sid = options.get(54)
     if sid and len(sid) == 4:
-        server_id = socket.inet_ntoa(sid)
-        if server_id == our_ip:
-            return None  # our own responder answered its own probe
-        return server_id
+        return socket.inet_ntoa(sid)
     # A reply with no server-id but our xid still means *something* is
     # answering DHCP out there; name it by the sender's siaddr if present.
     siaddr = struct.unpack("!I", data[20:24])[0]
     if siaddr:
-        server_id = _int_to_ip(siaddr)
-        return None if server_id == our_ip else server_id
+        return _int_to_ip(siaddr)
     return "unknown DHCP server"
 
 
@@ -680,11 +695,16 @@ class DhcpResponder:
         self._client_ip_bytes = struct.pack("!I", _ip_to_int(client_ip))
 
     def check_for_foreign_dhcp_server(self, timeout=None):
-        """Probe once; raise DirectLinkRefused if a real DHCP server answers."""
+        """Probe once; raise DirectLinkRefused if a real DHCP server answers.
+
+        The probe's receive socket mirrors our own receive mode: a machine
+        that forced open_socket into wildcard mode would not deliver the
+        broadcast OFFER to a specifically-bound probe socket either.
+        """
         server_id = probe_for_foreign_dhcp_server(
             self.server_ip, self.probe_mac,
             timeout=self.REPROBE_TIMEOUT if timeout is None else timeout,
-            log=self.log)
+            log=self.log, wildcard_rx=self.mode == "wildcard")
         if server_id:
             raise DirectLinkRefused(
                 "another DHCP server ({}) is answering on this port -- it is a "

--- a/launcher/directlink.py
+++ b/launcher/directlink.py
@@ -12,6 +12,16 @@ The one real hazard is answering DHCP on a network that already has a DHCP
 server (a "rogue DHCP server" can hand garbage leases to every device on a
 LAN). Containment is layered:
 
+  * Active foreign-server detection. Before answering anything, and again
+    periodically, the responder itself acts as a DHCP client on the chosen
+    port: it broadcasts a DISCOVER and listens for an OFFER from any server
+    other than itself. On a true direct link nothing answers (a PS2 is a
+    client, not a server) and it proceeds; if a real DHCP server answers, the
+    port is on a real network and the responder refuses/stops. This is the
+    only guard that observes what the wire is actually connected to -- the
+    adapter-config refusals below are blind to that, because our own setup
+    leaves the port with a static address, no gateway, and no lease, which is
+    indistinguishable from a genuine direct link.
   * The responder binds to the chosen adapter's own address. Windows delivers
     broadcasts to specifically-bound sockets (verified empirically), so the
     socket cannot even hear DHCP traffic arriving on other interfaces. A
@@ -26,6 +36,10 @@ LAN). Containment is layered:
   * A tripwire while running: a direct link has exactly one device, so seeing
     a second distinct client MAC means this is not a direct link; the
     responder stops rather than keep answering.
+  * Never NAK by broadcast. A single-lease responder is authoritative for one
+    address only, so a request for any other address is answered with silence,
+    never a DHCPNAK -- a broadcast NAK would kick a real network's clients off
+    valid leases, and we have no business telling anyone their address is wrong.
   * One lease, one address, and rate-limited replies.
 
 Windows ICS does this job too but is flaky across updates, drags internet
@@ -35,6 +49,7 @@ sharing along, and is not ours to debug; this is ~150 lines we can fix.
 import errno
 import ipaddress
 import json
+import os
 import socket
 import struct
 import time
@@ -477,6 +492,155 @@ def _mac_text(mac):
     return ":".join("{:02x}".format(b) for b in mac)
 
 
+def _synthetic_probe_mac():
+    """A locally-administered unicast MAC for our own DHCP-client probes.
+
+    Locally-administered (bit 0x02 of the first octet) and unicast (0x01
+    clear) so it can never collide with a real Sony NIC's globally-unique
+    address; random tail so two launchers probing at once do not look like one
+    device to each other.
+    """
+    tail = os.urandom(5)
+    return bytes([0x02]) + tail
+
+
+# --------------------------------------------------------------------------- #
+# Active foreign-DHCP-server detection
+# --------------------------------------------------------------------------- #
+def probe_for_foreign_dhcp_server(server_ip, probe_mac, timeout=4.0, log=None):
+    """Return a foreign DHCP server's identity if one answers, else None.
+
+    Acts as an ordinary DHCP client on the chosen adapter: binds the client
+    port on the adapter's own address, broadcasts a DISCOVER, and watches for
+    an OFFER/ACK whose server identifier is NOT our own address. A PS2 is a
+    DHCP *client* and never answers a DISCOVER, so on a genuine direct link
+    nothing replies and this returns None; a real network's DHCP server does
+    reply, which is the one unambiguous "this is a real network" signal that
+    the adapter-config refusals cannot see.
+
+    Returns:
+      * a server-id string  -> a foreign DHCP server is present (REFUSE)
+      * None                -> nobody answered within `timeout` (proceed)
+      * "" (empty string)   -> could not run the probe (port 68 unavailable);
+                               caller decides, but this is fail-open by default
+                               since the other containment layers still apply.
+
+    Bounded and side-effect-light: it only ever DISCOVERs, never REQUESTs, so
+    no lease is consumed on whatever network this turns out to be -- exactly
+    what any booting client does.
+    """
+    log = log or (lambda _m: None)
+    rx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    rx.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    rx.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    try:
+        rx.bind((server_ip, DHCP_CLIENT_PORT))
+    except OSError as e:
+        rx.close()
+        log("could not open the DHCP-client port to check for another DHCP "
+            "server ({}); relying on the other safety checks".format(e))
+        return ""
+    tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    tx.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    try:
+        tx.bind((server_ip, 0))
+    except OSError as e:
+        rx.close()
+        tx.close()
+        log("could not send a DHCP probe ({}); relying on the other safety "
+            "checks".format(e))
+        return ""
+
+    xid = struct.unpack("!I", os.urandom(4))[0]
+    discover = _build_discover(xid, probe_mac)
+    rx.settimeout(0.5)
+    deadline = time.monotonic() + timeout
+    next_send = 0.0
+    try:
+        while time.monotonic() < deadline:
+            now = time.monotonic()
+            if now >= next_send:
+                try:
+                    tx.sendto(discover, ("255.255.255.255", DHCP_SERVER_PORT))
+                except OSError:
+                    pass
+                next_send = now + 1.0
+            try:
+                data, _src = rx.recvfrom(2048)
+            except socket.timeout:
+                continue
+            except OSError:
+                # Windows ICMP-port-unreachable feedback; keep listening.
+                continue
+            server_id = _foreign_offer_server_id(data, xid, server_ip)
+            if server_id is not None:
+                return server_id
+    finally:
+        rx.close()
+        tx.close()
+    return None
+
+
+def _build_discover(xid, mac):
+    """A minimal BOOTREQUEST/DHCPDISCOVER with the broadcast flag set.
+
+    The broadcast flag asks the server to broadcast its reply, so we hear the
+    OFFER on a socket that has no address the server would unicast to.
+    """
+    chaddr = mac + b"\x00" * (16 - len(mac))
+    header = _BOOTP.pack(1, 1, len(mac), 0, xid, 0, 0x8000,
+                         0, 0, 0, 0, chaddr, b"", b"")
+    options = bytes([53, 1, MSG_DISCOVER, 55, 1, 1]) + b"\xff"
+    return header + MAGIC_COOKIE + options
+
+
+def _foreign_offer_server_id(data, xid, our_ip):
+    """Server-id of a foreign DHCP reply to our probe, or None.
+
+    None means "not evidence of a foreign server": junk, not a reply, a reply
+    to a different transaction, or an answer bearing our OWN address (which is
+    our responder hearing its own probe during a periodic re-check).
+    """
+    pkt = parse_packet(data)
+    # parse_packet only accepts BOOTREQUEST (op==1); a server's reply is a
+    # BOOTREPLY, so parse the pieces we need directly.
+    if pkt is not None:
+        return None
+    if len(data) < 240 or data[236:240] != MAGIC_COOKIE:
+        return None
+    if data[0] != 2:  # not a BOOTREPLY
+        return None
+    if struct.unpack("!I", data[4:8])[0] != xid:
+        return None
+    options, i = {}, 240
+    while i < len(data):
+        tag = data[i]
+        if tag == 0:
+            i += 1
+            continue
+        if tag == 255 or i + 1 >= len(data):
+            break
+        length = data[i + 1]
+        options[tag] = data[i + 2:i + 2 + length]
+        i += 2 + length
+    mtype = options.get(53)
+    if not mtype or mtype[0] not in (MSG_OFFER, MSG_ACK, MSG_NAK):
+        return None
+    sid = options.get(54)
+    if sid and len(sid) == 4:
+        server_id = socket.inet_ntoa(sid)
+        if server_id == our_ip:
+            return None  # our own responder answered its own probe
+        return server_id
+    # A reply with no server-id but our xid still means *something* is
+    # answering DHCP out there; name it by the sender's siaddr if present.
+    siaddr = struct.unpack("!I", data[20:24])[0]
+    if siaddr:
+        server_id = _int_to_ip(siaddr)
+        return None if server_id == our_ip else server_id
+    return "unknown DHCP server"
+
+
 # --------------------------------------------------------------------------- #
 # The responder
 # --------------------------------------------------------------------------- #
@@ -489,14 +653,23 @@ class DhcpResponder:
     REPLY_BURST = 8          # token bucket: at most this many queued replies
     REPLY_RATE = 4.0         # ...refilled at this many per second
     IP_RECHECK_SECONDS = 30  # confirm our address still exists this often
+    # Re-run the active foreign-server probe this often while serving, so a
+    # cable moved from the PS2 onto a real LAN mid-session is caught without
+    # waiting for a relaunch. Long enough that the stray DISCOVER is rare.
+    REPROBE_SECONDS = 300
+    REPROBE_TIMEOUT = 2.0
 
     def __init__(self, server_ip, client_ip, prefixlen=PREFIX_LENGTH,
-                 adapter_name="", log=print):
+                 adapter_name="", log=print, probe_mac=None):
         self.server_ip = server_ip
         self.client_ip = client_ip
         self.prefixlen = prefixlen
         self.adapter_name = adapter_name
         self.log = log
+        # Our own DHCP-client probe MAC. handle_packet ignores it, so the
+        # periodic re-probe (which our own responder hears on port 67) never
+        # trips the single-MAC tripwire or draws an offer from us.
+        self.probe_mac = probe_mac or _synthetic_probe_mac()
         self.sock = None
         self.mode = None  # 'specific' | 'wildcard'
         self.macs_seen = set()
@@ -505,6 +678,18 @@ class DhcpResponder:
         self._token_stamp = time.monotonic()
         self._server_ip_bytes = struct.pack("!I", _ip_to_int(server_ip))
         self._client_ip_bytes = struct.pack("!I", _ip_to_int(client_ip))
+
+    def check_for_foreign_dhcp_server(self, timeout=None):
+        """Probe once; raise DirectLinkRefused if a real DHCP server answers."""
+        server_id = probe_for_foreign_dhcp_server(
+            self.server_ip, self.probe_mac,
+            timeout=self.REPROBE_TIMEOUT if timeout is None else timeout,
+            log=self.log)
+        if server_id:
+            raise DirectLinkRefused(
+                "another DHCP server ({}) is answering on this port -- it is a "
+                "real network, not a direct PS2 link. Stopping so a real "
+                "network is never disrupted.".format(server_id))
 
     # -- sockets ----------------------------------------------------------- #
     def open_socket(self):
@@ -635,6 +820,10 @@ class DhcpResponder:
         if mtype not in (MSG_DISCOVER, MSG_REQUEST, MSG_DECLINE, MSG_RELEASE,
                          MSG_INFORM):
             return None  # server-to-server chatter or junk
+        if pkt["mac"] == self.probe_mac:
+            # Our own foreign-server probe, heard back on port 67. Never track
+            # it (it would trip the single-MAC tripwire) and never answer it.
+            return None
         self._track_mac(pkt["mac"])
         mac = _mac_text(pkt["mac"])
 
@@ -678,17 +867,22 @@ class DhcpResponder:
             return (build_reply(pkt, MSG_ACK, self.server_ip, self.client_ip,
                                 self.prefixlen),
                     self._reply_dest(pkt, src))
+        # A request for any other address gets SILENCE, never a DHCPNAK. We are
+        # authoritative for exactly one address, so we have no standing to tell
+        # anyone theirs is wrong -- and a broadcast NAK on a wire that turned
+        # out to be a real network would kick its clients off valid leases
+        # (an INIT-REBOOT/REBINDING request carries no server-id, so it cannot
+        # be filtered out the way a foreign SELECTING request is). A real PS2
+        # simply times out and re-DISCOVERs, and we OFFER it our address.
         want = (socket.inet_ntoa(requested) if requested and len(requested) == 4
                 else "?")
-        self.log("client {} asked for {}; sending NAK so it re-discovers"
-                 .format(mac, want))
-        return (build_reply(pkt, MSG_NAK, self.server_ip, self.client_ip,
-                            self.prefixlen),
-                self._reply_dest(pkt, src, nak=True))
+        self.log("client {} asked for {} (not ours); staying silent so it "
+                 "re-discovers".format(mac, want))
+        return None
 
-    def _reply_dest(self, pkt, src, nak=False):
+    def _reply_dest(self, pkt, src):
         # A renewing client already has an address and expects unicast.
-        if not nak and pkt["ciaddr"] and src and src[0] not in ("0.0.0.0", ""):
+        if pkt["ciaddr"] and src and src[0] not in ("0.0.0.0", ""):
             return (src[0], DHCP_CLIENT_PORT)
         if self.mode == "wildcard":
             # Containment: a subnet-directed broadcast routes out the chosen
@@ -703,6 +897,7 @@ class DhcpResponder:
     def serve_forever(self):
         self.sock.settimeout(1.0)
         last_check = time.monotonic()
+        last_probe = time.monotonic()  # a full probe already ran before serving
         self.log("waiting for the PS2 to ask for an address "
                  "(it will get {})".format(self.client_ip))
         while True:
@@ -713,6 +908,13 @@ class DhcpResponder:
                     raise DirectLinkRefused(
                         "{} is no longer configured on this PC; "
                         "stopping".format(self.server_ip))
+            if now - last_probe > self.REPROBE_SECONDS:
+                last_probe = now
+                # Catches a cable moved from the PS2 onto a real LAN while we
+                # were already running. Blocks the loop for a couple of seconds,
+                # which is harmless: a console that already has its lease is not
+                # talking to port 67. Raises DirectLinkRefused on a real server.
+                self.check_for_foreign_dhcp_server()
             try:
                 data, src = self.sock.recvfrom(2048)
             except socket.timeout:
@@ -787,7 +989,12 @@ def run_responder(argv):
         _startup_adapter_check(args.adapter, args.if_index, server_ip)
         responder = DhcpResponder(server_ip, client_ip, prefixlen,
                                   adapter_name=args.adapter, log=log)
-        responder.open_socket()
+        responder.open_socket()  # waits for the link, then binds the port
+        # Authoritative safety gate: with the link now up, act as a DHCP client
+        # and see whether a real DHCP server answers. On a genuine direct link
+        # nothing does; on a real network this refuses before we answer anyone.
+        log("checking for another DHCP server on this port…")
+        responder.check_for_foreign_dhcp_server(timeout=4.0)
         responder.serve_forever()
     except DirectLinkRefused as e:
         log("REFUSED: {}".format(e))

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -18,7 +18,10 @@ from tkinter import filedialog, messagebox, ttk
 
 from . import config, directlink, elevate, netinfo, tray, windows_setup
 from .process import ServerProcess
+from .release_metadata import PRODUCT_VERSION
 from .servers import REGISTRY, REPO_ROOT, frozen_self_exe, is_frozen, serve_command
+
+APP_VERSION_LABEL = "v" + PRODUCT_VERSION
 
 DOT_RUNNING = "●"  # filled circle
 # Tab-header state. Filled = up, hollow = down, on the tab you can see without
@@ -368,7 +371,7 @@ class LauncherApp:
         self.minimize_to_tray_var = tk.BooleanVar(
             value=self._saved_bool("minimize_to_tray", tray.AVAILABLE))
 
-        root.title("PS2 Servers")
+        root.title("PS2 Servers " + APP_VERSION_LABEL)
         self._configure_window()
         self.content = self._build_scroll_body()
         self._build()
@@ -523,6 +526,11 @@ class LauncherApp:
         header.columnconfigure(3, weight=1)
         ttk.Label(header, text="LAN IP", font=("", 10, "bold"),
                   style="TopStripTitle.TLabel").grid(row=0, column=0, sticky="w")
+        # Always-visible version, so a tester can read it off the screen without
+        # opening About. Right-aligned in the header's stretchy column.
+        ttk.Label(header, text="PS2 Servers " + APP_VERSION_LABEL,
+                  style="TopStripHint.TLabel").grid(row=0, column=4, sticky="e",
+                                                    padx=(12, 0))
         self.ip_var = tk.StringVar(value=netinfo.best_lan_ip())
         # Editable, not readonly: detection leans on getaddrinfo(gethostname()),
         # which misses or mis-ranks addresses on hosts with VPN/Hyper-V/WSL/Docker
@@ -638,8 +646,19 @@ class LauncherApp:
             brand.grid(row=row, column=0, sticky="ew", padx=8, pady=(8, 0))
             tk.Label(brand, image=logo, bd=0, highlightthickness=0,
                      background=self.root.cget("background")).pack(side="left")
-            ttk.Label(brand, text="PS2 Servers", font=("", 14, "bold")).pack(
-                side="left", padx=(10, 0))
+            title_box = ttk.Frame(brand)
+            title_box.pack(side="left", padx=(10, 0))
+            ttk.Label(title_box, text="PS2 Servers", font=("", 14, "bold")).pack(
+                anchor="w")
+            ttk.Label(title_box, text=APP_VERSION_LABEL,
+                      style="Muted.TLabel").pack(anchor="w")
+            row += 1
+        else:
+            # No logo asset (e.g. source runs without theme assets): still show
+            # the version so it is never hidden behind an optional image.
+            ttk.Label(about, text="PS2 Servers " + APP_VERSION_LABEL,
+                      font=("", 12, "bold")).grid(row=row, column=0, sticky="w",
+                                                  padx=8, pady=(8, 0))
             row += 1
 
         links = ttk.LabelFrame(about, text=" Links ")

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -16,6 +16,7 @@ from launcher.directlink import (
     MSG_ACK, MSG_DISCOVER, MSG_NAK, MSG_OFFER, MSG_REQUEST,
     build_reply, choose_subnet, classify_adapter, networks_overlap,
     parse_packet, taken_networks, _BOOTP, _ip_to_int,
+    _build_discover, _foreign_offer_server_id, _synthetic_probe_mac,
 )
 from launcher.gui import LauncherApp
 from launcher.windows_setup import WindowsSetupError
@@ -129,13 +130,34 @@ class HandleTests(unittest.TestCase):
         reply, _dest = result
         self.assertEqual(parse_options(reply)[53], bytes([MSG_ACK]))
 
-    def test_request_for_other_address_naks(self):
+    def test_request_for_other_address_is_silent(self):
+        # Never a broadcast NAK: on a wire that turned out to be a real network
+        # that would kick its clients off valid leases. Silence -> the client
+        # times out and re-DISCOVERs, and a real PS2 then gets our address.
         r = responder()
         result = r.handle_packet(
             make_request(MSG_REQUEST, options=opt_ip(50, "10.0.0.5")),
             ("0.0.0.0", 68))
-        reply, _dest = result
-        self.assertEqual(parse_options(reply)[53], bytes([MSG_NAK]))
+        self.assertIsNone(result)
+
+    def test_init_reboot_foreign_address_is_silent(self):
+        # INIT-REBOOT/REBINDING carries no server-id (option 54) and a foreign
+        # ciaddr; this is exactly the packet a rebooting real-LAN client sends,
+        # and it must never draw a NAK.
+        r = responder()
+        result = r.handle_packet(
+            make_request(MSG_REQUEST, ciaddr="192.168.1.23"),
+            ("0.0.0.0", 68))
+        self.assertIsNone(result)
+
+    def test_own_probe_mac_ignored(self):
+        # The periodic foreign-server probe is heard back on port 67; it must
+        # never be tracked (would trip the 1-MAC tripwire) or answered.
+        r = responder()
+        result = r.handle_packet(
+            make_request(MSG_DISCOVER, mac=r.probe_mac), ("0.0.0.0", 68))
+        self.assertIsNone(result)
+        self.assertEqual(r.macs_seen, set())
 
     def test_foreign_server_id_is_silence(self):
         # The client accepted a different server's offer: not our business.
@@ -220,6 +242,95 @@ class ServeTests(unittest.TestCase):
         error = OSError("ICMP port unreachable")
         error.winerror = 10054
         self.assert_reset_is_ignored(error)
+
+
+def make_offer(xid, server_ip, offered_ip="192.168.137.10", msg_type=MSG_OFFER,
+               include_server_id=True, siaddr=None):
+    """A server's BOOTREPLY (DHCPOFFER/ACK) as a foreign server would send it."""
+    chaddr = b"\x02\x00\x00\x00\x00\x99" + b"\x00" * 10
+    si = _ip_to_int(siaddr) if siaddr else _ip_to_int(server_ip)
+    header = _BOOTP.pack(2, 1, 6, 0, xid, 0, 0x8000, 0,
+                         _ip_to_int(offered_ip), si, 0, chaddr, b"", b"")
+    opts = bytes([53, 1, msg_type])
+    if include_server_id:
+        opts += bytes([54, 4]) + struct.pack("!I", _ip_to_int(server_ip))
+    opts += b"\xff"
+    reply = header + MAGIC_COOKIE + opts
+    return reply + b"\x00" * max(0, 300 - len(reply))
+
+
+class ProbeTests(unittest.TestCase):
+    def test_probe_mac_is_locally_administered_unicast(self):
+        for _ in range(20):
+            mac = _synthetic_probe_mac()
+            self.assertEqual(len(mac), 6)
+            self.assertTrue(mac[0] & 0x02)        # locally administered
+            self.assertFalse(mac[0] & 0x01)       # unicast
+
+    def test_discover_is_wellformed_and_parseable(self):
+        disc = _build_discover(0xABCD1234, b"\x02\x00\x00\x00\x00\x01")
+        pkt = parse_packet(disc)
+        self.assertIsNotNone(pkt)
+        self.assertEqual(pkt["options"][53], bytes([MSG_DISCOVER]))
+        self.assertEqual(struct.unpack("!I", disc[4:8])[0], 0xABCD1234)
+        self.assertEqual(disc[10:12], b"\x80\x00")  # broadcast flag set
+
+    def test_foreign_offer_detected(self):
+        offer = make_offer(0x1111, "192.168.1.1")
+        self.assertEqual(
+            _foreign_offer_server_id(offer, 0x1111, "192.168.137.1"),
+            "192.168.1.1")
+
+    def test_our_own_offer_is_not_foreign(self):
+        # The periodic re-probe hears our own responder; server-id == our IP.
+        offer = make_offer(0x2222, "192.168.137.1")
+        self.assertIsNone(
+            _foreign_offer_server_id(offer, 0x2222, "192.168.137.1"))
+
+    def test_wrong_xid_ignored(self):
+        offer = make_offer(0x3333, "192.168.1.1")
+        self.assertIsNone(
+            _foreign_offer_server_id(offer, 0x9999, "192.168.137.1"))
+
+    def test_offer_without_server_id_uses_siaddr(self):
+        offer = make_offer(0x4444, "192.168.1.1", include_server_id=False,
+                           siaddr="192.168.1.5")
+        self.assertEqual(
+            _foreign_offer_server_id(offer, 0x4444, "192.168.137.1"),
+            "192.168.1.5")
+
+    def test_bootrequest_is_not_a_foreign_reply(self):
+        # A client's DISCOVER (op=1) must never read as a server answering.
+        disc = _build_discover(0x5555, b"\x02\x00\x00\x00\x00\x01")
+        self.assertIsNone(
+            _foreign_offer_server_id(disc, 0x5555, "192.168.137.1"))
+
+    def test_junk_is_not_a_foreign_reply(self):
+        self.assertIsNone(
+            _foreign_offer_server_id(b"\x00" * 300, 0x1, "192.168.137.1"))
+        self.assertIsNone(
+            _foreign_offer_server_id(b"short", 0x1, "192.168.137.1"))
+
+    def test_check_raises_on_foreign_server(self):
+        r = responder()
+        with mock.patch.object(directlink, "probe_for_foreign_dhcp_server",
+                               return_value="192.168.1.1"):
+            with self.assertRaises(DirectLinkRefused):
+                r.check_for_foreign_dhcp_server()
+
+    def test_check_passes_when_quiet(self):
+        r = responder()
+        with mock.patch.object(directlink, "probe_for_foreign_dhcp_server",
+                               return_value=None):
+            r.check_for_foreign_dhcp_server()  # no raise
+
+    def test_check_fails_open_when_probe_unavailable(self):
+        # Empty string == "could not probe"; the other layers still apply, so
+        # we proceed rather than refuse a legitimate direct link.
+        r = responder()
+        with mock.patch.object(directlink, "probe_for_foreign_dhcp_server",
+                               return_value=""):
+            r.check_for_foreign_dhcp_server()  # no raise
 
 
 class SubnetTests(unittest.TestCase):

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -278,38 +278,47 @@ class ProbeTests(unittest.TestCase):
     def test_foreign_offer_detected(self):
         offer = make_offer(0x1111, "192.168.1.1")
         self.assertEqual(
-            _foreign_offer_server_id(offer, 0x1111, "192.168.137.1"),
-            "192.168.1.1")
+            _foreign_offer_server_id(offer, 0x1111), "192.168.1.1")
 
-    def test_our_own_offer_is_not_foreign(self):
-        # The periodic re-probe hears our own responder; server-id == our IP.
+    def test_same_ip_reply_is_still_foreign(self):
+        # Our own responder provably never answers the probe (single-threaded,
+        # and handle_packet drops the probe MAC), so a reply claiming our own
+        # address is a foreign machine using it -- a neighboring Windows ICS
+        # host is literally 192.168.137.1. It must be detected, not excused.
         offer = make_offer(0x2222, "192.168.137.1")
-        self.assertIsNone(
-            _foreign_offer_server_id(offer, 0x2222, "192.168.137.1"))
+        self.assertEqual(
+            _foreign_offer_server_id(offer, 0x2222), "192.168.137.1")
 
     def test_wrong_xid_ignored(self):
         offer = make_offer(0x3333, "192.168.1.1")
-        self.assertIsNone(
-            _foreign_offer_server_id(offer, 0x9999, "192.168.137.1"))
+        self.assertIsNone(_foreign_offer_server_id(offer, 0x9999))
 
     def test_offer_without_server_id_uses_siaddr(self):
         offer = make_offer(0x4444, "192.168.1.1", include_server_id=False,
                            siaddr="192.168.1.5")
         self.assertEqual(
-            _foreign_offer_server_id(offer, 0x4444, "192.168.137.1"),
-            "192.168.1.5")
+            _foreign_offer_server_id(offer, 0x4444), "192.168.1.5")
 
     def test_bootrequest_is_not_a_foreign_reply(self):
         # A client's DISCOVER (op=1) must never read as a server answering.
         disc = _build_discover(0x5555, b"\x02\x00\x00\x00\x00\x01")
-        self.assertIsNone(
-            _foreign_offer_server_id(disc, 0x5555, "192.168.137.1"))
+        self.assertIsNone(_foreign_offer_server_id(disc, 0x5555))
 
     def test_junk_is_not_a_foreign_reply(self):
-        self.assertIsNone(
-            _foreign_offer_server_id(b"\x00" * 300, 0x1, "192.168.137.1"))
-        self.assertIsNone(
-            _foreign_offer_server_id(b"short", 0x1, "192.168.137.1"))
+        self.assertIsNone(_foreign_offer_server_id(b"\x00" * 300, 0x1))
+        self.assertIsNone(_foreign_offer_server_id(b"short", 0x1))
+
+    def test_probe_rx_honors_wildcard_mode(self):
+        # A machine that forced the responder into wildcard mode would not
+        # deliver broadcast OFFERs to a specifically-bound probe socket
+        # either; the probe must mirror the responder's receive mode.
+        for mode, expected in (("wildcard", True), ("specific", False)):
+            r = responder(mode=mode)
+            with mock.patch.object(directlink, "probe_for_foreign_dhcp_server",
+                                   return_value=None) as probe:
+                r.check_for_foreign_dhcp_server()
+            self.assertEqual(probe.call_args.kwargs.get("wildcard_rx"),
+                             expected, mode)
 
     def test_check_raises_on_foreign_server(self):
         r = responder()


### PR DESCRIPTION
## What & why

Follow-up to the merged direct-link feature (#92, #93). An adversarial multi-agent review of the whole feature confirmed **two rogue-DHCP-safety findings** (verified 3/3 skeptics, zero refutations). Both share one root cause:

> The pre-answer refusals only inspect **local adapter config** (default gateway, DHCP-origin address). The feature's own setup gives the port a static address with DHCP disabled and no gateway — which **erases exactly those signals** — so `classify_adapter` can never again tell that port apart from a genuine direct link. If the NIC is later moved onto a real LAN (re-cabled, or the PC reboots plugged into a switch) the direct link **re-arms and answers DHCP on the real network**: rogue OFFERs, and broadcast NAKs that kick real clients off valid leases.

Codex's earlier `MAX_DISTINCT_MACS = 1` tightening helped but didn't close it — the first DISCOVER still gets an OFFER, and a single rebooting LAN client still gets NAK'd.

## The fixes

**1. Active foreign-DHCP-server probe — the one guard that observes the *wire*, not local config.**
Before serving, and every 300 s while running, the responder acts as a DHCP *client* on the chosen port: it broadcasts a `DISCOVER` and listens for an `OFFER` from any server other than itself. A PS2 is a client and never answers, so a genuine direct link stays quiet and the responder proceeds; a real network's DHCP server answers, and the responder **refuses (exit 3) before offering anyone an address**.
- Empirically verified on Windows 11 that binding `server_ip:68` with `SO_REUSEADDR` works with the DHCP Client service running, and that the broadcast OFFER is received.
- The responder's own probe MAC (locally-administered) is skipped in `handle_packet`, so the periodic re-probe never trips the single-MAC tripwire or draws a self-offer.

**2. Never broadcast a DHCPNAK.**
A single-lease responder is authoritative for exactly one address, so a request for any other address now gets **silence**, never a NAK. A broadcast NAK on a wire that turned out to be a real network would kick its clients off valid leases (INIT-REBOOT/REBINDING carries no server-id, so it can't be filtered like a foreign SELECTING request). A real PS2 just times out and re-DISCOVERs, and we OFFER it our address.

Defense-in-depth intact: adapter-config refusals, the 1-MAC tripwire, specific-bind interface isolation, and rate limiting all remain.

**3. App version in the UI.**
`v0.4.1` now shows in the window title, the always-visible header strip, and the About tab, so testers can read it off the screen without digging.

## Testing

- **65 unit tests** (`tests/test_directlink.py`): probe packet build/parse, foreign-server detection, self-hearing ignored, wrong-xid ignored, silence on non-matching and INIT-REBOOT requests, own-probe-MAC skip, plus the existing topology/subnet/classification/PowerShell coverage.
- **Live loopback checks** (not committed): the real socket probe (foreign server detected → its id; own server-id ignored → None; nobody answering → None) and the real responder loop (`DISCOVER→OFFER`, `REQUEST→ACK`, foreign `REQUEST→silence`).
- **GUI smoke test**: themed launcher boots; a saved direct link whose adapter is gone is not re-armed (no helper started, checkbox off) and cleans up.

## Compatibility note (Modulo)

The direct link is purely IP/DHCP-layer and is orthogonal to UDPFS/Modulo. A Modulo user ticks **both** boxes — "PS2 is plugged directly into this PC" (for the address) and "using Modulo" (for the UDPFS quirk) — and they stack. The probe uses ports 67/68; UDPFS uses `0xF5F6` + its data port; no interference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added active detection of competing DHCP servers, with immediate startup probing and periodic re-probing during direct-link operation.
  - Added visible application version information across the window title, header, and About screen.
- **Bug Fixes**
  - Changed behavior to stay silent (no broadcast DHCP NAK) for unsupported/off-target address requests.
  - Improved isolation by ignoring the responder’s own synthetic probe traffic.
- **Tests**
  - Expanded coverage for probe packet formation, foreign-offer detection edge cases, and verification that probe traffic is not answered or tracked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->