### PR TITLE
Direct link: coexist automatically with a console already on the wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,11 +186,18 @@ runs a tiny DHCP helper on that port only, so the console — which asks for an
 address by itself — just gets one. The LAN IP box fills in with the address to use
 in OPL. Unticking the box undoes all of it.
 
+**You never configure the PS2.** If the console still has a leftover static IP from
+an earlier setup, the helper sees the device on the wire and quietly moves *this
+PC* to a compatible address so the two coexist — stepping off a clashing address,
+or even adopting the console's subnet if it is on a different one. The console
+finds the server by broadcasting, so it never needs the PC's address, and its
+network settings are never touched.
+
 The helper is deliberately paranoid, because a DHCP server answering on a real
 network could hand bad addresses to everything on it. It binds only to the
 direct-link port, refuses to start if that port reaches a router or already got an
 address from a real DHCP server, serves exactly one address to one console, and
-stops itself if a second device starts asking. Windows-only for now.
+stops itself if several devices start asking. Windows-only for now.
 
 ## Run a server on its own (terminal)
 

--- a/README.md
+++ b/README.md
@@ -186,12 +186,13 @@ runs a tiny DHCP helper on that port only, so the console — which asks for an
 address by itself — just gets one. The LAN IP box fills in with the address to use
 in OPL. Unticking the box undoes all of it.
 
-**You never configure the PS2.** If the console still has a leftover static IP from
-an earlier setup, the helper sees the device on the wire and quietly moves *this
-PC* to a compatible address so the two coexist — stepping off a clashing address,
-or even adopting the console's subnet if it is on a different one. The console
-finds the server by broadcasting, so it never needs the PC's address, and its
-network settings are never touched.
+**You normally never configure the PS2.** If the console still has a leftover
+static IP from an earlier setup, the helper sees the device on the wire and
+quietly moves *this PC* to a compatible address so the two coexist — stepping off
+a clashing address, or even adopting the console's subnet if it is on a different
+one. The console finds the server by broadcasting, so it usually needs no changes.
+Only if no shared address can be found — an unusually busy wire — does the
+launcher fall back to asking you to set the PS2 to DHCP or a different static IP.
 
 The helper is deliberately paranoid, because a DHCP server answering on a real
 network could hand bad addresses to everything on it. It binds only to the

--- a/launcher/directlink.py
+++ b/launcher/directlink.py
@@ -85,6 +85,18 @@ class DirectLinkRefused(RuntimeError):
     """A safety refusal: the situation does not look like a direct PS2 link."""
 
 
+class _Rehome(Exception):
+    """Internal: move the PC's address to coexist with a device on the wire.
+
+    Carries (server_ip, client_ip, prefixlen). run_responder turns it into a
+    'REHOME=...' line + exit code 5; the launcher reconfigures and restarts.
+    """
+
+    def __init__(self, plan):
+        self.server_ip, self.client_ip, self.prefixlen = plan
+        super().__init__("re-home to {}".format(self.server_ip))
+
+
 # --------------------------------------------------------------------------- #
 # Small IPv4 helpers
 # --------------------------------------------------------------------------- #
@@ -317,6 +329,141 @@ def choose_subnet(taken):
             return ("{}.{}".format(base, SERVER_HOST_NUM),
                     "{}.{}".format(base, CLIENT_HOST_NUM))
     return None, None
+
+
+# --------------------------------------------------------------------------- #
+# Coexisting with a device already on the wire (a PS2 with a leftover static IP)
+# --------------------------------------------------------------------------- #
+def _network_of_int(ip_int, prefixlen):
+    mask = (0xFFFFFFFF << (32 - prefixlen)) & 0xFFFFFFFF if prefixlen else 0
+    return ip_int & mask
+
+
+def _free_host(network_int, prefixlen, avoid_ints):
+    """Lowest usable host address (as int) in the /prefixlen not in avoid_ints."""
+    network = _network_of_int(network_int, prefixlen)
+    broadcast = network | (0xFFFFFFFF >> prefixlen)
+    for host in range(network + 1, broadcast):
+        if host not in avoid_ints:
+            return host
+    return None
+
+
+def plan_rehome(server_ip, client_ip, prefixlen, neighbors, our_ip_present):
+    """Move the PC's address to coexist with a device already on the wire.
+
+    Returns (new_server_ip, new_client_ip, prefixlen) or None if no move is
+    needed. The whole point of PS2 Servers is that nothing is configured on the
+    console, so when a PS2 turns up with a leftover static IP we adapt the PC
+    instead of asking the user to change the PS2:
+
+      * a device SHARES our subnet and collides with (or sits on) our address
+        -> step the PC to a free host in the same subnet;
+      * a device is on a DIFFERENT subnet (a static left over from another
+        network) -> adopt its /24, so the PC can unicast back to it. The console
+        finds the server by broadcasting UDPFS discovery, so it needs no address
+        of ours -- it just needs us reachable in its subnet.
+
+    neighbors are the IPv4 addresses seen on the direct-link interface (already
+    filtered of link-local/multicast/our own). our_ip_present is whether our
+    current address is still on the adapter (False + a neighbour at our address
+    == a duplicate-address conflict).
+    """
+    prefixlen = int(prefixlen)
+    server_int = _ip_to_int(server_ip)
+    our_net = _network_of_int(server_int, prefixlen)
+    neigh_ints = []
+    for n in neighbors:
+        try:
+            neigh_ints.append(_ip_to_int(n))
+        except OSError:
+            pass
+    avoid = set(neigh_ints)
+
+    # Case C: a neighbour on a different subnet -> adopt its /24.
+    off_subnet = [n for n in neigh_ints
+                  if _network_of_int(n, prefixlen) != our_net]
+    if off_subnet:
+        target_net = _network_of_int(off_subnet[0], 24)
+        new_server = _free_host(target_net, 24, avoid)
+        if new_server is not None:
+            new_client = _free_host(target_net, 24, avoid | {new_server})
+            if new_client is not None:
+                return (_int_to_ip(new_server), _int_to_ip(new_client), 24)
+
+    # Case B: a neighbour shares our subnet and our address is contested.
+    same_subnet = any(_network_of_int(n, prefixlen) == our_net
+                      for n in neigh_ints)
+    contested = (not our_ip_present) or (server_int in neigh_ints)
+    if same_subnet and contested:
+        new_server = _free_host(our_net, prefixlen, avoid | {server_int})
+        if new_server is not None:
+            client_int = _ip_to_int(client_ip)
+            if client_int in avoid or client_int == new_server:
+                new_client = _free_host(our_net, prefixlen,
+                                        avoid | {server_int, new_server})
+            else:
+                new_client = client_int
+            if new_client is not None:
+                return (_int_to_ip(new_server), _int_to_ip(new_client),
+                        prefixlen)
+    return None
+
+
+def _parse_neighbors(json_text, our_ips=()):
+    """Usable neighbour IPv4 addresses from the Get-NetNeighbor JSON output.
+
+    Drops our own addresses, loopback/link-local/all-zero, multicast and higher
+    (>=224), and network/broadcast host numbers -- what is left is a real device
+    the PC has exchanged frames with (the directly-attached PS2).
+    """
+    try:
+        data = json.loads((json_text or "").strip() or "[]")
+    except ValueError:
+        return []
+    if isinstance(data, str):
+        data = [data]
+    our = set(our_ips)
+    out = []
+    for ip in data:
+        if not isinstance(ip, str) or ip in our:
+            continue
+        if ip.startswith(("127.", "169.254.", "0.")):
+            continue
+        try:
+            octets = [int(o) for o in ip.split(".")]
+        except ValueError:
+            continue
+        if len(octets) != 4 or octets[0] >= 224 or octets[3] in (0, 255):
+            continue
+        out.append(ip)
+    return out
+
+
+def _neighbor_script(if_index):
+    return ("Get-NetNeighbor -InterfaceIndex " + str(int(if_index)) +
+            " -AddressFamily IPv4 -ErrorAction SilentlyContinue | "
+            "Where-Object { $_.State -in 'Reachable','Stale','Delay','Probe',"
+            "'Permanent' } | ForEach-Object { [string]$_.IPAddress } | "
+            "ConvertTo-Json")
+
+
+def interface_neighbors(if_index, our_ips=()):
+    """IPv4 addresses of devices seen on this interface, or [] on any failure.
+
+    Windows-only (Get-NetNeighbor). The neighbour cache is populated as a side
+    effect of frames the PC receives, so an active console -- one broadcasting
+    UDPFS discovery -- turns up here within seconds.
+    """
+    if not is_windows():
+        return []
+    try:
+        res = _powershell(_neighbor_script(if_index))
+    except Exception:
+        return []
+    if res.returncode != 0:
+        return []
+    return _parse_neighbors(res.stdout, our_ips)
 
 
 # --------------------------------------------------------------------------- #
@@ -678,13 +825,17 @@ class DhcpResponder:
     # waiting for a relaunch. Long enough that the stray DISCOVER is rare.
     REPROBE_SECONDS = 300
     REPROBE_TIMEOUT = 2.0
+    # How often to look at who else is on the wire, so a console with a leftover
+    # static IP can be coexisted with (re-home) instead of fought over.
+    REHOME_CHECK_SECONDS = 15
 
     def __init__(self, server_ip, client_ip, prefixlen=PREFIX_LENGTH,
-                 adapter_name="", log=print, probe_mac=None):
+                 adapter_name="", log=print, probe_mac=None, if_index=0):
         self.server_ip = server_ip
         self.client_ip = client_ip
         self.prefixlen = prefixlen
         self.adapter_name = adapter_name
+        self.if_index = if_index
         self.log = log
         # Our own DHCP-client probe MAC. handle_packet ignores it, so the
         # periodic re-probe (which our own responder hears on port 67) never
@@ -952,18 +1103,45 @@ class DhcpResponder:
             return (bcast, DHCP_CLIENT_PORT)
         return ("255.255.255.255", DHCP_CLIENT_PORT)
 
+    def _plan_rehome_now(self, server_ip_present):
+        """A coexist plan if a device on the wire needs us to move, else None.
+
+        Looks at who else is on the interface and, per plan_rehome, either steps
+        the PC to a free host in the same subnet (a console statically on our
+        address) or adopts the console's subnet (a console left on another
+        network's static IP). No console reconfiguration -- it finds us by
+        broadcasting UDPFS discovery regardless of our address.
+        """
+        neighbors = interface_neighbors(self.if_index, our_ips=[self.server_ip])
+        if not neighbors:
+            return None
+        return plan_rehome(self.server_ip, self.client_ip, self.prefixlen,
+                           neighbors, server_ip_present)
+
     # -- main loop ---------------------------------------------------------- #
     def serve_forever(self):
         self.sock.settimeout(1.0)
         last_check = time.monotonic()
+        last_neigh = time.monotonic()
         last_probe = time.monotonic()  # a full probe already ran before serving
         self.log("waiting for the PS2 to ask for an address "
                  "(it will get {})".format(self.client_ip))
         while True:
             now = time.monotonic()
+            present = True
             if now - last_check > self.IP_RECHECK_SECONDS:
                 last_check = now
-                if not self._server_ip_still_present():
+                present = self._server_ip_still_present()
+            # Look at the wire when our address just went missing (a conflict),
+            # or on the slower rehome cadence. If a device is present we can
+            # coexist with, re-home to it; only if there is no such plan AND our
+            # address is gone do we refuse with the diagnosis.
+            if (not present) or (now - last_neigh > self.REHOME_CHECK_SECONDS):
+                last_neigh = now
+                plan = self._plan_rehome_now(present)
+                if plan is not None:
+                    raise _Rehome(plan)
+                if not present:
                     raise DirectLinkRefused(self._diagnose_missing_server_ip())
             if now - last_probe > self.REPROBE_SECONDS:
                 last_probe = now
@@ -1045,7 +1223,8 @@ def run_responder(argv):
             args.server_ip, args.client_ip, args.prefix)
         _startup_adapter_check(args.adapter, args.if_index, server_ip)
         responder = DhcpResponder(server_ip, client_ip, prefixlen,
-                                  adapter_name=args.adapter, log=log)
+                                  adapter_name=args.adapter, log=log,
+                                  if_index=args.if_index)
         responder.open_socket()  # waits for the link, then binds the port
         # Authoritative safety gate: with the link now up, act as a DHCP client
         # and see whether a real DHCP server answers. On a genuine direct link
@@ -1053,6 +1232,15 @@ def run_responder(argv):
         log("checking for another DHCP server on this port…")
         responder.check_for_foreign_dhcp_server(timeout=4.0)
         responder.serve_forever()
+    except _Rehome as r:
+        # Coexist with a device already on the wire: ask the launcher to move
+        # this PC's address (one elevated reconfigure) and restart us. The
+        # console is never touched -- it finds us by broadcast.
+        log("a device is already using this wire; moving this PC to {} so they "
+            "can coexist (the PS2 needs no changes)".format(r.server_ip))
+        print("REHOME server_ip={} client_ip={} prefix={}".format(
+            r.server_ip, r.client_ip, r.prefixlen), flush=True)
+        return 5
     except DirectLinkRefused as e:
         log("REFUSED: {}".format(e))
         return 3

--- a/launcher/directlink.py
+++ b/launcher/directlink.py
@@ -667,7 +667,12 @@ class DhcpResponder:
     MAX_DISTINCT_MACS = 1
     REPLY_BURST = 8          # token bucket: at most this many queued replies
     REPLY_RATE = 4.0         # ...refilled at this many per second
-    IP_RECHECK_SECONDS = 30  # confirm our address still exists this often
+    IP_RECHECK_SECONDS = 5   # confirm our address still exists this often
+    # ...short, because the common reason it vanishes is a duplicate-address
+    # conflict (another device on the wire using our address), and Windows
+    # removes ours within seconds of that device ARPing. Catching it fast turns
+    # a confusing flap into one clear message. The check is a cheap socket bind;
+    # only the failure path does the (slower) adapter lookup to diagnose why.
     # Re-run the active foreign-server probe this often while serving, so a
     # cable moved from the PS2 onto a real LAN mid-session is caught without
     # waiting for a relaunch. Long enough that the stray DISCOVER is rare.
@@ -808,6 +813,31 @@ class DhcpResponder:
         finally:
             s.close()
 
+    def _diagnose_missing_server_ip(self):
+        """Why our address vanished, in words a user can act on.
+
+        The case worth naming is a duplicate-address conflict: another device
+        on the wire is already using our address, so Windows' duplicate-address
+        detection strips it from this PC within seconds -- which is exactly the
+        confusing 'it keeps disconnecting' failure a PS2 left on a static IP
+        equal to our server address produces. That reads completely differently
+        from the console simply being switched off (the link would be down).
+        """
+        generic = "{} is no longer configured on this PC".format(self.server_ip)
+        adapter = None
+        try:
+            adapter = adapter_state(0, self.adapter_name or None)
+        except Exception:
+            adapter = None
+        if adapter is not None and (adapter.get("status") or "").lower() == "up":
+            return (generic + " -- Windows removed it, which means another "
+                    "device on this cable is already using {ip}. If your PS2 "
+                    "is set to a static IP of {ip}, switch it to DHCP "
+                    "(automatic), or to a different address such as {client}."
+                    .format(ip=self.server_ip, client=self.client_ip))
+        return (generic + "; the link went down -- the cable was unplugged or "
+                "the console was switched off")
+
     # -- refusals ---------------------------------------------------------- #
     def _take_token(self):
         now = time.monotonic()
@@ -925,9 +955,7 @@ class DhcpResponder:
             if now - last_check > self.IP_RECHECK_SECONDS:
                 last_check = now
                 if not self._server_ip_still_present():
-                    raise DirectLinkRefused(
-                        "{} is no longer configured on this PC; "
-                        "stopping".format(self.server_ip))
+                    raise DirectLinkRefused(self._diagnose_missing_server_ip())
             if now - last_probe > self.REPROBE_SECONDS:
                 last_probe = now
                 # Catches a cable moved from the PS2 onto a real LAN while we

--- a/launcher/directlink.py
+++ b/launcher/directlink.py
@@ -824,12 +824,15 @@ class DhcpResponder:
         from the console simply being switched off (the link would be down).
         """
         generic = "{} is no longer configured on this PC".format(self.server_ip)
-        adapter = None
         try:
             adapter = adapter_state(0, self.adapter_name or None)
         except Exception:
             adapter = None
-        if adapter is not None and (adapter.get("status") or "").lower() == "up":
+        if adapter is None:
+            # Could not read the adapter (lookup failed, or it is gone) -- do
+            # not guess a cause; the bare fact is still useful.
+            return generic
+        if (adapter.get("status") or "").lower() == "up":
             return (generic + " -- Windows removed it, which means another "
                     "device on this cable is already using {ip}. If your PS2 "
                     "is set to a static IP of {ip}, switch it to DHCP "

--- a/launcher/directlink.py
+++ b/launcher/directlink.py
@@ -832,14 +832,20 @@ class DhcpResponder:
             # Could not read the adapter (lookup failed, or it is gone) -- do
             # not guess a cause; the bare fact is still useful.
             return generic
-        if (adapter.get("status") or "").lower() == "up":
+        status = (adapter.get("status") or "").lower()
+        if status == "up":
             return (generic + " -- Windows removed it, which means another "
                     "device on this cable is already using {ip}. If your PS2 "
                     "is set to a static IP of {ip}, switch it to DHCP "
                     "(automatic), or to a different address such as {client}."
                     .format(ip=self.server_ip, client=self.client_ip))
-        return (generic + "; the link went down -- the cable was unplugged or "
-                "the console was switched off")
+        # Only an explicitly-recognized down state gets the link-down wording;
+        # a missing or unfamiliar status is "unknown cause", not a guess.
+        if status in ("disconnected", "down", "not present", "disabled",
+                      "not operational", "inactive", "lowerlayerdown"):
+            return (generic + "; the link went down -- the cable was unplugged "
+                    "or the console was switched off")
+        return generic
 
     # -- refusals ---------------------------------------------------------- #
     def _take_token(self):

--- a/launcher/directlink.py
+++ b/launcher/directlink.py
@@ -880,6 +880,7 @@ class DhcpResponder:
         retransmits, so coming up a few seconds after the link does is fine.
         """
         waiting_logged = False
+        waits = 0
         while True:
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
@@ -896,6 +897,16 @@ class DhcpResponder:
                         "service running (Windows ICS, or a leftover PS2 "
                         "Servers helper)?".format(
                             self.server_ip, DHCP_SERVER_PORT, e))
+                waits += 1
+                # A device already holding our address (a console on a leftover
+                # static IP present at launch) makes the bind fail exactly like a
+                # down link does. After giving the link a moment to settle, look
+                # at the wire: if someone is there, coexist (re-home) rather than
+                # wait forever for a "console" that is actually the conflict.
+                if waits >= 2:
+                    plan = self._plan_rehome_now(server_ip_present=False)
+                    if plan is not None:
+                        raise _Rehome(plan)
                 if not waiting_logged:
                     waiting_logged = True
                     self.log("waiting for the link to come up ({} is not "
@@ -976,7 +987,7 @@ class DhcpResponder:
         """
         generic = "{} is no longer configured on this PC".format(self.server_ip)
         try:
-            adapter = adapter_state(0, self.adapter_name or None)
+            adapter = adapter_state(self.if_index, self.adapter_name or None)
         except Exception:
             adapter = None
         if adapter is None:
@@ -1112,7 +1123,12 @@ class DhcpResponder:
         network's static IP). No console reconfiguration -- it finds us by
         broadcasting UDPFS discovery regardless of our address.
         """
-        neighbors = interface_neighbors(self.if_index, our_ips=[self.server_ip])
+        # Exclude our own address from the neighbour list ONLY while we still
+        # hold it. If a duplicate-address conflict has removed it, the device
+        # now answering for that address IS the conflict we must see -- filtering
+        # it here would drop exactly the evidence plan_rehome needs.
+        our_ips = [self.server_ip] if server_ip_present else []
+        neighbors = interface_neighbors(self.if_index, our_ips=our_ips)
         if not neighbors:
             return None
         return plan_rehome(self.server_ip, self.client_ip, self.prefixlen,

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -103,7 +103,7 @@ Direct PS2-to-PC link
 
 A PS2 cabled straight into the PC has no router on the wire, so nothing hands the console an IP address and every network app fails the same way. Ticking "PS2 is plugged directly into this PC" fixes that: PS2 Servers gives the chosen network port a fixed address (one administrator prompt), allows DHCP through the firewall, and runs a small DHCP helper that answers only on that port, so the console configures itself.
 
-You do not configure anything on the PS2. If the console already has a leftover static IP from an earlier setup, the helper notices the device on the wire and quietly moves THIS PC to a compatible address so the two coexist — including onto the console's own subnet if it is on a different one. The console finds the server by broadcasting, so it never needs to know the PC's address, and you never have to touch its network settings.
+You normally do not configure anything on the PS2. If the console already has a leftover static IP from an earlier setup, the helper notices the device on the wire and quietly moves THIS PC to a compatible address so the two coexist — including onto the console's own subnet if it is on a different one. The console finds the server by broadcasting, so it usually needs no changes. Only when no shared address can be found does the launcher fall back to asking you to set the PS2 to DHCP or a different static IP.
 
 The helper is deliberately paranoid, because a DHCP server answering on a real network could disrupt every device on it. It binds to the direct-link port alone, refuses to run if that port reaches a router or holds a DHCP lease, hands out exactly one address to one console, and stops itself if several devices start asking. Unticking the box stops the helper and returns the port to automatic (DHCP); "Remove PS2 Servers firewall rules" also undoes it. Direct link mode is currently Windows-only.
 
@@ -1851,7 +1851,13 @@ class LauncherApp:
         cfg["server_ip"] = server_ip
         cfg["client_ip"] = client_ip
         cfg["prefix"] = prefix
+        cfg["enabled"] = True
         self.saved["direct_link"] = cfg
+        # Persist the recovery marker BEFORE touching the adapter, so a crash or
+        # failure mid-move still returns the port to DHCP on the next launch
+        # instead of stranding it static.
+        self.saved["pending_direct_link_restore"] = True
+        self._save()
         self._set_direct_checkbox(True, busy=True)
         self._set_direct_status(
             "A device is already on this cable — moving this PC to {} so they "
@@ -1862,12 +1868,22 @@ class LauncherApp:
                 out = directlink.apply_adapter_config(
                     cfg["if_index"], server_ip, client_ip, prefix)
             except Exception as e:
-                self.root.after(0, lambda err=e: self._direct_link_fail(
-                    "Could not move the direct-link address:\n\n{}".format(err)))
+                self.root.after(0, lambda err=e: self._direct_link_rehome_failed(err))
                 return
             self.root.after(0, lambda: self._direct_link_rehome_done(out))
 
         threading.Thread(target=worker, daemon=True).start()
+
+    def _direct_link_rehome_failed(self, err):
+        self._append_log("directlink",
+                         "[launcher] could not move the direct-link address: "
+                         "{}\n".format(err))
+        self._set_direct_status(
+            "Couldn't move the direct-link address — see the TERMINAL tab. "
+            "Untick and tick to retry.")
+        # Route through the recovery path: it returns the port to DHCP and
+        # clears the saved direct-link state.
+        self._rollback_failed_direct_responder(self.saved.get("direct_link") or {})
 
     def _direct_link_rehome_done(self, output):
         if output:
@@ -1876,7 +1892,13 @@ class LauncherApp:
         cfg = self.saved.get("direct_link") or {}
         self._direct_proc = None
         if not self._start_direct_responder():
+            # The port was reconfigured but the helper won't start: recover
+            # rather than leave a stranded static port.
+            self._rollback_failed_direct_responder(cfg)
             return
+        # Configured and serving on the new address -> the move is committed;
+        # drop the crash-recovery marker.
+        self.saved.pop("pending_direct_link_restore", None)
         self.ip_var.set(cfg["server_ip"])
         self._save()
         self._set_direct_checkbox(True)

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -103,7 +103,9 @@ Direct PS2-to-PC link
 
 A PS2 cabled straight into the PC has no router on the wire, so nothing hands the console an IP address and every network app fails the same way. Ticking "PS2 is plugged directly into this PC" fixes that: PS2 Servers gives the chosen network port a fixed address (one administrator prompt), allows DHCP through the firewall, and runs a small DHCP helper that answers only on that port, so the console configures itself.
 
-The helper is deliberately paranoid, because a DHCP server answering on a real network could disrupt every device on it. It binds to the direct-link port alone, refuses to run if that port reaches a router or holds a DHCP lease, hands out exactly one address to one console, and stops itself if a second device starts asking. Unticking the box stops the helper and returns the port to automatic (DHCP); "Remove PS2 Servers firewall rules" also undoes it. Direct link mode is currently Windows-only.
+You do not configure anything on the PS2. If the console already has a leftover static IP from an earlier setup, the helper notices the device on the wire and quietly moves THIS PC to a compatible address so the two coexist — including onto the console's own subnet if it is on a different one. The console finds the server by broadcasting, so it never needs to know the PC's address, and you never have to touch its network settings.
+
+The helper is deliberately paranoid, because a DHCP server answering on a real network could disrupt every device on it. It binds to the direct-link port alone, refuses to run if that port reaches a router or holds a DHCP lease, hands out exactly one address to one console, and stops itself if several devices start asking. Unticking the box stops the helper and returns the port to automatic (DHCP); "Remove PS2 Servers firewall rules" also undoes it. Direct link mode is currently Windows-only.
 
 No terminal required
 
@@ -383,6 +385,7 @@ class LauncherApp:
         self._direct_proc = None            # the DHCP helper child, when running
         self._direct_expected = False       # we started it and expect it alive
         self._direct_busy = False           # an enable/disable flow is mid-flight
+        self._direct_rehomes = 0            # times we moved to coexist this run
         self._tray = None
         self._tray_option_widgets = []
         self.close_to_tray_var = tk.BooleanVar(
@@ -1011,6 +1014,7 @@ class LauncherApp:
         if output:
             self._append_log("directlink", "[setup] {}\n".format(
                 output.replace("\n", "\n[setup] ")))
+        self._direct_rehomes = 0  # fresh coexist budget for this enable
         cfg = self.saved.get("direct_link") or {}
         if not self._start_direct_responder():
             # The adapter and firewall were already configured. Keep recovery
@@ -1786,21 +1790,97 @@ class LauncherApp:
         if (self._direct_expected and self._direct_proc is not None
                 and not self._direct_proc.is_running()):
             code = self._direct_proc.returncode
+            plan = self._parse_rehome(self._direct_proc.lines)
             self._direct_expected = False
             self._append_log("directlink",
                              "[launcher] DHCP helper exited (code {})\n".format(code))
-            if code == 3:  # a safety refusal; the helper said why in the log
+            if code == 5 and plan:
+                self._direct_link_rehome(plan)
+            elif code == 3:  # a safety refusal; the helper said why in the log
                 self._set_direct_status(
                     "The DHCP helper stopped itself for safety — see the "
                     "TERMINAL tab. Untick and tick the box to retry.")
+                self._finish_direct_exit()
             else:
                 self._set_direct_status(
                     "The DHCP helper stopped (code {}) — see the TERMINAL "
                     "tab. Untick and tick the box to retry.".format(code))
-            cfg = self.saved.get("direct_link") or {}
-            if cfg.get("server_ip"):
-                self._rollback_failed_direct_responder(cfg)
+                self._finish_direct_exit()
         self.root.after(600, self._poll_status)
+
+    def _finish_direct_exit(self):
+        cfg = self.saved.get("direct_link") or {}
+        if cfg.get("server_ip"):
+            self._rollback_failed_direct_responder(cfg)
+
+    @staticmethod
+    def _parse_rehome(lines):
+        """(server_ip, client_ip, prefix) from the helper's last REHOME line."""
+        for line in reversed(list(lines or [])):
+            if "REHOME " not in line:
+                continue
+            fields = {}
+            for token in line.split("REHOME ", 1)[1].split():
+                key, _, val = token.partition("=")
+                fields[key] = val
+            try:
+                return (fields["server_ip"], fields["client_ip"],
+                        int(fields.get("prefix", directlink.PREFIX_LENGTH)))
+            except (KeyError, ValueError):
+                return None
+        return None
+
+    _MAX_REHOMES = 4
+
+    def _direct_link_rehome(self, plan):
+        """The helper found a device already on the wire; move this PC's address
+        to coexist with it and restart the helper. No console reconfiguration."""
+        server_ip, client_ip, prefix = plan
+        cfg = self.saved.get("direct_link") or {}
+        if self._direct_rehomes >= self._MAX_REHOMES:
+            self._append_log("directlink",
+                             "[launcher] stopped moving after {} tries; the "
+                             "wire looks busier than a single console\n".format(
+                                 self._direct_rehomes))
+            self._set_direct_status(
+                "Couldn't find a clear address to share this link — see the "
+                "TERMINAL tab. Untick and tick to retry.")
+            self._finish_direct_exit()
+            return
+        self._direct_rehomes += 1
+        cfg["server_ip"] = server_ip
+        cfg["client_ip"] = client_ip
+        cfg["prefix"] = prefix
+        self.saved["direct_link"] = cfg
+        self._set_direct_checkbox(True, busy=True)
+        self._set_direct_status(
+            "A device is already on this cable — moving this PC to {} so they "
+            "share the link (nothing to change on the PS2)…".format(server_ip))
+
+        def worker():
+            try:
+                out = directlink.apply_adapter_config(
+                    cfg["if_index"], server_ip, client_ip, prefix)
+            except Exception as e:
+                self.root.after(0, lambda err=e: self._direct_link_fail(
+                    "Could not move the direct-link address:\n\n{}".format(err)))
+                return
+            self.root.after(0, lambda: self._direct_link_rehome_done(out))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _direct_link_rehome_done(self, output):
+        if output:
+            self._append_log("directlink", "[setup] {}\n".format(
+                output.replace("\n", "\n[setup] ")))
+        cfg = self.saved.get("direct_link") or {}
+        self._direct_proc = None
+        if not self._start_direct_responder():
+            return
+        self.ip_var.set(cfg["server_ip"])
+        self._save()
+        self._set_direct_checkbox(True)
+        self._set_direct_status(self._direct_ready_status(cfg))
 
     # -- config ----------------------------------------------------------- #
     def _saved_bool(self, key, default=False):

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -16,7 +16,7 @@ from launcher.directlink import (
     DhcpResponder, DirectLinkRefused, MAGIC_COOKIE,
     MSG_ACK, MSG_DISCOVER, MSG_NAK, MSG_OFFER, MSG_REQUEST,
     build_reply, choose_subnet, classify_adapter, networks_overlap,
-    parse_packet, taken_networks, _BOOTP, _ip_to_int,
+    parse_packet, plan_rehome, taken_networks, _BOOTP, _free_host, _ip_to_int,
     _build_discover, _foreign_offer_server_id, _synthetic_probe_mac,
 )
 from launcher.gui import LauncherApp
@@ -245,6 +245,69 @@ class ServeTests(unittest.TestCase):
         self.assert_reset_is_ignored(error)
 
 
+class RehomeTests(unittest.TestCase):
+    # PC default is 192.168.137.1, DHCP client .10.
+    def test_no_neighbors_no_move(self):
+        self.assertIsNone(plan_rehome("192.168.137.1", "192.168.137.10", 24,
+                                      [], our_ip_present=True))
+
+    def test_neighbor_in_subnet_not_contesting_no_move(self):
+        # A console at .10 (not our address) with our address still present:
+        # nothing to fix.
+        self.assertIsNone(plan_rehome("192.168.137.1", "192.168.137.10", 24,
+                                      ["192.168.137.10"], our_ip_present=True))
+
+    def test_conflict_steps_to_next_free_host(self):
+        # GZAst's case: a console statically at 192.168.137.1 (our address);
+        # Windows removed ours. Step the PC to a free host in the same subnet.
+        plan = plan_rehome("192.168.137.1", "192.168.137.10", 24,
+                           ["192.168.137.1"], our_ip_present=False)
+        self.assertIsNotNone(plan)
+        new_server, new_client, prefix = plan
+        self.assertEqual(new_server, "192.168.137.2")   # .1 avoided
+        self.assertEqual(new_client, "192.168.137.10")  # unchanged, free
+        self.assertEqual(prefix, 24)
+
+    def test_conflict_moves_client_if_it_would_collide(self):
+        # Console occupies BOTH .1 and the client host .10 -> both move off.
+        plan = plan_rehome("192.168.137.1", "192.168.137.10", 24,
+                           ["192.168.137.1", "192.168.137.10"],
+                           our_ip_present=False)
+        new_server, new_client, _p = plan
+        self.assertEqual(new_server, "192.168.137.2")
+        self.assertNotIn(new_client, ("192.168.137.1", "192.168.137.10",
+                                      new_server))
+
+    def test_offsubnet_neighbor_adopts_its_subnet(self):
+        # Console left static on an old router subnet (192.168.1.50): adopt
+        # 192.168.1.x so the PC can reach it; it finds us by broadcast.
+        plan = plan_rehome("192.168.137.1", "192.168.137.10", 24,
+                           ["192.168.1.50"], our_ip_present=True)
+        self.assertIsNotNone(plan)
+        new_server, new_client, prefix = plan
+        self.assertTrue(new_server.startswith("192.168.1."))
+        self.assertNotEqual(new_server, "192.168.1.50")   # avoid the console
+        self.assertNotEqual(new_client, "192.168.1.50")
+        self.assertNotEqual(new_client, new_server)
+        self.assertEqual(prefix, 24)
+
+    def test_free_host_skips_avoided(self):
+        net = _ip_to_int("192.168.137.0")
+        first = _free_host(net, 24, {_ip_to_int("192.168.137.1")})
+        self.assertEqual(first, _ip_to_int("192.168.137.2"))
+
+    def test_parse_neighbors_filters(self):
+        js = ('["192.168.137.1", "169.254.9.9", "224.0.0.251", '
+              '"192.168.137.255", "192.168.137.2", "127.0.0.1"]')
+        got = directlink._parse_neighbors(js, our_ips=("192.168.137.2",))
+        self.assertEqual(got, ["192.168.137.1"])  # the rest are filtered
+
+    def test_parse_neighbors_single_and_empty(self):
+        self.assertEqual(directlink._parse_neighbors('"10.0.0.5"'), ["10.0.0.5"])
+        self.assertEqual(directlink._parse_neighbors(""), [])
+        self.assertEqual(directlink._parse_neighbors("not json"), [])
+
+
 class MissingIpDiagnosisTests(unittest.TestCase):
     def test_up_adapter_means_address_conflict(self):
         # Link up but our address gone -> another device is using it.
@@ -294,18 +357,35 @@ class MissingIpDiagnosisTests(unittest.TestCase):
 
     def test_serve_forever_refuses_with_diagnosis_when_ip_vanishes(self):
         # Exercise the real refusal path: the periodic recheck finds the
-        # address gone and serve_forever raises with the conflict diagnosis.
+        # address gone, no coexist plan exists, and serve_forever raises with
+        # the conflict diagnosis.
         r = responder()
         r.sock = ServeTests.FakeSocket(socket.timeout())  # recvfrom never reached
         with mock.patch.object(r, "_server_ip_still_present", return_value=False), \
                 mock.patch.object(directlink.DhcpResponder,
                                   "IP_RECHECK_SECONDS", -1), \
+                mock.patch.object(directlink, "interface_neighbors",
+                                  return_value=[]), \
                 mock.patch.object(directlink, "adapter_state",
                                   return_value={"name": "Ethernet 2",
                                                 "status": "Up", "ipv4": []}):
             with self.assertRaises(DirectLinkRefused) as caught:
                 r.serve_forever()
         self.assertIn("another device", str(caught.exception))
+
+    def test_serve_forever_rehomes_when_a_device_shares_our_address(self):
+        # A console statically on our address removes ours (DAD); a neighbour is
+        # visible at our address -> coexist by re-homing, not refusing.
+        r = responder()
+        r.sock = ServeTests.FakeSocket(socket.timeout())
+        with mock.patch.object(r, "_server_ip_still_present", return_value=False), \
+                mock.patch.object(directlink.DhcpResponder,
+                                  "IP_RECHECK_SECONDS", -1), \
+                mock.patch.object(directlink, "interface_neighbors",
+                                  return_value=["192.168.137.1"]):
+            with self.assertRaises(directlink._Rehome) as caught:
+                r.serve_forever()
+        self.assertEqual(caught.exception.server_ip, "192.168.137.2")
 
 
 def make_offer(xid, server_ip, offered_ip="192.168.137.10", msg_type=MSG_OFFER,
@@ -636,12 +716,32 @@ class LauncherLifecycleTests(unittest.TestCase):
         app._direct_proc = mock.Mock()
         app._direct_proc.is_running.return_value = False
         app._direct_proc.returncode = 3
+        app._direct_proc.lines = []  # no REHOME line -> normal exit path
         app._rollback_failed_direct_responder = mock.Mock()
         app.root = mock.Mock()
         LauncherApp._poll_status(app)
         app._rollback_failed_direct_responder.assert_called_once_with(
             app.saved["direct_link"])
         app.root.after.assert_called_once_with(600, app._poll_status)
+
+    def test_rehome_exit_triggers_coexist_not_rollback(self):
+        app = self.app()
+        app.saved["direct_link"]["enabled"] = True
+        app.procs = {}
+        app._direct_expected = True
+        app._direct_proc = mock.Mock()
+        app._direct_proc.is_running.return_value = False
+        app._direct_proc.returncode = 5
+        app._direct_proc.lines = [
+            "[direct link] moving…",
+            "REHOME server_ip=192.168.1.1 client_ip=192.168.1.10 prefix=24"]
+        app._direct_link_rehome = mock.Mock()
+        app._rollback_failed_direct_responder = mock.Mock()
+        app.root = mock.Mock()
+        LauncherApp._poll_status(app)
+        app._direct_link_rehome.assert_called_once_with(
+            ("192.168.1.1", "192.168.1.10", 24))
+        app._rollback_failed_direct_responder.assert_not_called()
 
     def test_stop_all_also_stops_direct_responder(self):
         app = self.app()

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -6,6 +6,7 @@ Everything here is socket-free: handle_packet() is deliberately pure so the
 protocol and the refusals can be tested without a wire.
 """
 
+import socket
 import struct
 import unittest
 from unittest import mock
@@ -268,6 +269,31 @@ class MissingIpDiagnosisTests(unittest.TestCase):
                                side_effect=RuntimeError("boom")):
             msg = responder()._diagnose_missing_server_ip()
         self.assertIn("no longer configured", msg)  # never raises
+        # A failed lookup must NOT be reported as either specific cause.
+        self.assertNotIn("link went down", msg)
+        self.assertNotIn("another device", msg)
+
+    def test_adapter_absent_is_generic(self):
+        # adapter_state returning None (port gone) is also "unknown cause".
+        with mock.patch.object(directlink, "adapter_state", return_value=None):
+            msg = responder()._diagnose_missing_server_ip()
+        self.assertIn("no longer configured", msg)
+        self.assertNotIn("link went down", msg)
+
+    def test_serve_forever_refuses_with_diagnosis_when_ip_vanishes(self):
+        # Exercise the real refusal path: the periodic recheck finds the
+        # address gone and serve_forever raises with the conflict diagnosis.
+        r = responder()
+        r.sock = ServeTests.FakeSocket(socket.timeout())  # recvfrom never reached
+        with mock.patch.object(r, "_server_ip_still_present", return_value=False), \
+                mock.patch.object(directlink.DhcpResponder,
+                                  "IP_RECHECK_SECONDS", -1), \
+                mock.patch.object(directlink, "adapter_state",
+                                  return_value={"name": "Ethernet 2",
+                                                "status": "Up", "ipv4": []}):
+            with self.assertRaises(DirectLinkRefused) as caught:
+                r.serve_forever()
+        self.assertIn("another device", str(caught.exception))
 
 
 def make_offer(xid, server_ip, offered_ip="192.168.137.10", msg_type=MSG_OFFER,

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -374,17 +374,54 @@ class MissingIpDiagnosisTests(unittest.TestCase):
         self.assertIn("another device", str(caught.exception))
 
     def test_serve_forever_rehomes_when_a_device_shares_our_address(self):
-        # A console statically on our address removes ours (DAD); a neighbour is
-        # visible at our address -> coexist by re-homing, not refusing.
+        # A console statically on our address removes ours (DAD). Exercise the
+        # REAL neighbour contract: Get-NetNeighbor reports .1, and because our
+        # address is gone we must NOT filter it out (our_ips is empty), so the
+        # conflict is seen and we coexist by re-homing instead of refusing.
         r = responder()
+        r.if_index = 12
         r.sock = ServeTests.FakeSocket(socket.timeout())
+        neigh = mock.Mock(returncode=0, stdout='["192.168.137.1"]')
         with mock.patch.object(r, "_server_ip_still_present", return_value=False), \
                 mock.patch.object(directlink.DhcpResponder,
                                   "IP_RECHECK_SECONDS", -1), \
-                mock.patch.object(directlink, "interface_neighbors",
-                                  return_value=["192.168.137.1"]):
+                mock.patch.object(directlink, "is_windows", return_value=True), \
+                mock.patch.object(directlink, "_powershell", return_value=neigh):
             with self.assertRaises(directlink._Rehome) as caught:
                 r.serve_forever()
+        self.assertEqual(caught.exception.server_ip, "192.168.137.2")
+
+    def test_plan_rehome_now_keeps_our_address_while_present(self):
+        # While we still hold our address it is filtered from the neighbour list
+        # (it is ours, not a device), so an idle wire yields no move.
+        r = responder()
+        r.if_index = 3
+        neigh = mock.Mock(returncode=0, stdout='["192.168.137.1"]')  # only us
+        with mock.patch.object(directlink, "is_windows", return_value=True), \
+                mock.patch.object(directlink, "_powershell", return_value=neigh):
+            self.assertIsNone(r._plan_rehome_now(server_ip_present=True))
+
+    def test_open_socket_rehomes_on_startup_conflict(self):
+        # A console already holding our address at launch makes bind() fail with
+        # EADDRNOTAVAIL forever; once a device is seen, coexist via re-home.
+        import errno
+        r = responder()
+        r.if_index = 7
+
+        def fail_bind(*_a, **_k):
+            err = OSError("address not available")
+            err.errno = errno.EADDRNOTAVAIL
+            raise err
+
+        fake = mock.Mock()
+        fake.bind.side_effect = fail_bind
+        with mock.patch.object(directlink.socket, "socket", return_value=fake), \
+                mock.patch.object(directlink.time, "sleep"), \
+                mock.patch.object(
+                    r, "_plan_rehome_now",
+                    return_value=("192.168.137.2", "192.168.137.10", 24)):
+            with self.assertRaises(directlink._Rehome) as caught:
+                r.open_socket()
         self.assertEqual(caught.exception.server_ip, "192.168.137.2")
 
 

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -244,6 +244,32 @@ class ServeTests(unittest.TestCase):
         self.assert_reset_is_ignored(error)
 
 
+class MissingIpDiagnosisTests(unittest.TestCase):
+    def test_up_adapter_means_address_conflict(self):
+        # Link up but our address gone -> another device is using it.
+        with mock.patch.object(directlink, "adapter_state",
+                               return_value={"name": "Ethernet 2", "status": "Up",
+                                             "ipv4": []}):
+            msg = responder()._diagnose_missing_server_ip()
+        self.assertIn("another", msg)
+        self.assertIn("DHCP", msg)
+        self.assertIn(CLIENT, msg)   # suggests the non-colliding address
+
+    def test_down_adapter_means_cable_or_console(self):
+        with mock.patch.object(directlink, "adapter_state",
+                               return_value={"name": "Ethernet 2",
+                                             "status": "Disconnected", "ipv4": []}):
+            msg = responder()._diagnose_missing_server_ip()
+        self.assertIn("link went down", msg)
+        self.assertNotIn("another device", msg)
+
+    def test_adapter_lookup_failure_is_safe(self):
+        with mock.patch.object(directlink, "adapter_state",
+                               side_effect=RuntimeError("boom")):
+            msg = responder()._diagnose_missing_server_ip()
+        self.assertIn("no longer configured", msg)  # never raises
+
+
 def make_offer(xid, server_ip, offered_ip="192.168.137.10", msg_type=MSG_OFFER,
                include_server_id=True, siaddr=None):
     """A server's BOOTREPLY (DHCPOFFER/ACK) as a foreign server would send it."""

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -279,6 +279,18 @@ class MissingIpDiagnosisTests(unittest.TestCase):
             msg = responder()._diagnose_missing_server_ip()
         self.assertIn("no longer configured", msg)
         self.assertNotIn("link went down", msg)
+        self.assertNotIn("another device", msg)
+
+    def test_unknown_status_is_generic(self):
+        # A missing/unfamiliar status must not be guessed as a link-down.
+        for status in ("", None, "weird"):
+            with mock.patch.object(directlink, "adapter_state",
+                                   return_value={"name": "Ethernet 2",
+                                                 "status": status, "ipv4": []}):
+                msg = responder()._diagnose_missing_server_ip()
+            self.assertNotIn("link went down", msg, status)
+            self.assertNotIn("another device", msg, status)
+            self.assertIn("no longer configured", msg, status)
 
     def test_serve_forever_refuses_with_diagnosis_when_ip_vanishes(self):
         # Exercise the real refusal path: the periodic recheck finds the


### PR DESCRIPTION
From GZAst's hardware test of v0.4.6, but taken all the way to the product-correct outcome: **a PS2 with a leftover static IP should just work — the user should never have to configure the console.** Now it does.

## The problem
GZAst's PS2 was statically on `192.168.137.1`, the same address the direct link gives the PC. They collided, Windows' duplicate-address detection kept stripping the PC's address, the helper flapped, and every UDPFS client died. Telling the user "go set the PS2 to DHCP" is exactly the outside-the-GUI configuration PS2 Servers exists to eliminate.

## The fix: coexist, don't fight
While serving, the helper watches the interface's neighbor table (`Get-NetNeighbor`). If a device is already on the wire, it plans a coexistence move:
- **Console statically on our address** → step the PC to a free host in the same subnet (`.1` → `.2`). *(GZAst's exact case.)*
- **Console on a different subnet** (a static left over from an old network) → adopt its `/24` so the PC can unicast back to it.

The console is **never touched** — it finds the server by broadcasting UDPFS discovery, so it doesn't need the PC's address at all.

Mechanism: the helper exits `5` with a `REHOME server_ip=… …` line; the launcher reconfigures the port (one elevated pass, no new prompt) and restarts the helper, which **re-runs every safety gate** (foreign-DHCP probe, gateway/lease refusal) on the new address. Bounded to a few moves so a genuinely busy wire gives up rather than oscillates; the clearer conflict *diagnosis* remains the last-resort fallback when no coexistence is possible.

## Safety
Re-homing only happens on a wire that already passed the "no DHCP server, no gateway" gate — i.e. a real direct link with one static device, which is exactly a misconfigured PS2. A real network is still refused.

## Testing honesty
Pure logic (`plan_rehome`, `_free_host`, neighbor parsing, `REHOME` parsing) is unit-tested; `serve_forever` re-home and the launcher orchestration are tested with mocks (89 tests pass). The Windows setup path is otherwise unchanged. I can't reproduce the duplicate-address condition locally, so the on-hardware behavior rests on these tests plus GZAst's rig — he tests it with the PS2 exactly as it sits, nothing changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improves Direct PS2-to-PC coexistence: if the console has a leftover static IP, the PC can be moved to a compatible address so both devices can work together.
  * When a device is already on the link, the helper can attempt an address re-home instead of immediately refusing.
* **Bug Fixes**
  * Detects when the configured server IP disappears faster (every 5 seconds).
  * Refined “direct link refused” messaging with more actionable, scenario-specific guidance.
* **Tests**
  * Added coverage for the improved refusal diagnostics and re-home behavior.
* **Documentation**
  * Updated the Direct PS2-to-PC link instructions to reflect the safer PC re-home behavior (Windows-only).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->