### PR TITLE
Release v0.4.7

### DIFF
--- a/launcher/release_metadata.py
+++ b/launcher/release_metadata.py
@@ -10,7 +10,7 @@ PRODUCT_NAME = APP_NAME
 # reject anything that is not a dotted number. A pre-release qualifier like
 # "-rc1" lives in VERSION_QUALIFIER instead and is shown to the user via
 # DISPLAY_VERSION, never handed to the build.
-PRODUCT_VERSION = "0.4.6"
+PRODUCT_VERSION = "0.4.7"
 FILE_VERSION = PRODUCT_VERSION
 # "" for a normal release; "-rc1" / "-beta1" while a version is under test.
 VERSION_QUALIFIER = ""


### PR DESCRIPTION
Cut a stable **v0.4.7**.

- `PRODUCT_VERSION` 0.4.6 → **0.4.7**; in-app version reads `v0.4.7`.
- Tagging `v0.4.7` (no `-` qualifier) publishes as a normal release and takes the **Latest** badge (per the release.yml rule).

**Ships since v0.4.6:**
- Direct-link **auto-coexist** (#100) — a PS2 with a leftover static IP just works: the helper watches the wire and re-homes this PC to share the link (steps off a clashing address, or adopts the console's subnet if it's on a different one). Nothing is ever configured on the console; it finds the server by broadcast. Bounded, with every safety gate re-run on each move.

Compliance clean; version wiring verified; tests pass.

After merge: tag `v0.4.7` → CI builds and publishes the stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the stable build version to 0.4.7.
  * Related displayed and file version information now reflects the new release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->