### PR TITLE
Replace the per-tab running dot with a clear colored indicator

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -146,6 +146,17 @@ def tab_label(key, running, fallback=None):
     return "{} {}".format(dot, title)
 
 
+def tab_text(label):
+    """The padded tab text, matching StyledNotebook.add's own wrapping.
+
+    Both the initial nb.add() (via StyledNotebook) and the later nb.tab()
+    refreshes must produce identical text, or the label shifts on the first
+    status change. Making this the single source of truth removes that coupling
+    -- and keeps them consistent even where StyledNotebook is not in play.
+    """
+    return "  {}  ".format(label.strip())
+
+
 def opl_hint(key, ip, values):
     if key == "smbv1":
         port = "445" if values.get("take_445") else str(values.get("port") or 1111)
@@ -235,11 +246,10 @@ class ServerCard(ttk.LabelFrame):
         try:
             if img is not None:
                 title = TAB_TITLES.get(self.server.key, self.server.label)
-                nb.tab(tab, text="  {}  ".format(title), image=img,
-                       compound="left")
+                nb.tab(tab, text=tab_text(title), image=img, compound="left")
             else:  # image generation unavailable: fall back to the glyph
-                nb.tab(tab, text=tab_label(self.server.key, running,
-                                           fallback=self.server.label))
+                nb.tab(tab, text=tab_text(tab_label(
+                    self.server.key, running, fallback=self.server.label)))
         except tk.TclError:
             pass
 
@@ -597,10 +607,11 @@ class LauncherApp:
             img = self._tab_dot_image(running=False)
             if img is not None:
                 title = TAB_TITLES.get(server.key, server.label)
-                self.nb.add(tab, text=title, image=img, compound="left")
+                self.nb.add(tab, text=tab_text(title), image=img,
+                            compound="left")
             else:
-                self.nb.add(tab, text=tab_label(server.key, running=False,
-                                                fallback=server.label))
+                self.nb.add(tab, text=tab_text(tab_label(
+                    server.key, running=False, fallback=server.label)))
             self.server_tabs[server.key] = tab
             self.cards[server.key] = card
 

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -14,7 +14,9 @@ import sys
 import threading
 import tkinter as tk
 import webbrowser
-from tkinter import filedialog, messagebox, ttk
+from tkinter import filedialog, font as tkfont, messagebox, ttk
+
+from . import status_dot
 
 from . import config, directlink, elevate, netinfo, tray, windows_setup
 from .process import ServerProcess
@@ -23,11 +25,12 @@ from .servers import REGISTRY, REPO_ROOT, frozen_self_exe, is_frozen, serve_comm
 
 APP_VERSION_LABEL = "v" + DISPLAY_VERSION
 
-DOT_RUNNING = "●"  # filled circle
-# Tab-header state. Filled = up, hollow = down, on the tab you can see without
-# opening it. Deliberately not a red/green glyph: ttk.Notebook has no per-tab
-# foreground, and a coloured emoji renders as a box wherever the font lacks it --
-# shape survives every platform and every colourblindness.
+DOT_RUNNING = "●"  # filled circle, used in the in-card status label
+# Per-tab running state. The primary indicator is a small coloured image dot
+# (green disc = running, grey ring = stopped) set as the tab's image -- a tab's
+# text is a single colour, so a glyph could never be just-the-dot green, but a
+# per-tab image carries its own colour and renders identically everywhere. These
+# glyphs remain the fallback for the rare case image generation is unavailable.
 TAB_DOT_RUNNING = "●"
 TAB_DOT_STOPPED = "○"
 COLOR_RUNNING = "#2e9e44"
@@ -228,9 +231,15 @@ class ServerCard(ttk.LabelFrame):
         nb = getattr(self.app, "nb", None)
         if tab is None or nb is None:
             return
+        img = self.app._tab_dot_image(running)
         try:
-            nb.tab(tab, text=tab_label(self.server.key, running,
-                                       fallback=self.server.label))
+            if img is not None:
+                title = TAB_TITLES.get(self.server.key, self.server.label)
+                nb.tab(tab, text="  {}  ".format(title), image=img,
+                       compound="left")
+            else:  # image generation unavailable: fall back to the glyph
+                nb.tab(tab, text=tab_label(self.server.key, running,
+                                           fallback=self.server.label))
         except tk.TclError:
             pass
 
@@ -578,14 +587,20 @@ class LauncherApp:
         self.nb = ttk.Notebook(parent)
         self.nb.pack(fill="x", padx=16, pady=(0, 12))
         self.server_tabs = {}
+        self._init_tab_dots()
 
         for server in REGISTRY.values():
             tab = ttk.Frame(self.nb)
             tab.columnconfigure(0, weight=1)
             card = ServerCard(tab, self, server)
             card.grid(row=0, column=0, sticky="ew", padx=10, pady=10)
-            self.nb.add(tab, text=tab_label(server.key, running=False,
-                                            fallback=server.label))
+            img = self._tab_dot_image(running=False)
+            if img is not None:
+                title = TAB_TITLES.get(server.key, server.label)
+                self.nb.add(tab, text=title, image=img, compound="left")
+            else:
+                self.nb.add(tab, text=tab_label(server.key, running=False,
+                                                fallback=server.label))
             self.server_tabs[server.key] = tab
             self.cards[server.key] = card
 
@@ -707,6 +722,34 @@ class LauncherApp:
             webbrowser.open_new_tab(url)
         except Exception as e:
             messagebox.showerror("Cannot open link", str(e))
+
+    # -- per-tab running/stopped dots ------------------------------------- #
+    def _init_tab_dots(self):
+        """Build the two shared tab-status images (running / stopped), once.
+
+        Sized from the tab font so the dot scales with the label at any DPI, and
+        coloured to match the in-card status label. Any failure leaves
+        self._tab_dots None, and the tabs fall back to the text glyph -- a dot is
+        decoration and must never be able to take the window down.
+        """
+        self._tab_dots = None
+        try:
+            linespace = tkfont.Font(root=self.root, font=("", 10, "bold")).metrics(
+                "linespace")
+            diameter = max(9, min(48, round(linespace * 0.6)))
+            online = tk.PhotoImage(data=status_dot.dot_png_base64(
+                diameter, COLOR_RUNNING, filled=True))
+            offline = tk.PhotoImage(data=status_dot.dot_png_base64(
+                diameter, COLOR_STOPPED, filled=False))
+            self._tab_dots = (online, offline)  # kept referenced so Tk won't GC them
+        except Exception:
+            self._tab_dots = None
+
+    def _tab_dot_image(self, running):
+        dots = getattr(self, "_tab_dots", None)
+        if not dots:
+            return None
+        return dots[0] if running else dots[1]
 
     # -- IP --------------------------------------------------------------- #
     def current_ip(self):

--- a/launcher/status_dot.py
+++ b/launcher/status_dot.py
@@ -1,0 +1,86 @@
+"""Small anti-aliased status-dot images for the server tabs.
+
+A ttk.Notebook tab is single-colour text, so a running/stopped state drawn as a
+glyph (the old "* / o") inherits the tab's text colour -- there is no way to make
+just the dot green. A per-tab *image* can carry its own colour, and Tk renders
+PNG data with a real alpha channel, so we draw a crisp dot ourselves using only
+the standard library: Pillow is not a dependency and is not bundled in releases.
+
+dot_png_base64() returns a base64 PNG string suitable for tk.PhotoImage(data=...).
+Sizes are tiny and results are cached, so calling it per rebuild is cheap.
+"""
+
+import base64
+import struct
+import zlib
+
+_cache = {}
+
+
+def _hex_rgb(color):
+    if not isinstance(color, str):
+        return tuple(color[:3])
+    c = color.lstrip("#")
+    if len(c) == 3:
+        c = "".join(ch * 2 for ch in c)
+    return (int(c[0:2], 16), int(c[2:4], 16), int(c[4:6], 16))
+
+
+def _png_rgba(size, pixels):
+    """Encode a size x size RGBA buffer as a PNG (no filtering, one IDAT)."""
+    def chunk(tag, data):
+        return (struct.pack(">I", len(data)) + tag + data
+                + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF))
+
+    ihdr = struct.pack(">IIBBBBB", size, size, 8, 6, 0, 0, 0)  # 8-bit RGBA
+    row = size * 4
+    raw = bytearray()
+    for y in range(size):
+        raw.append(0)  # filter: none
+        raw += pixels[y * row:(y + 1) * row]
+    return (b"\x89PNG\r\n\x1a\n"
+            + chunk(b"IHDR", ihdr)
+            + chunk(b"IDAT", zlib.compress(bytes(raw), 9))
+            + chunk(b"IEND", b""))
+
+
+def dot_png_base64(diameter, color, filled=True, samples=3):
+    """A base64 PNG of one status dot.
+
+    filled=True -> a solid disc (running / online).
+    filled=False -> a hollow ring (stopped / offline).
+    Edges are anti-aliased by `samples`x`samples` supersampling; the alpha
+    channel keeps the corners transparent so the dot sits cleanly on any tab
+    background (selected or not).
+    """
+    d = max(6, int(diameter))
+    key = (d, color, filled, samples)
+    cached = _cache.get(key)
+    if cached is not None:
+        return cached
+
+    r = d / 2.0
+    ring = max(1.6, d * 0.22)
+    cr, cg, cb = _hex_rgb(color)
+    px = bytearray(d * d * 4)
+    for y in range(d):
+        for x in range(d):
+            covered = 0
+            for sy in range(samples):
+                for sx in range(samples):
+                    fx = x + (sx + 0.5) / samples
+                    fy = y + (sy + 0.5) / samples
+                    dist = ((fx - r) ** 2 + (fy - r) ** 2) ** 0.5
+                    if filled:
+                        covered += dist <= r - 0.6
+                    else:
+                        covered += (r - 0.6 - ring) <= dist <= (r - 0.6)
+            i = (y * d + x) * 4
+            px[i] = cr
+            px[i + 1] = cg
+            px[i + 2] = cb
+            px[i + 3] = 255 * covered // (samples * samples)
+
+    out = base64.b64encode(_png_rgba(d, bytes(px))).decode("ascii")
+    _cache[key] = out
+    return out

--- a/tests/test_status_dot.py
+++ b/tests/test_status_dot.py
@@ -1,0 +1,84 @@
+"""Unit tests for the stdlib status-dot PNG generator.
+
+Run:  python -m unittest tests.test_status_dot -v
+"""
+
+import base64
+import struct
+import unittest
+
+from launcher import status_dot
+
+
+def decode_png_header(b64):
+    raw = base64.b64decode(b64)
+    assert raw[:8] == b"\x89PNG\r\n\x1a\n", "bad PNG signature"
+    # first chunk after the 8-byte signature is IHDR: len(4) type(4) then data
+    assert raw[12:16] == b"IHDR", "IHDR not first"
+    width, height, bit_depth, color_type = struct.unpack(">IIBB", raw[16:26])
+    return width, height, bit_depth, color_type, raw
+
+
+class StatusDotTests(unittest.TestCase):
+    def test_filled_dot_is_valid_rgba_png(self):
+        w, h, depth, ctype, raw = decode_png_header(
+            status_dot.dot_png_base64(16, "#46f6b1", filled=True))
+        self.assertEqual((w, h), (16, 16))
+        self.assertEqual(depth, 8)
+        self.assertEqual(ctype, 6)  # RGBA
+        self.assertIn(b"IEND", raw)
+
+    def test_ring_dot_is_valid(self):
+        w, h, _d, ctype, _raw = decode_png_header(
+            status_dot.dot_png_base64(14, "#8aa9d6", filled=False))
+        self.assertEqual((w, h), (14, 14))
+        self.assertEqual(ctype, 6)
+
+    def test_minimum_diameter_clamped(self):
+        w, h, _d, _c, _r = decode_png_header(
+            status_dot.dot_png_base64(2, "#ffffff"))
+        self.assertGreaterEqual(w, 6)
+        self.assertEqual(w, h)
+
+    def test_hex_forms_and_tuple_accepted(self):
+        for color in ("#46f6b1", "46f6b1", "#4fa", (70, 246, 177)):
+            self.assertTrue(status_dot.dot_png_base64(12, color))
+
+    def test_result_is_cached(self):
+        a = status_dot.dot_png_base64(20, "#123456", filled=True)
+        b = status_dot.dot_png_base64(20, "#123456", filled=True)
+        self.assertIs(a, b)  # same cached string object
+
+    def test_filled_and_ring_differ(self):
+        filled = status_dot.dot_png_base64(18, "#46f6b1", filled=True)
+        ring = status_dot.dot_png_base64(18, "#46f6b1", filled=False)
+        self.assertNotEqual(filled, ring)
+
+    def test_center_filled_opaque_ring_hollow(self):
+        # Un-filter the IDAT and read the centre pixel's alpha: a filled disc is
+        # opaque in the middle, a ring is transparent there.
+        def center_alpha(b64, size):
+            import zlib
+            raw = base64.b64decode(b64)
+            i, idat = 8, b""
+            while i < len(raw):
+                length = struct.unpack(">I", raw[i:i + 4])[0]
+                tag = raw[i + 4:i + 8]
+                if tag == b"IDAT":
+                    idat += raw[i + 8:i + 8 + length]
+                i += 12 + length
+            data = zlib.decompress(idat)
+            stride = size * 4
+            cy = size // 2
+            # each row is prefixed with a 1-byte filter (0 == none, as we write)
+            row = data[cy * (stride + 1) + 1:cy * (stride + 1) + 1 + stride]
+            cx = size // 2
+            return row[cx * 4 + 3]
+        self.assertGreater(center_alpha(
+            status_dot.dot_png_base64(18, "#46f6b1", filled=True), 18), 200)
+        self.assertEqual(center_alpha(
+            status_dot.dot_png_base64(18, "#46f6b1", filled=False), 18), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The per-tab online/offline indicator looked bad (reported): running vs stopped was a monochrome `●` / `○` glyph in the same muted color as the tab label — no color, only a subtle filled-vs-hollow shape difference, so it read as colorless noise before each label.

**Why it was stuck that way:** a ttk.Notebook tab's text is a single color, so a glyph can never be *just the dot* green.

**Fix:** give each server tab a small **image** dot instead (ttk tabs support a per-tab image + `compound`). Tk renders PNG data with a real alpha channel, so the dot is drawn with only the standard library — no Pillow (which isn't bundled): a green filled disc for running, a gray hollow ring for stopped, anti-aliased via supersampling and sized from the tab font so it scales with the label at any DPI. The old glyphs remain as a fallback if image generation is ever unavailable.

**Verified** against the actual launcher render on Windows — running (UDPFS/UDPBD) and stopped (SMBv1) tabs side by side; the green "online" dots are immediately readable.

- New `launcher/status_dot.py` — stdlib RGBA-PNG dot generator, with unit tests (`tests/test_status_dot.py`) covering the encoder, caching, hex/tuple color forms, and filled-vs-ring alpha.
- `launcher/gui.py` — build the two shared dot images once, set them as tab images, fall back to the glyph on any failure.

73 tests pass; compliance check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-tab status dot images to show each server’s running state, matching tab background colors.
  * Support for both filled and hollow dot styles.
  * Improved tab label consistency to prevent visual shifting during tab refreshes.

* **Bug Fixes**
  * More robust status rendering with automatic fallback to text-based indicators if dot images can’t be generated.

* **Tests**
  * Added coverage for the status-dot PNG generator, including format validation, caching behavior, and basic pixel-level correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->