### PR TITLE
UDPFS: decompress by default, accept udpfsd's config grammar, widen recv buffer

### DIFF
--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -193,8 +193,11 @@ def _udpfs_argv(v):
         args += ["--peer-timeout", str(timeout)]
     if v.get("read_only"):
         args.append("--read-only")
-    if v.get("enable_compression"):
-        args.append("--enable-compression")
+    # The server decompresses by default now, so ticking the box is a no-op and
+    # UNTICKING is the instruction that has to be sent. Passing nothing when it
+    # is unticked would silently leave decompression on.
+    if not v.get("enable_compression"):
+        args.append("--no-compression")
     if v.get("modulo_mode"):
         # Implies --single-port server-side; passing both would be redundant.
         args.append("--modulo-mode")

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -195,8 +195,11 @@ def _udpfs_argv(v):
         args.append("--read-only")
     # The server decompresses by default now, so ticking the box is a no-op and
     # UNTICKING is the instruction that has to be sent. Passing nothing when it
-    # is unticked would silently leave decompression on.
-    if not v.get("enable_compression"):
+    # is unticked would silently leave decompression on. Default the lookup to
+    # True: a config written before this field existed has no key, and treating
+    # that as "unticked" would disable decompression for exactly the users who
+    # never asked to.
+    if not v.get("enable_compression", True):
         args.append("--no-compression")
     if v.get("modulo_mode"):
         # Implies --single-port server-side; passing both would be redundant.

--- a/tests/test_udpfs_config.py
+++ b/tests/test_udpfs_config.py
@@ -95,6 +95,34 @@ class BindTests(unittest.TestCase):
                 udpfs.split_bind(bad)
 
 
+class DataPortPrecedenceTests(unittest.TestCase):
+    """--data-port beats a port embedded in --bind; the parse must tell an
+    explicit 0 ('pick ephemeral') apart from the flag being absent."""
+
+    @staticmethod
+    def _resolve(data_port_arg, bind_arg):
+        # Mirror main()'s resolution without standing a server up. args.data_port
+        # is None when --data-port was not passed; 0 is a real, explicit value.
+        data_port = data_port_arg
+        _bind_ip, bind_port = udpfs.split_bind(bind_arg)
+        if data_port is None:
+            data_port = bind_port if bind_port is not None else 0
+        return data_port
+
+    def test_explicit_data_port_beats_bind_port(self):
+        self.assertEqual(self._resolve(50000, ':41233'), 50000)
+
+    def test_explicit_zero_data_port_wins_over_bind_port(self):
+        # The bug: 0 was treated as "unset" and --bind's 41233 leaked through.
+        self.assertEqual(self._resolve(0, ':41233'), 0)
+
+    def test_bind_port_used_when_data_port_absent(self):
+        self.assertEqual(self._resolve(None, ':41233'), 41233)
+
+    def test_auto_when_neither_given(self):
+        self.assertEqual(self._resolve(None, '192.168.1.5'), 0)
+
+
 class ExtensionAliasTests(unittest.TestCase):
     """'.ciso'/'.ziso' occur in the wild for the same containers."""
 
@@ -122,22 +150,54 @@ class ExtensionAliasTests(unittest.TestCase):
         self.assertIn('.cso', exts)  # zlib is stdlib: always supported
 
 
+class _FakeSock:
+    """Records setsockopt calls; a real socket always reports a positive buffer,
+    which would let a no-op implementation pass."""
+
+    def __init__(self, current, fail=False):
+        self.current = current
+        self.fail = fail
+        self.set_calls = []
+
+    def getsockopt(self, level, opt):
+        if self.fail:
+            raise OSError('nope')
+        return self.current
+
+    def setsockopt(self, level, opt, value):
+        if self.fail:
+            raise OSError('nope')
+        self.set_calls.append(value)
+        self.current = value
+
+
 class RecvBufferTests(unittest.TestCase):
-    def test_widen_is_best_effort_and_never_shrinks(self):
+    def test_widen_sets_the_option_when_current_is_smaller(self):
+        s = _FakeSock(current=8192)
+        udpfs._widen_recv_buffer(s, udpfs.DATA_RECV_BUFFER_BYTES)
+        self.assertEqual(s.set_calls, [udpfs.DATA_RECV_BUFFER_BYTES])
+
+    def test_widen_does_nothing_when_current_is_already_adequate(self):
+        # Never shrink a buffer the OS already gave us (some platforms hand out
+        # a large one, and asking for less would be a downgrade).
+        s = _FakeSock(current=4 << 20)
+        udpfs._widen_recv_buffer(s, udpfs.DATA_RECV_BUFFER_BYTES)
+        self.assertEqual(s.set_calls, [])
+
+    def test_widen_is_best_effort_when_the_option_is_refused(self):
+        s = _FakeSock(current=0, fail=True)
+        udpfs._widen_recv_buffer(s, 1 << 20)  # must not raise
+        self.assertEqual(s.set_calls, [])
+
+    def test_widen_on_a_real_socket(self):
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         try:
             udpfs._widen_recv_buffer(s, udpfs.DATA_RECV_BUFFER_BYTES)
-            got = s.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
-            self.assertGreater(got, 0)
-            # Asking for less must not shrink what we already have.
-            before = got
-            udpfs._widen_recv_buffer(s, 1024)
-            self.assertGreaterEqual(
-                s.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF), before)
+            self.assertGreater(s.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF), 0)
         finally:
             s.close()
 
-    def test_widen_tolerates_a_broken_socket(self):
+    def test_widen_tolerates_a_closed_socket(self):
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         s.close()
         udpfs._widen_recv_buffer(s, 1 << 20)  # must not raise
@@ -153,6 +213,13 @@ class LauncherCompressionArgTests(unittest.TestCase):
 
     def test_ticked_sends_nothing_because_it_is_the_default(self):
         args = servers._udpfs_argv({'root_dir': '/games', 'enable_compression': True})
+        self.assertNotIn('--no-compression', args)
+
+    def test_omitted_key_keeps_decompression_on(self):
+        # A config written before this field existed has no key at all. Treating
+        # that as "unticked" would disable decompression for people who never
+        # asked to -- the exact opposite of the default this PR establishes.
+        args = servers._udpfs_argv({'root_dir': '/games'})
         self.assertNotIn('--no-compression', args)
 
     def test_only_long_flags_are_emitted(self):

--- a/tests/test_udpfs_config.py
+++ b/tests/test_udpfs_config.py
@@ -1,0 +1,171 @@
+"""Unit tests for the UDPFS configuration surface.
+
+These cover the udpfsd-compatibility edges: a command line or compose file
+written against udpfsd's README must land here without crashing. Each of the
+duration/bind cases below was an unhandled traceback before.
+
+Run:  python -m unittest tests.test_udpfs_config -v
+"""
+
+import os
+import socket
+import sys
+import unittest
+
+# udpfs_server/ is not a package; the server module and its compressed_iso
+# package both resolve once that directory is on the path.
+_UDPFS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'udpfs_server')
+if _UDPFS_DIR not in sys.path:
+    sys.path.insert(0, _UDPFS_DIR)
+
+import udpfs_server as udpfs  # noqa: E402
+
+from launcher import servers  # noqa: E402
+
+
+class DurationTests(unittest.TestCase):
+    """udpfsd takes Go duration strings for --peer-timeout/--metrics-period."""
+
+    def test_plain_number_is_seconds(self):
+        # The historical form: must keep working exactly as it did.
+        self.assertEqual(udpfs.parse_duration('90'), 90.0)
+        self.assertEqual(udpfs.parse_duration('0'), 0.0)
+        self.assertEqual(udpfs.parse_duration('1.5'), 1.5)
+        self.assertEqual(udpfs.parse_duration(90), 90.0)
+
+    def test_go_duration_strings(self):
+        self.assertEqual(udpfs.parse_duration('90s'), 90.0)
+        self.assertEqual(udpfs.parse_duration('30m'), 1800.0)
+        self.assertEqual(udpfs.parse_duration('1h'), 3600.0)
+        self.assertEqual(udpfs.parse_duration('1h30m'), 5400.0)
+        self.assertEqual(udpfs.parse_duration('500ms'), 0.5)
+        self.assertEqual(udpfs.parse_duration(' 2M '), 120.0)  # case/space tolerant
+
+    def test_ms_is_not_read_as_minutes(self):
+        # Alternation order matters: 'ms' must win over 'm'.
+        self.assertEqual(udpfs.parse_duration('100ms'), 0.1)
+        self.assertNotEqual(udpfs.parse_duration('100ms'), 6000.0)
+
+    def test_garbage_is_none_not_an_exception(self):
+        for bad in ('abc', '1x', '1h junk', 'h', '', None, '  '):
+            self.assertIsNone(udpfs.parse_duration(bad), repr(bad))
+
+    def test_env_duration_falls_back_and_never_raises(self):
+        # udpfsd ignores an unparseable duration and uses its default; dying
+        # with a traceback would be strictly worse for the container users who
+        # are the only people setting these.
+        os.environ['_T_DUR'] = 'bogus'
+        try:
+            self.assertEqual(udpfs._env_duration('_T_DUR', 3600.0), 3600.0)
+            os.environ['_T_DUR'] = '1h'
+            self.assertEqual(udpfs._env_duration('_T_DUR', 3600.0), 3600.0)
+            os.environ['_T_DUR'] = '45m'
+            self.assertEqual(udpfs._env_duration('_T_DUR', 3600.0), 2700.0)
+            os.environ['_T_DUR'] = ''
+            self.assertEqual(udpfs._env_duration('_T_DUR', 12.0), 12.0)
+        finally:
+            os.environ.pop('_T_DUR', None)
+
+    def test_unset_env_returns_default(self):
+        os.environ.pop('_T_MISSING', None)
+        self.assertEqual(udpfs._env_duration('_T_MISSING', 7.0), 7.0)
+
+
+class BindTests(unittest.TestCase):
+    """udpfsd's -bind is documented as 'Address and port for data connection'."""
+
+    def test_bare_ip_keeps_its_old_meaning(self):
+        self.assertEqual(udpfs.split_bind('192.168.1.5'), ('192.168.1.5', None))
+        self.assertEqual(udpfs.split_bind(''), ('', None))
+        self.assertEqual(udpfs.split_bind(None), ('', None))
+
+    def test_host_port_forms(self):
+        self.assertEqual(udpfs.split_bind('0.0.0.0:62966'), ('0.0.0.0', 62966))
+        self.assertEqual(udpfs.split_bind(':41233'), ('', 41233))
+        self.assertEqual(udpfs.split_bind('192.168.1.5:0'), ('192.168.1.5', 0))
+
+    def test_hex_port_accepted(self):
+        self.assertEqual(udpfs.split_bind(':0xF5F7'), ('', 0xF5F7))
+
+    def test_malformed_port_raises_valueerror_not_gaierror(self):
+        # These used to reach getaddrinfo intact and die with socket.gaierror.
+        for bad in ('0.0.0.0:abc', '0.0.0.0:99999', ':-1'):
+            with self.assertRaises(ValueError):
+                udpfs.split_bind(bad)
+
+
+class ExtensionAliasTests(unittest.TestCase):
+    """'.ciso'/'.ziso' occur in the wild for the same containers."""
+
+    def test_aliases_map_to_the_same_codec(self):
+        self.assertEqual(udpfs._format_for_extension('game.cso'), 'cso')
+        self.assertEqual(udpfs._format_for_extension('game.ciso'), 'cso')
+        self.assertEqual(udpfs._format_for_extension('game.zso'), 'zso')
+        self.assertEqual(udpfs._format_for_extension('game.ziso'), 'zso')
+        self.assertEqual(udpfs._format_for_extension('game.chd'), 'chd')
+
+    def test_extension_match_is_case_insensitive(self):
+        self.assertEqual(udpfs._format_for_extension('GAME.CISO'), 'cso')
+        self.assertEqual(udpfs._format_for_extension('Game.Chd'), 'chd')
+
+    def test_plain_iso_is_not_compressed(self):
+        self.assertIsNone(udpfs._format_for_extension('game.iso'))
+        self.assertIsNone(udpfs._format_for_extension('game'))
+
+    def test_alias_listed_whenever_its_base_format_is(self):
+        # A format is only advertised when its library is present; the alias
+        # must never be advertised separately from the extension it aliases.
+        exts = udpfs.COMPRESSED_EXTENSIONS
+        self.assertEqual('.cso' in exts, '.ciso' in exts)
+        self.assertEqual('.zso' in exts, '.ziso' in exts)
+        self.assertIn('.cso', exts)  # zlib is stdlib: always supported
+
+
+class RecvBufferTests(unittest.TestCase):
+    def test_widen_is_best_effort_and_never_shrinks(self):
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            udpfs._widen_recv_buffer(s, udpfs.DATA_RECV_BUFFER_BYTES)
+            got = s.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
+            self.assertGreater(got, 0)
+            # Asking for less must not shrink what we already have.
+            before = got
+            udpfs._widen_recv_buffer(s, 1024)
+            self.assertGreaterEqual(
+                s.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF), before)
+        finally:
+            s.close()
+
+    def test_widen_tolerates_a_broken_socket(self):
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.close()
+        udpfs._widen_recv_buffer(s, 1 << 20)  # must not raise
+
+
+class LauncherCompressionArgTests(unittest.TestCase):
+    """The server decompresses by default, so UNTICKING is what must be sent."""
+
+    def test_unticked_sends_no_compression(self):
+        args = servers._udpfs_argv({'root_dir': '/games', 'enable_compression': False})
+        self.assertIn('--no-compression', args)
+        self.assertNotIn('--enable-compression', args)
+
+    def test_ticked_sends_nothing_because_it_is_the_default(self):
+        args = servers._udpfs_argv({'root_dir': '/games', 'enable_compression': True})
+        self.assertNotIn('--no-compression', args)
+
+    def test_only_long_flags_are_emitted(self):
+        # The packaged app re-executes itself; Nuitka's self-exec guard aborts
+        # on a bare '-c'/'-m' followed by another argument.
+        args = servers._udpfs_argv({
+            'root_dir': '/games', 'enable_compression': False,
+            'read_only': True, 'verbose': True, 'modulo_mode': True,
+        })
+        for a in args:
+            if a.startswith('-') and not a.startswith('--'):
+                self.fail(f"short flag {a!r} would trip the Nuitka self-exec guard")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/udpfs_server/compression_selftest.py
+++ b/udpfs_server/compression_selftest.py
@@ -334,18 +334,45 @@ def test_extension_gating_builder():
     print("[builder] library-availability gating")
     saved = (srv.LZ4_AVAILABLE, srv.LIBCHDR_AVAILABLE)
     try:
+        # '.ziso'/'.ciso' are alternate spellings of the SAME containers, so an
+        # alias must appear exactly when its base format does -- gating them
+        # apart would advertise a file the matching codec cannot open.
         srv.LZ4_AVAILABLE, srv.LIBCHDR_AVAILABLE = True, True
-        check(srv._supported_compressed_extensions() == ('.zso', '.cso', '.chd'),
-              "all libraries available -> all three formats")
+        check(srv._supported_compressed_extensions() ==
+              ('.zso', '.ziso', '.cso', '.ciso', '.chd'),
+              "all libraries available -> all three formats, aliases included")
         srv.LZ4_AVAILABLE, srv.LIBCHDR_AVAILABLE = False, True
-        check(srv._supported_compressed_extensions() == ('.cso', '.chd'),
-              "no lz4 -> ZSO dropped")
+        check(srv._supported_compressed_extensions() == ('.cso', '.ciso', '.chd'),
+              "no lz4 -> ZSO dropped, and .ziso with it")
         srv.LZ4_AVAILABLE, srv.LIBCHDR_AVAILABLE = True, False
-        check(srv._supported_compressed_extensions() == ('.zso', '.cso'),
+        check(srv._supported_compressed_extensions() ==
+              ('.zso', '.ziso', '.cso', '.ciso'),
               "no libchdr -> CHD dropped")
         srv.LZ4_AVAILABLE, srv.LIBCHDR_AVAILABLE = False, False
-        check(srv._supported_compressed_extensions() == ('.cso',),
-              "neither library -> only CSO (zlib is stdlib)")
+        check(srv._supported_compressed_extensions() == ('.cso', '.ciso'),
+              "neither library -> only CSO and its alias (zlib is stdlib)")
+    finally:
+        srv.LZ4_AVAILABLE, srv.LIBCHDR_AVAILABLE = saved
+
+
+def test_extension_alias_mapping():
+    """Every advertised extension must map to a codec, and aliases must map to
+    the same one as the spelling they alias -- the listing transform and the
+    .iso sibling probe both key off this table."""
+    print("[builder] extension -> codec mapping")
+    check(srv._format_for_extension('a.cso') == 'cso', ".cso -> cso")
+    check(srv._format_for_extension('a.ciso') == 'cso', ".ciso -> cso (alias)")
+    check(srv._format_for_extension('a.zso') == 'zso', ".zso -> zso")
+    check(srv._format_for_extension('a.ziso') == 'zso', ".ziso -> zso (alias)")
+    check(srv._format_for_extension('a.chd') == 'chd', ".chd -> chd")
+    check(srv._format_for_extension('A.CISO') == 'cso', "matching is case-folded")
+    check(srv._format_for_extension('a.iso') is None, "plain .iso is not compressed")
+    saved = (srv.LZ4_AVAILABLE, srv.LIBCHDR_AVAILABLE)
+    try:
+        srv.LZ4_AVAILABLE, srv.LIBCHDR_AVAILABLE = True, True
+        for ext in srv._supported_compressed_extensions():
+            check(srv._format_for_extension('x' + ext) is not None,
+                  f"advertised {ext} has a codec")
     finally:
         srv.LZ4_AVAILABLE, srv.LIBCHDR_AVAILABLE = saved
 
@@ -382,6 +409,7 @@ def main():
         test_prefers_parseable_sibling(root)
         test_exact_stem_no_case_collision(root)
         test_extension_gating_builder()
+        test_extension_alias_mapping()
     finally:
         shutil.rmtree(root, ignore_errors=True)
 

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -33,6 +33,7 @@ import gzip
 import math
 import os
 import queue
+import re
 import select
 import socket
 import struct
@@ -56,6 +57,25 @@ except ImportError:
     LZ4_AVAILABLE = False
 
 
+# Extension -> format id. The ONLY place an extension is mapped to a codec.
+# '.ciso' and '.zso' both occur in the wild for the same containers -- several
+# conversion tools write CSO as '.ciso' and ZSO as '.ziso', and udpfsd accepts
+# both spellings. An extension we do not recognise is not a cosmetic problem:
+# the file is never renamed to .iso, so the console simply cannot see it.
+_EXTENSION_FORMATS = {
+    '.zso': 'zso',
+    '.ziso': 'zso',
+    '.cso': 'cso',
+    '.ciso': 'cso',
+    '.chd': 'chd',
+}
+
+
+def _format_for_extension(file_path: str) -> Optional[str]:
+    """Codec id ('zso'/'cso'/'chd') for a path's extension, or None."""
+    return _EXTENSION_FORMATS.get(os.path.splitext(file_path)[1].lower())
+
+
 def _supported_compressed_extensions() -> Tuple[str, ...]:
     """Compressed-image extensions this server can actually decompress.
 
@@ -67,8 +87,8 @@ def _supported_compressed_extensions() -> Tuple[str, ...]:
     """
     exts = []
     if LZ4_AVAILABLE:
-        exts.append('.zso')
-    exts.append('.cso')  # zlib is stdlib; CSO is always supported
+        exts.extend(('.zso', '.ziso'))
+    exts.extend(('.cso', '.ciso'))  # zlib is stdlib; CSO is always supported
     if LIBCHDR_AVAILABLE:
         exts.append('.chd')
     return tuple(exts)
@@ -79,6 +99,34 @@ def _supported_compressed_extensions() -> Tuple[str, ...]:
 # '.zso'/'.cso'/'.chd' lists at call sites -- that drift is exactly how CHD
 # files silently vanished from directory listings once before.
 COMPRESSED_EXTENSIONS = _supported_compressed_extensions()
+
+
+# Kernel receive-buffer sizes. The PS2 streams bursts of small datagrams, so
+# any stall in the receive loop lets the socket buffer overflow -- and a dropped
+# datagram costs a NACK plus a retransmit round-trip, which is far more
+# expensive than the memory. udpfsd asks for the same 1 MB on its data socket
+# (internal/udpfsd/data.go) and a small one on discovery, which only ever sees
+# occasional broadcasts. Both are requests, not guarantees: the OS may cap them.
+DATA_RECV_BUFFER_BYTES = 1 << 20
+DISCOVERY_RECV_BUFFER_BYTES = 1 << 16
+
+
+def _widen_recv_buffer(sock, size: int) -> None:
+    """Ask for a larger SO_RCVBUF, never shrinking one the OS already gave us.
+
+    Best-effort by design: a platform that refuses the option, clamps it, or
+    reports nonsense must not stop the server from serving.
+    """
+    try:
+        current = sock.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
+    except OSError:
+        current = 0
+    if current >= size:
+        return
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, size)
+    except OSError:
+        pass  # keep the default; smaller buffer is slower, not broken
 
 
 # UDPRDMA Protocol Constants
@@ -173,17 +221,19 @@ def open_compressed(file_path: str, cache_size: int = None) -> Optional[Compress
     Returns:
         CompressedFileWrapper subclass instance, or None if unsupported format
     """
-    ext = os.path.splitext(file_path)[1].lower()
-    
-    if ext == '.zso':
+    fmt = _format_for_extension(file_path)
+
+    if fmt == 'zso':
         if not LZ4_AVAILABLE:
             return None
         return ZsoFileWrapper(file_path, cache_size)
-    elif ext == '.cso':
+    elif fmt == 'cso':
         return CsoFileWrapper(file_path, cache_size)
-    elif ext == '.chd':
+    elif fmt == 'chd':
+        if not LIBCHDR_AVAILABLE:
+            return None
         return ChdFileWrapper(file_path, cache_size)
-    
+
     return None
 
 
@@ -192,11 +242,11 @@ def get_compressed_info(file_path: str) -> Optional[Tuple[int, str]]:
     Get info about a compressed file without fully opening it.
     Returns (uncompressed_size, format_name) or None if not a supported compressed file.
     """
-    ext = os.path.splitext(file_path)[1].lower()
-    
+    fmt = _format_for_extension(file_path)
+
     try:
         with open(file_path, 'rb') as f:
-            if ext == '.chd':
+            if fmt == 'chd':
                 # CHD has different header structure
                 header = f.read(64)
                 if len(header) < 64:
@@ -243,14 +293,14 @@ def get_compressed_info(file_path: str) -> Optional[Tuple[int, str]]:
             magic = header[0:4]
             magic_int = struct.unpack('<I', magic)[0]
             
-            if ext == '.zso':
+            if fmt == 'zso':
                 if magic == ZSO_MAGIC:
                     uncompressed_size = struct.unpack('<Q', header[8:16])[0]
                     return (uncompressed_size, 'ZSO')
                 elif magic == b'ZISO':
                     uncompressed_size = struct.unpack('<Q', header[8:16])[0]
                     return (uncompressed_size, 'ZISO')
-            elif ext == '.cso':
+            elif fmt == 'cso':
                 if magic_int == CSO_MAGIC:
                     uncompressed_size = struct.unpack('<Q', header[8:16])[0]
                     return (uncompressed_size, 'CSO')
@@ -432,10 +482,14 @@ class UdpfsServer:
                   f"discovery and data on one port.")
             sys.exit(1)
 
-        # Discovery socket, broadcast UDP
+        # Discovery socket, broadcast UDP. In single-port mode this socket also
+        # carries the data stream, so it needs the data-sized receive buffer.
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        _widen_recv_buffer(
+            self.sock,
+            DATA_RECV_BUFFER_BYTES if single_port else DISCOVERY_RECV_BUFFER_BYTES)
         self.sock.bind(('', port))
         self.sock.setblocking(False)
 
@@ -456,6 +510,7 @@ class UdpfsServer:
             # port that changes every launch.
             self.dsock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             self.dsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            _widen_recv_buffer(self.dsock, DATA_RECV_BUFFER_BYTES)
             self.dsock.bind((bind_ip, data_port))
             self.dsock.setblocking(False)
 
@@ -2275,6 +2330,95 @@ def _env_float(name, default):
     return float(v) if v else default
 
 
+_DURATION_UNITS = {
+    'ns': 1e-9, 'us': 1e-6, 'ms': 1e-3, 's': 1.0, 'm': 60.0, 'h': 3600.0,
+}
+# Longest-first so 'ms' is not read as 'm' + junk.
+_DURATION_RE = re.compile(r'(\d+(?:\.\d+)?)(ns|us|ms|h|m|s)')
+
+
+def parse_duration(text) -> Optional[float]:
+    """Seconds from '90', '90s', '1h', '1h30m'. None when unparseable.
+
+    udpfsd takes Go time.Duration strings for --peer-timeout/--metrics-period
+    and its README documents them that way, so a command line or compose file
+    written against udpfsd lands here verbatim. A bare number stays seconds,
+    which is what this server always accepted.
+    """
+    if text is None:
+        return None
+    if isinstance(text, (int, float)):
+        return float(text)
+    s = str(text).strip().lower()
+    if not s:
+        return None
+    try:
+        return float(s)  # plain seconds -- the historical form
+    except ValueError:
+        pass
+    parts = _DURATION_RE.findall(s)
+    # Every character must belong to a component: '1h' parses, '1h junk' does not.
+    if not parts or ''.join(n + u for n, u in parts) != s.replace(' ', ''):
+        return None
+    return sum(float(n) * _DURATION_UNITS[u] for n, u in parts)
+
+
+def _env_duration(name, default, label=None):
+    """Duration env var. NEVER raises: an unusable value warns and falls back.
+
+    udpfsd ignores a duration it cannot parse and carries on with its default;
+    dying with a traceback because someone set PEER_TIMEOUT=1h (a value udpfsd
+    documents) would be a strictly worse answer for the container users who are
+    the only people setting these at all.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == '':
+        return default
+    secs = parse_duration(raw)
+    if secs is None:
+        print(f"Warning: ignoring {name}={raw!r} (expected seconds, or a "
+              f"duration like 1h / 30m / 90s); using {default}", file=sys.stderr)
+        return default
+    return secs
+
+
+def _duration_arg(label):
+    """argparse type for a duration option: a clean error, never a traceback."""
+    def parse(value):
+        secs = parse_duration(value)
+        if secs is None:
+            raise argparse.ArgumentTypeError(
+                f"invalid {label} {value!r}: expected seconds, or a duration "
+                f"like 1h / 30m / 90s")
+        return secs
+    return parse
+
+
+def split_bind(value) -> Tuple[str, Optional[int]]:
+    """(ip, port|None) from 'IP', 'IP:PORT' or ':PORT'.
+
+    udpfsd's -bind is documented as "Address and port for data connection"
+    (e.g. 0.0.0.0:62966 or :41233). A bare IP keeps its long-standing meaning
+    here; the host:port form used to reach getaddrinfo intact and die with an
+    unhandled socket.gaierror. Raises ValueError on a malformed port so the
+    caller can turn it into a usage error.
+    """
+    text = (value or '').strip()
+    if ':' not in text:
+        return text, None
+    host, _, port_s = text.rpartition(':')
+    port_s = port_s.strip()
+    if not port_s:
+        return host, None
+    try:
+        port = int(port_s, 0)
+    except ValueError:
+        raise ValueError(f"invalid port in --bind value {value!r}")
+    if not 0 <= port <= 65535:
+        raise ValueError(f"port out of range in --bind value {value!r}")
+    return host, port
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='UDPFS Server - Unified file and block device server over UDPRDMA',
@@ -2297,8 +2441,11 @@ def main():
         help=f'UDP port to listen on (default: 0x{UDPFS_PORT:04X}; env: PORT)'
     )
     parser.add_argument(
-        '--bind', '-i', default=os.environ.get('BIND', ''), metavar='IP',
-        help='IP address to bind/listen on (default: all interfaces; env: BIND)'
+        '--bind', '-i', default=os.environ.get('BIND', ''), metavar='IP[:PORT]',
+        help='IP address to bind/listen on, optionally with the data port '
+             '(e.g. 192.168.1.5, 0.0.0.0:62966, :41233). A port here is the '
+             'same knob as --data-port, which wins if both are given. '
+             '(default: all interfaces; env: BIND)'
     )
     parser.add_argument(
         '--sector-size', '-s', type=int, default=_env_int('SECTOR_SIZE', 512),
@@ -2312,11 +2459,23 @@ def main():
         '--verbose', '-v', action='store_true', default=_env_bool('VERBOSE'),
         help='Verbose output (env: VERBOSE)'
     )
-    parser.add_argument(
-        '--enable-compression', '-c', action='store_true',
-        default=_env_bool('ENABLE_COMPRESSION'),
-        help='Enable transparent decompression of .zso (LZ4), .cso (zlib), and .chd (CHD v5) '
-             'files. Compressed files appear as .iso in directory listings. (env: ENABLE_COMPRESSION)'
+    # Compression is ON by default (as udpfsd is): a folder of .chd/.cso/.zso
+    # otherwise looks EMPTY to the console until the user knows to pass a flag,
+    # which is a silent-wrong-answer, not a preference. Both spellings are kept
+    # so old command lines and configs still mean what they used to.
+    compression = parser.add_mutually_exclusive_group()
+    compression.add_argument(
+        '--enable-compression', '-c', action='store_true', default=False,
+        help='Force transparent decompression on. It is already on by default; '
+             'kept for compatibility with existing command lines. '
+             '(env: ENABLE_COMPRESSION)'
+    )
+    compression.add_argument(
+        '--no-compression', action='store_true', default=False,
+        help='Disable transparent decompression of .zso/.ziso (LZ4), '
+             '.cso/.ciso (zlib) and .chd (CHD v5). With it on (the default) '
+             'those files appear as .iso in directory listings and are '
+             'decompressed on the fly. (env: NO_COMPRESSION)'
     )
     parser.add_argument(
         '--compression-cache-size', type=int, default=_env_int('COMPRESSION_CACHE_SIZE', 32),
@@ -2347,7 +2506,8 @@ def main():
              'connect while this is on (env: MODULO_MODE)'
     )
     parser.add_argument(
-        '--peer-timeout', type=float, default=_env_float('PEER_TIMEOUT', SESSION_TIMEOUT),
+        '--peer-timeout', type=_duration_arg('--peer-timeout'),
+        default=_env_duration('PEER_TIMEOUT', SESSION_TIMEOUT),
         help=f'Seconds of client inactivity before its session is reaped, closing '
              f'the files it had open. Clamped to '
              f'{int(SESSION_TIMEOUT_MIN)}-{int(SESSION_TIMEOUT_MAX)}; 0 does not '
@@ -2360,11 +2520,35 @@ def main():
         help='Periodically log transfer/op statistics (env: METRICS)'
     )
     parser.add_argument(
-        '--metrics-period', type=float, default=_env_float('METRICS_PERIOD', 60.0),
-        help='Seconds between metrics log lines (default: 60; env: METRICS_PERIOD)'
+        '--metrics-period', type=_duration_arg('--metrics-period'),
+        default=_env_duration('METRICS_PERIOD', 60.0),
+        help='Seconds between metrics log lines. Accepts a duration '
+             '(e.g. 90s, 5m). (default: 60; env: METRICS_PERIOD)'
     )
 
     args = parser.parse_args()
+
+    # Compression: default on; CLI beats env; an explicit disable beats an enable.
+    enable_compression = True
+    if os.environ.get('ENABLE_COMPRESSION') is not None:
+        enable_compression = _env_bool('ENABLE_COMPRESSION', True)
+    if _env_bool('NO_COMPRESSION'):
+        enable_compression = False
+    if args.enable_compression:
+        enable_compression = True
+    if args.no_compression:
+        enable_compression = False
+    args.enable_compression = enable_compression
+
+    # --bind may carry the data port (udpfsd grammar). An explicit --data-port
+    # wins; otherwise a port here fills it in.
+    try:
+        bind_ip, bind_port = split_bind(args.bind)
+    except ValueError as e:
+        parser.error(str(e))
+    args.bind = bind_ip
+    if not args.data_port and bind_port:
+        args.data_port = bind_port
 
     if not args.block_device and not args.root_dir:
         parser.error("At least one of --block-device or --root-dir is required")

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -85,13 +85,16 @@ def _supported_compressed_extensions() -> Tuple[str, ...]:
     only serve as raw container bytes. The tuple order is also the probe order
     when several compressed siblings of the same .iso exist.
     """
-    exts = []
-    if LZ4_AVAILABLE:
-        exts.extend(('.zso', '.ziso'))
-    exts.extend(('.cso', '.ciso'))  # zlib is stdlib; CSO is always supported
-    if LIBCHDR_AVAILABLE:
-        exts.append('.chd')
-    return tuple(exts)
+    # Derived from _EXTENSION_FORMATS, never a second hand-written list: an
+    # alias added to the table but forgotten here would map to a codec while
+    # staying unadvertised, so the console would never see the file. Dict order
+    # is insertion order, which keeps the documented probe order.
+    available = {
+        'zso': LZ4_AVAILABLE,
+        'cso': True,  # zlib is stdlib; CSO is always supported
+        'chd': LIBCHDR_AVAILABLE,
+    }
+    return tuple(ext for ext, fmt in _EXTENSION_FORMATS.items() if available[fmt])
 
 
 # The single source of truth for every extension predicate below (listing
@@ -2482,7 +2485,7 @@ def main():
         help='Number of decompressed blocks to cache per file (default: 32; env: COMPRESSION_CACHE_SIZE)'
     )
     parser.add_argument(
-        '--data-port', type=lambda x: int(x, 0), default=_env_int('DATA_PORT', 0),
+        '--data-port', type=lambda x: int(x, 0), default=None,
         help='Pin the UDP data port instead of using an ephemeral one (default: 0 = '
              'auto). Use when the data endpoint must be predictable for a manual '
              'firewall rule, port forwarding, or NAT. Ignored with --single-port '
@@ -2540,15 +2543,20 @@ def main():
         enable_compression = False
     args.enable_compression = enable_compression
 
-    # --bind may carry the data port (udpfsd grammar). An explicit --data-port
-    # wins; otherwise a port here fills it in.
+    # --bind may carry the data port (udpfsd grammar). Precedence: an explicit
+    # --data-port wins, then a port in --bind, then DATA_PORT, then auto (0).
+    # args.data_port is None when the flag was absent -- 0 is a REAL value
+    # ("pick an ephemeral port"), so it must not be mistaken for "unset".
     try:
         bind_ip, bind_port = split_bind(args.bind)
     except ValueError as e:
         parser.error(str(e))
     args.bind = bind_ip
-    if not args.data_port and bind_port:
-        args.data_port = bind_port
+    if args.data_port is None:
+        if bind_port is not None:
+            args.data_port = bind_port
+        else:
+            args.data_port = _env_int('DATA_PORT', 0)
 
     if not args.block_device and not args.root_dir:
         parser.error("At least one of --block-device or --root-dir is required")


### PR DESCRIPTION
I audited [pcm720/udpfsd](https://github.com/pcm720/udpfsd) against our UDPFS server feature-by-feature (parallel readers per dimension, then an adversarial pass whose job was to *break* every absence claim). It found **real gaps, not style differences**. This closes the ones users actually hit.

### Compression is on by default now

udpfsd decompresses out of the box; we required `-c`. Same folder of `.chd`/`.cso`/`.zso`, same command line: udpfsd lists the games, we listed **nothing**. That's a silent wrong answer, not a preference.

- `--no-compression` / `NO_COMPRESSION` is the opt-out — **udpfsd's own env var, which we didn't have**.
- `-c` and `ENABLE_COMPRESSION=0` keep their old meanings, so existing configs still mean what they meant.
- **The launcher had to change too:** its box already said "on by default" and passed `-c` when ticked. With the server default flipped, passing nothing when *unticked* would have silently left decompression on — it now sends `--no-compression`. (Caught by checking, not by guessing.)

Safe to flip: missing `lz4`/`libchdr` still leaves those files with their real extension + a warning, a corrupt sibling never hides a good one, and a real `Game.iso` still wins over `Game.chd`.

### Three crashes on inputs udpfsd documents

| input | before | now |
| --- | --- | --- |
| `PEER_TIMEOUT=1h` | `ValueError` traceback, **server never starts** | 3600s |
| `PEER_TIMEOUT=bogus` | `ValueError` traceback | warns, falls back to default (as udpfsd does) |
| `--bind :41233` | unhandled `socket.gaierror` | binds; port fills in `--data-port` |
| `--bind 0.0.0.0:abc` | traceback | clean argparse error, exit 2 |

Durations accept `1h`, `30m`, `1h30m`, `500ms` or bare seconds. Anyone porting a compose file from udpfsd's README hit a Python stack trace — which is exactly the story that makes "the Python one is worse" *feel* true.

### `.ciso` / `.ziso`

Recognised as CSO/ZSO. Several tools write those spellings and udpfsd accepts them; an unrecognised extension isn't cosmetic — the file is **invisible to the console**. Extension→codec is now one table instead of hardcoded checks at three call sites (the drift the existing comment warns about).

### 1 MB data-socket receive buffer

udpfsd asks for this; we took the OS default. The PS2 streams bursts, and a datagram dropped to buffer overflow costs a NACK + retransmit round-trip. The auditor's note: we need it *more* than they do.

### Deliberately NOT matched

- **udpfsd's unbounded peer-timeout** — we clamp 60s–24h and warn. Matching them removes a guardrail.
- **udpfsd's silent `./fsroot` default** with no args — serving a directory nobody named is a footgun; our explicit error is safer.

Parity where parity is right.

### Verified

- 19 new unit tests (durations incl. `ms`-vs-`m`, bind grammar, alias mapping, recv-buffer best-effort, launcher arg wiring, no-short-flags/Nuitka guard).
- The compression selftest caught me breaking it — it pins the extension tuple per library-availability combo. Updated to assert aliases appear **exactly when their base format does**, never separately.
- Full suite **147 passed / 3 skipped**; pathguard, multiclient and compression selftests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)