### PR TITLE
Release on main: prune old dev pre-releases, keeping the newest 5

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -334,3 +334,44 @@ jobs:
             release-assets/SHA256SUMS.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prune old development pre-releases
+        # Every push to main publishes one of these, and nothing used to remove
+        # them: they reached 49 releases / 83 tags before a manual cleanup. Keep
+        # only the newest few so the Releases page stays readable.
+        #
+        # Deliberately paranoid about what it deletes: a release must BOTH be
+        # flagged prerelease AND carry a main-<run>-<sha> tag. A tagged vX.Y.Z
+        # release satisfies neither, so it can never be selected here -- and the
+        # loop refuses anything starting with "v" as a last line of defence.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KEEP: '5'
+        shell: bash
+        run: |
+          # Cleanup must never fail a release that already published fine.
+          set +e
+          # Newest first. Selection is done here; "how many to keep" is applied
+          # with tail below rather than inside jq, so the slice stays trivial to
+          # reason about and needs no jq binary (gh has jq built in).
+          gh release list --limit 200 --json tagName,isPrerelease,createdAt \
+            --jq '[ .[]
+                    | select(.isPrerelease == true)
+                    | select(.tagName | test("^main-[0-9]+-"))
+                  ]
+                  | sort_by(.createdAt) | reverse | .[].tagName' > all_dev.txt || exit 0
+          total=$(grep -c . all_dev.txt)
+          # Skip the newest KEEP lines; everything after them is stale.
+          tail -n +"$((KEEP + 1))" all_dev.txt > stale.txt
+          count=$(grep -c . stale.txt)
+          echo "Dev pre-releases: ${total}. Keeping newest ${KEEP}, pruning ${count}."
+          while read -r tag; do
+            [ -z "$tag" ] && continue
+            case "$tag" in
+              v*) echo "REFUSING to touch version release ${tag}"; continue ;;
+            esac
+            echo "  deleting ${tag}"
+            gh release delete "$tag" --cleanup-tag --yes \
+              || echo "  (could not delete ${tag}; leaving it)"
+          done < stale.txt
+          exit 0


### PR DESCRIPTION
Every push to `main` publishes a `main-<run>-<sha>` pre-release, and nothing ever removed them — they reached **49 releases / 83 tags** before today's manual cleanup. Without this they silt up again from zero.

Adds a prune step to the `Publish release` job: keep the newest **5** dev pre-releases, delete the rest (release + tag via `--cleanup-tag`).

### Why it can't eat a real release

Selection requires **both** conditions:
- `isPrerelease == true`, **and**
- the tag matches `^main-[0-9]+-`

A tagged `vX.Y.Z` release satisfies neither. Note `v0.4.5-rc1` *is* flagged prerelease — it's still excluded, because it fails the tag pattern. The delete loop then refuses anything starting with `v` as a last line of defence.

### Why it can't break a release

It runs only after a successful publish, `set +e`s, exits 0 if listing fails, and logs (rather than fails) any delete it can't perform. A cleanup hiccup must never fail a release that already published — we just lived through a GitHub outage doing exactly that.

### Design note

The "keep newest N" cut is applied with `tail -n +$((KEEP+1))` instead of a jq slice, so the logic is trivially reviewable and needs no `jq` binary (`gh` has jq built in). `KEEP` is one env value at the top of the step.

### Verified

- Workflow YAML parses; `release` job step wiring confirmed.
- Selection logic tested against a fixture (7 dev pre-releases + `v0.4.8`/`v0.4.7`/`v0.4.5-rc1`/`v0.1.4`): selects **exactly** the 2 oldest dev builds, no version tags.
- Edge cases: fewer than KEEP → selects nothing; exactly KEEP → selects nothing.
- `v*` refusal guard exercised.

Effect on the next main push: prunes down to 5 and holds there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release maintenance for development pre-releases.
  - Automatically removes older development releases after new ones are published, keeping the release list focused on the five most recent versions.
  - Stable version releases are protected and unaffected.
  - Cleanup runs safely without preventing a successful release when maintenance encounters an issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->