### PR TITLE
Release v0.4.8

### DIFF
--- a/launcher/release_metadata.py
+++ b/launcher/release_metadata.py
@@ -10,7 +10,7 @@ PRODUCT_NAME = APP_NAME
 # reject anything that is not a dotted number. A pre-release qualifier like
 # "-rc1" lives in VERSION_QUALIFIER instead and is shown to the user via
 # DISPLAY_VERSION, never handed to the build.
-PRODUCT_VERSION = "0.4.7"
+PRODUCT_VERSION = "0.4.8"
 FILE_VERSION = PRODUCT_VERSION
 # "" for a normal release; "-rc1" / "-beta1" while a version is under test.
 VERSION_QUALIFIER = ""


### PR DESCRIPTION
Cut a stable **v0.4.8**.

- `PRODUCT_VERSION` 0.4.7 → **0.4.8**; in-app version reads `v0.4.8`.
- Tagging `v0.4.8` (no `-` qualifier) publishes as a normal release and takes the **Latest** badge.

**Ships since v0.4.7:**
- **Cross-platform direct link (#99)** — the "PS2 is plugged directly into this PC" mode now runs on **Linux and macOS**, labelled **experimental** (Windows is tested; the Unix paths are validated by unit tests but untested on real hardware). On Unix the helper runs elevated (pkexec / the macOS admin prompt), adds a temporary address to the port for the session, and removes it again on stop — the port's existing configuration is left untouched. Auto-coexist / re-home stays Windows-only for now and is documented as such.
- **Safety hardening from review** — macOS and Linux adapter enumeration now **fail closed** when route/DHCP state can't be read (never offering a real network as a direct link), `open_socket` honours teardown while waiting for the link, and the Unix exit path confirms its temporary address was actually removed before reporting a clean stop.

Compliance clean; version wiring verified; **128 tests pass** (3 POSIX-only skips on the CI host).

After merge: tag `v0.4.8` → CI builds and publishes the stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)