### PR TITLE
Release v0.4.6

### DIFF
--- a/launcher/release_metadata.py
+++ b/launcher/release_metadata.py
@@ -10,10 +10,10 @@ PRODUCT_NAME = APP_NAME
 # reject anything that is not a dotted number. A pre-release qualifier like
 # "-rc1" lives in VERSION_QUALIFIER instead and is shown to the user via
 # DISPLAY_VERSION, never handed to the build.
-PRODUCT_VERSION = "0.4.5"
+PRODUCT_VERSION = "0.4.6"
 FILE_VERSION = PRODUCT_VERSION
 # "" for a normal release; "-rc1" / "-beta1" while a version is under test.
-VERSION_QUALIFIER = "-rc1"
+VERSION_QUALIFIER = ""
 # What the GUI shows and what a tester should quote in a report.
 DISPLAY_VERSION = PRODUCT_VERSION + VERSION_QUALIFIER
 FILE_DESCRIPTION = "PS2 Servers launcher for Open PS2 Loader local network servers"


### PR DESCRIPTION
Cut a stable **v0.4.6**.

- `PRODUCT_VERSION` 0.4.5 → **0.4.6**, `VERSION_QUALIFIER` cleared → in-app version reads `v0.4.6`; the numeric build metadata stays valid for Nuitka.
- Tagging `v0.4.6` (no `-` qualifier) publishes as a normal release and takes the **Latest** badge (per the release.yml rule added in #95).

**Ships since v0.4.1:**
- Direct PS2-to-PC link mode — opt-in "PS2 is plugged directly into this PC" checkbox, guarded single-lease DHCP with active foreign-server detection and no-broadcast-NAK (#94).
- In-app version display in the title bar / header / About (#94).
- Clearer active-tab styling (#96).
- Colored per-tab running/stopped status dots (#97).

Compliance check clean; version wiring verified (`v0.4.6`, build metadata `0.4.6`); 73 tests pass.

After merge: tag `v0.4.6` → CI builds and publishes the stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the product version to **0.4.6**.
  * Marked the release as a stable version by removing the prerelease suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->