### PR TITLE
Make the selected notebook tab clearly the active one

### DIFF
--- a/launcher/main.py
+++ b/launcher/main.py
@@ -167,16 +167,29 @@ def _apply_gui_review_fixes(gui):
         style.configure("PageActions.TLabel", background=palette["panel"], foreground=palette["muted"])
         style.configure("Admin.TFrame", background=palette["panel"], relief="solid", borderwidth=1)
         style.configure("Server.TNotebook", background=palette["bg"], borderwidth=0,
-                        tabmargins=(8, 6, 8, 0))
-        style.configure("Server.TNotebook.Tab", padding=(12, 6), font=("", 10, "bold"),
-                        background=palette["panel"], foreground=palette["muted"], borderwidth=1)
+                        tabmargins=(6, 4, 6, 0))
+        # Inactive tabs sit flat and muted; the selected tab is lifted with a
+        # brighter fill, accent2 text, and an accent outline that ties it to the
+        # page below. clam otherwise blends its own lighter fill onto the raised
+        # selected tab (a washed-out, low-contrast box), so light/dark/bordercolor
+        # are pinned per state to keep every tab exactly the colour asked for.
+        style.configure("Server.TNotebook.Tab", padding=(16, 8), font=("", 10, "bold"),
+                        background=palette["panel"], foreground=palette["muted"],
+                        borderwidth=1, bordercolor="#18416f",
+                        lightcolor=palette["panel"], darkcolor=palette["panel"])
         style.map("Server.TNotebook.Tab",
                   background=[("selected", palette["panel3"]),
-                              ("active", palette["panel2"]),
+                              ("active", "!selected", palette["panel2"]),
                               ("!selected", palette["panel"])],
                   foreground=[("selected", palette["accent2"]),
                               ("active", palette["text"]),
-                              ("!selected", palette["muted"])])
+                              ("!selected", palette["muted"])],
+                  bordercolor=[("selected", palette["accent"]),
+                               ("!selected", "#18416f")],
+                  lightcolor=[("selected", palette["panel3"]),
+                              ("!selected", palette["panel"])],
+                  darkcolor=[("selected", palette["panel3"]),
+                             ("!selected", palette["panel"])])
 
     def configure_window(self):
         screen_width = max(640, self.root.winfo_screenwidth())


### PR DESCRIPTION
The tab bar's active/inactive states were unclear (reported with a screenshot): the selected tab rendered as a washed-out, low-contrast light box (cyan text on a pale fill) while inactive tabs read as heavier bordered buttons — the active tab looked *less* prominent than the inactive ones.

**Cause:** ttk's `clam` theme blends its own lighter fill onto the raised selected tab, overriding the dark `panel3` the style asked for.

**Fix:** pin `background`/`foreground`/`bordercolor`/`lightcolor`/`darkcolor` per state in the tab style map so every tab is exactly the color intended. Inactive tabs sit flat and muted; the selected tab gets the brighter panel fill, accent2 (cyan) text, and an accent outline connecting it to the page below — a proper active-tab cue with real contrast.

**Verified** by rendering the actual launcher (real `_apply_gui_review_fixes` styling + `StyledNotebook` + running/stopped dots) on Windows and screenshotting the tab strip — the selected tab is now unmistakably active and readable.

Style-only change; no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved notebook tab styling for a more consistent appearance.
  * Adjusted tab spacing and padding for clearer presentation.
  * Prevented theme colors from bleeding through selected and unselected tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->