### PR TITLE
Bump to 0.4.5-rc1; publish hyphenated tags as pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,12 +266,17 @@ jobs:
             out/${{ matrix.folder_asset }}
             out/${{ matrix.folder_asset }}.sha256.txt
 
+      # A tag with a '-' qualifier (v0.4.5-rc1, v0.5.0-beta2) is a pre-release:
+      # publish it as such and never let it take the "Latest" badge from the
+      # current stable tag. A plain vX.Y.Z tag is a normal release and does.
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           name: PS2 Servers ${{ github.ref_name }}
           body_path: out/release-notes.md
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
           files: |
             out/${{ matrix.asset }}
             out/${{ matrix.asset }}.sha256.txt
@@ -283,6 +288,8 @@ jobs:
         with:
           name: PS2 Servers ${{ github.ref_name }}
           body_path: out/release-notes.md
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
           files: |
             out/${{ matrix.folder_asset }}
             out/${{ matrix.folder_asset }}.sha256.txt

--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -4,9 +4,11 @@ A small GUI/engine that lets any user pick and run one or more of the PS2 OPL
 network servers (SMBv1, UDPBD, UDPFS) without touching a terminal.
 """
 
-from .release_metadata import PRODUCT_VERSION
+from .release_metadata import DISPLAY_VERSION
 
-__version__ = PRODUCT_VERSION
+# The human-facing version, including any pre-release qualifier (e.g. 0.4.5-rc1).
+# The numeric build version lives in release_metadata.PRODUCT_VERSION.
+__version__ = DISPLAY_VERSION
 
 
 def _install_dependency_panel_hook():

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -18,10 +18,10 @@ from tkinter import filedialog, messagebox, ttk
 
 from . import config, directlink, elevate, netinfo, tray, windows_setup
 from .process import ServerProcess
-from .release_metadata import PRODUCT_VERSION
+from .release_metadata import DISPLAY_VERSION
 from .servers import REGISTRY, REPO_ROOT, frozen_self_exe, is_frozen, serve_command
 
-APP_VERSION_LABEL = "v" + PRODUCT_VERSION
+APP_VERSION_LABEL = "v" + DISPLAY_VERSION
 
 DOT_RUNNING = "●"  # filled circle
 # Tab-header state. Filled = up, hollow = down, on the tab you can see without

--- a/launcher/release_metadata.py
+++ b/launcher/release_metadata.py
@@ -6,8 +6,16 @@ WINDOWS_EXE_NAME = EXECUTABLE_BASENAME + ".exe"
 WINDOWS_PACKAGE_NAME = EXECUTABLE_BASENAME + "-windows-x64.zip"
 COMPANY_NAME = "NathanNeurotic"
 PRODUCT_NAME = APP_NAME
-PRODUCT_VERSION = "0.4.1"
+# Numeric only -- both feed Nuitka's --product-version/--file-version, which
+# reject anything that is not a dotted number. A pre-release qualifier like
+# "-rc1" lives in VERSION_QUALIFIER instead and is shown to the user via
+# DISPLAY_VERSION, never handed to the build.
+PRODUCT_VERSION = "0.4.5"
 FILE_VERSION = PRODUCT_VERSION
+# "" for a normal release; "-rc1" / "-beta1" while a version is under test.
+VERSION_QUALIFIER = "-rc1"
+# What the GUI shows and what a tester should quote in a report.
+DISPLAY_VERSION = PRODUCT_VERSION + VERSION_QUALIFIER
 FILE_DESCRIPTION = "PS2 Servers launcher for Open PS2 Loader local network servers"
 COPYRIGHT = "Copyright (c) NathanNeurotic and PS2 Servers contributors"
 


### PR DESCRIPTION
Prep for a **v0.4.5-rc1** release candidate so the direct-link build (merged in #94) is testable as a named, findable release instead of a buried `main-NN` auto-build that still reports `v0.4.1` in-app.

## What changed
- **Version bump to 0.4.5**, with a pre-release qualifier decoupled from the build version:
  - `PRODUCT_VERSION = "0.4.5"` (numeric — both `--product-version` and `--file-version` feed Nuitka, which rejects non-numeric strings).
  - `VERSION_QUALIFIER = "-rc1"` → `DISPLAY_VERSION = "0.4.5-rc1"`, shown in the title bar / header / About. Promoting to stable is just `VERSION_QUALIFIER = ""`.
- **`release.yml`:** a tag containing `-` (e.g. `v0.4.5-rc1`) now publishes as a **pre-release** and **does not take the "Latest" badge** — so `v0.4.1` stays the stable download until hardware testing clears. Plain `vX.Y.Z` tags are unchanged.

## Why an RC and not stable 0.4.5
The direct-link feature mutates the PC's NIC config and runs a DHCP responder. All verification so far is unit + loopback + GUI-smoke on a dev box — zero real-hardware validation. This RC gets it in front of a direct-connect tester (packaged binary, correct version string) without pushing an untested network-mutating feature to everyone as "Latest".

## Validation
- Compliance check passes; `PRODUCT_VERSION`/`FILE_VERSION` asserted Nuitka-numeric.
- 66 unit tests pass; version wiring verified (`APP_VERSION_LABEL == v0.4.5-rc1`, build metadata `0.4.5`).
- `release.yml` YAML parses; both attach steps carry the conditional `prerelease`/`make_latest`.

After merge: tag `v0.4.5-rc1` → CI publishes the RC as a pre-release. After hardware sign-off, re-tag `v0.4.5` for stable Latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the displayed application version to **0.4.5-rc1**, including the launcher header, title, and About section.
  * Release artifacts now consistently appear as pre-releases when published from qualified tags.

* **Bug Fixes**
  * Stable releases are correctly marked as the latest release, while pre-releases are excluded from latest-release status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->