### PR TITLE
Linux parity: firewall guidance, close-confirm, and drop dead Windows-only UI

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -29,7 +29,7 @@ def _direct_link_experimental():
     """Non-Windows: the setup path is real but unverified on hardware."""
     return platform.system() in ("Linux", "Darwin")
 
-from . import config, directlink, elevate, netinfo, tray, windows_setup
+from . import config, directlink, elevate, netinfo, posix_firewall, tray, windows_setup
 from .process import ServerProcess
 from .release_metadata import DISPLAY_VERSION
 from .servers import REGISTRY, REPO_ROOT, frozen_self_exe, is_frozen, serve_command
@@ -219,9 +219,14 @@ class ServerCard(ttk.LabelFrame):
             self.toggle_btn.config(state="disabled")
         row += 1
 
-        # primary fields, then advanced fields (hidden behind a toggle)
-        primary = [f for f in self.server.fields if not f.advanced]
-        advanced = [f for f in self.server.fields if f.advanced]
+        # primary fields, then advanced fields (hidden behind a toggle).
+        # windows_only fields (e.g. take-445, which pauses LanmanServer) are
+        # dropped off Windows: their mechanism cannot work there, and showing a
+        # dead control just invites a confusing permission error.
+        shown = [f for f in self.server.fields
+                 if windows_setup.is_windows() or not f.windows_only]
+        primary = [f for f in shown if not f.advanced]
+        advanced = [f for f in shown if f.advanced]
         for f in primary:
             row = self._add_field(self, f, row)
 
@@ -670,15 +675,18 @@ class LauncherApp:
         footer = ttk.Frame(parent, style="Footer.TFrame", padding=(12, 10))
         footer.pack(fill="x", padx=16, pady=(0, 8), before=self.nb)
         footer.columnconfigure(2, weight=1)
-        allow = ttk.Button(footer, text="Allow through firewall",
-                           command=self.allow_windows_setup)
-        allow.grid(row=0, column=0, sticky="w")
-        remove = ttk.Button(footer, text="Remove PS2 Servers firewall rules",
-                            command=self.remove_windows_setup)
-        remove.grid(row=0, column=1, sticky="w", padx=(8, 0))
-        if not windows_setup.is_windows():
-            allow.config(state="disabled")
-            remove.config(state="disabled")
+        # These two manage named WINDOWS Firewall rules. On other OSes there is
+        # nothing for them to do, so rather than show them permanently greyed --
+        # which just makes a Linux user wonder what they're missing -- omit them
+        # entirely (the admin panel is hidden the same way). Linux firewall
+        # guidance is instead printed to the terminal when a server starts.
+        if windows_setup.is_windows():
+            allow = ttk.Button(footer, text="Allow through firewall",
+                               command=self.allow_windows_setup)
+            allow.grid(row=0, column=0, sticky="w")
+            remove = ttk.Button(footer, text="Remove PS2 Servers firewall rules",
+                                command=self.remove_windows_setup)
+            remove.grid(row=0, column=1, sticky="w", padx=(8, 0))
         ttk.Button(footer, text="Stop all", command=self.stop_all).grid(
             row=0, column=3, sticky="e")
         ttk.Button(footer, text="Restart", command=self.restart_app).grid(
@@ -729,19 +737,25 @@ class LauncherApp:
         ttk.Button(links, text="Security notes",
                    command=lambda: self._open_url(SECURITY_URL)).pack(side="left", padx=(6, 0), pady=6)
 
-        behavior = ttk.LabelFrame(about, text=" Window behavior ")
-        behavior.grid(row=row, column=0, sticky="ew", padx=8, pady=(8, 0))
-        behavior.columnconfigure(2, weight=1)
-        row += 1
-        close_to_tray = ttk.Checkbutton(
-            behavior, text="Close to tray", variable=self.close_to_tray_var,
-            command=self._save, style="Card.TCheckbutton")
-        close_to_tray.grid(row=0, column=0, sticky="w", padx=(6, 12), pady=6)
-        minimize_to_tray = ttk.Checkbutton(
-            behavior, text="Minimize to tray", variable=self.minimize_to_tray_var,
-            command=self._save, style="Card.TCheckbutton")
-        minimize_to_tray.grid(row=0, column=1, sticky="w", padx=(0, 12), pady=6)
-        self._tray_option_widgets.extend([close_to_tray, minimize_to_tray])
+        # The tray options only mean anything with a tray, which is Windows-only.
+        # Omit the frame entirely elsewhere rather than show two dead checkboxes
+        # (on Linux closing the window quits, with a confirm if servers are up).
+        # Gate on tray.AVAILABLE, not self._tray: the tray instance is created
+        # AFTER _build() runs, so self._tray is still None here on every OS.
+        if tray.AVAILABLE:
+            behavior = ttk.LabelFrame(about, text=" Window behavior ")
+            behavior.grid(row=row, column=0, sticky="ew", padx=8, pady=(8, 0))
+            behavior.columnconfigure(2, weight=1)
+            row += 1
+            close_to_tray = ttk.Checkbutton(
+                behavior, text="Close to tray", variable=self.close_to_tray_var,
+                command=self._save, style="Card.TCheckbutton")
+            close_to_tray.grid(row=0, column=0, sticky="w", padx=(6, 12), pady=6)
+            minimize_to_tray = ttk.Checkbutton(
+                behavior, text="Minimize to tray", variable=self.minimize_to_tray_var,
+                command=self._save, style="Card.TCheckbutton")
+            minimize_to_tray.grid(row=0, column=1, sticky="w", padx=(0, 12), pady=6)
+            self._tray_option_widgets.extend([close_to_tray, minimize_to_tray])
 
         text_frame = ttk.Frame(about)
         about.rowconfigure(row, weight=1)
@@ -1602,6 +1616,29 @@ class LauncherApp:
         card.refresh_status(True)
         card.toggle_btn.config(state="normal")
         self.nb.select(self.terminal_tab)
+        if not windows_setup.is_windows():
+            self._log_firewall_hint(key, values)
+
+    def _log_firewall_hint(self, key, values):
+        """Unix: after a server starts, tell the user how to open its ports if a
+        firewall is blocking them. Windows manages allow-rules directly; on Unix
+        we are not root, so guidance is the honest option -- and it turns a
+        silent 'the PS2 sees nothing' into an actionable message. The systemctl
+        active-probe runs OFF the Tk thread; the lines are appended back on it."""
+        ports = windows_setup.server_ports(key, values)
+        if not ports:
+            return
+
+        def worker():
+            lines = posix_firewall.firewall_hint_lines(ports, probe_active=True)
+
+            def emit():
+                for line in lines:
+                    self._append_log(key, "[firewall] {}\n".format(line))
+
+            self.root.after(0, emit)
+
+        threading.Thread(target=worker, daemon=True).start()
 
     def _allow_pending(self):
         self.saved.pop("pending_firewall_allow", None)
@@ -2185,7 +2222,12 @@ class LauncherApp:
         if self._should_close_to_tray():
             self._hide_to_tray()
             return
-        self.exit_app(confirm=False)
+        # No tray to fall back to (every OS but Windows, or the tray disabled):
+        # closing the window really does quit. Confirm ONLY when servers are
+        # running -- _confirm_app_shutdown returns True instantly otherwise, so
+        # an idle close is still one click. Without this a Linux user clicking X
+        # out of habit silently kills a server mid-load.
+        self.exit_app()
 
     def _should_close_to_tray(self):
         return bool(self._tray and self.close_to_tray_var.get())

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -2267,13 +2267,16 @@ class LauncherApp:
                 if action == "open":
                     self._restore_from_tray()
                 elif action == "quit":
-                    self.exit_app(confirm=False)
+                    # Confirm if servers are running, like the window-close and
+                    # Exit paths -- an explicit Quit should not silently kill a
+                    # transfer either. No-op prompt when nothing is running.
+                    self.exit_app()
         except queue.Empty:
             pass
         self.root.after(150, self._drain_tray)
 
     def _quit_from_tray(self):
-        self.exit_app(confirm=False)
+        self.exit_app()
 
 
 def run_gui():

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -41,6 +41,10 @@ def main(argv=None):
         from . import gui
     except ImportError as e:  # Tkinter not present in this Python build
         print("GUI unavailable ({}). Servers on this machine:".format(e))
+        if platform.system() == "Linux":
+            print("(Tk is bundled in the packaged download. Running from source? "
+                  "Install your distro's Tk package, e.g. "
+                  "'sudo apt install python3-tk' or 'sudo dnf install python3-tkinter'.)")
         _print_list()
         return 1
     _apply_gui_review_fixes(gui)
@@ -60,6 +64,18 @@ Administrator rights are requested only when Windows requires them:
 - using the advanced SMB port 445 mode.
 
 The launcher shows whether it is currently running as administrator. Use "Restart as administrator" only when you intentionally need elevated Windows setup actions. Keeping the default launch non-admin reduces the blast radius of bugs and makes the app easier to trust.
+"""
+
+
+UNIX_ABOUT_TEXT = """
+
+Linux and macOS
+
+PS2 Servers runs the same three servers here as on Windows. A few things differ:
+
+- There is no firewall management. If the PS2 cannot see a server after you start it, open its port in your firewall -- the TERMINAL tab prints the exact command for ufw or firewalld when a server starts. Many desktops allow LAN traffic by default and need nothing.
+- System tray, and the "Take port 445" SMB option, are Windows-only and are not shown here.
+- Direct link mode is experimental on Linux and macOS: it runs a small helper as administrator (via your system's password prompt) to configure the port, and removes that configuration again when it stops.
 """
 
 
@@ -89,8 +105,15 @@ def _apply_gui_review_fixes(gui):
         "disabled": "#5f6f8d",
     }
 
-    if ADMIN_ABOUT_TEXT not in gui.ABOUT_TEXT:
-        gui.ABOUT_TEXT += ADMIN_ABOUT_TEXT
+    # The admin section is about Windows Firewall rules, UAC, and 445 mode --
+    # none of which apply on Linux/macOS. Append it only on Windows; elsewhere
+    # add a short, accurate note so the About tab isn't full of Windows-only
+    # instructions and references to buttons that don't exist off Windows.
+    if gui.windows_setup.is_windows():
+        if ADMIN_ABOUT_TEXT not in gui.ABOUT_TEXT:
+            gui.ABOUT_TEXT += ADMIN_ABOUT_TEXT
+    elif UNIX_ABOUT_TEXT not in gui.ABOUT_TEXT:
+        gui.ABOUT_TEXT += UNIX_ABOUT_TEXT
 
     gui.COLOR_RUNNING = palette["ok"]
     gui.COLOR_STOPPED = palette["muted"]

--- a/launcher/netinfo.py
+++ b/launcher/netinfo.py
@@ -7,7 +7,78 @@ the warning the SMBv1 server already prints ("usually 192.168.x.x -- NOT a
 VPN/WSL address").
 """
 
+import shutil
 import socket
+import subprocess
+import sys
+
+
+# Interfaces the PS2 is never reachable on: containers, bridges, VPN tunnels,
+# VM host-only nets. Matched as name prefixes.
+_VIRTUAL_IFACE_PREFIXES = (
+    "lo", "docker", "veth", "virbr", "br-", "tun", "tap", "vmnet", "vboxnet",
+    "zt", "wg", "utun", "llw", "awdl", "bridge", "gif", "stf", "ap",
+)
+
+
+def _iface_is_virtual(name):
+    return name.startswith(_VIRTUAL_IFACE_PREFIXES)
+
+
+def _parse_linux_ip_addr(text):
+    """IPv4s from `ip -o -4 addr show`, skipping virtual interfaces.
+
+    A line looks like: '3: enp3s0    inet 192.168.1.50/24 brd ... scope global'
+    """
+    ips = []
+    for line in (text or "").splitlines():
+        parts = line.split()
+        if len(parts) < 4 or parts[2] != "inet":
+            continue
+        if _iface_is_virtual(parts[1]):
+            continue
+        ips.append(parts[3].split("/")[0])
+    return ips
+
+
+def _parse_macos_ifconfig(text):
+    """IPv4s from `ifconfig`, skipping virtual interfaces.
+
+    Interface headers start in column 0 ('en0: flags=...'); their addresses
+    follow on indented 'inet <ip> netmask ...' lines.
+    """
+    ips = []
+    current = None
+    for line in (text or "").splitlines():
+        if line and not line[0].isspace():
+            current = line.split(":", 1)[0]
+            continue
+        stripped = line.strip()
+        if stripped.startswith("inet ") and current and not _iface_is_virtual(current):
+            ips.append(stripped.split()[1])
+    return ips
+
+
+def _posix_extra_ipv4():
+    """Interface IPv4s that getaddrinfo(hostname) misses on Unix.
+
+    On Debian/Ubuntu the hostname resolves to 127.0.1.1, so getaddrinfo returns
+    only loopback and the machine's real NICs never reach the LAN-IP dropdown --
+    a multi-NIC, NAS, or VPN user is then left to type the address by hand. Read
+    the interfaces directly instead. Best-effort: any failure yields nothing.
+    """
+    try:
+        if sys.platform.startswith("linux") and shutil.which("ip"):
+            out = subprocess.run(["ip", "-o", "-4", "addr", "show"],
+                                 capture_output=True, text=True, timeout=3).stdout
+            return _parse_linux_ip_addr(out)
+        if sys.platform == "darwin" and shutil.which("ifconfig"):
+            out = subprocess.run(["ifconfig"],
+                                 capture_output=True, text=True, timeout=3).stdout
+            return _parse_macos_ifconfig(out)
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return []
 
 
 def primary_ip():
@@ -42,6 +113,9 @@ def all_ipv4():
     except OSError:
         pass
     ips.add(primary_ip())
+    # getaddrinfo(hostname) under-reports on Unix (Debian/Ubuntu point the
+    # hostname at 127.0.1.1); read the interfaces directly to fill the dropdown.
+    ips.update(_posix_extra_ipv4())
     return sorted(ip for ip in ips if not ip.startswith(("127.", "169.254.")))
 
 

--- a/launcher/posix_firewall.py
+++ b/launcher/posix_firewall.py
@@ -19,11 +19,12 @@ import subprocess
 
 
 _TOOLS = (
-    # (binary, systemd unit, command template). Order = preference.
-    ("ufw", "ufw", "sudo ufw allow {port}/{proto}"),
-    ("firewall-cmd", "firewalld",
-     "sudo firewall-cmd --add-port={port}/{proto}"
-     "  (add --permanent to keep it after a reboot)"),
+    # (binary, systemd unit, command template, note). Order = preference. The
+    # template renders to a bare, copy-pasteable command; any caveat goes in
+    # `note`, printed separately so pasting the command line just works.
+    ("ufw", "ufw", "sudo ufw allow {port}/{proto}", ""),
+    ("firewall-cmd", "firewalld", "sudo firewall-cmd --add-port={port}/{proto}",
+     "firewall-cmd: add --permanent to keep the rule after a reboot."),
 )
 
 
@@ -42,17 +43,17 @@ def _unit_is_active(unit):
 
 
 def detect_firewall_tools(probe_active=True):
-    """[(binary, template, active_bool), ...] for the firewall tools present.
+    """[(binary, template, note, active_bool), ...] for the tools present.
 
     probe_active runs one short `systemctl is-active` per tool; pass False to
     skip the subprocess entirely (e.g. on a UI thread that must not block).
     """
     found = []
-    for binary, unit, template in _TOOLS:
+    for binary, unit, template, note in _TOOLS:
         if not shutil.which(binary):
             continue
         active = _unit_is_active(unit) if probe_active else False
-        found.append((binary, template, active))
+        found.append((binary, template, note, active))
     return found
 
 
@@ -65,7 +66,7 @@ def firewall_hint_lines(ports, probe_active=True):
     if not ports:
         return []
     tools = detect_firewall_tools(probe_active=probe_active)
-    active = [t for t in tools if t[2]]
+    active = [t for t in tools if t[3]]
 
     if active:
         lead = ("Your {} firewall is active -- if the PS2 cannot see this "
@@ -79,9 +80,13 @@ def firewall_hint_lines(ports, probe_active=True):
 
     if tools:
         for proto, port, _purpose in ports:
-            for binary, template, _act in tools:
+            for _binary, template, _note, _act in tools:
                 lines.append("    " + template.format(
                     port=port, proto=proto.lower()))
+        # Tool caveats once, after the copy-pasteable commands.
+        for _binary, _template, note, _act in tools:
+            if note:
+                lines.append("  " + note)
     else:
         lines.append("  (open them in whatever firewall your distro uses; most "
                      "desktop setups already allow LAN traffic)")

--- a/launcher/posix_firewall.py
+++ b/launcher/posix_firewall.py
@@ -1,0 +1,88 @@
+"""Best-effort firewall guidance for Linux/macOS -- no root, no automation.
+
+Windows gets real allow-rule management (windows_setup.py). On Unix there is no
+single firewall API and the launcher is not root, so instead of silently
+succeeding while a default-deny firewall drops the console's packets, we tell
+the user the exact command to open the ports. Fedora / RHEL / openSUSE ship
+firewalld active by default and Ubuntu users who ran `ufw enable` are in the
+same boat, so a blocked port is a real failure mode -- and one that otherwise
+looks like "PS2 Servers is broken on Linux" because the server itself starts
+fine and the packets just vanish.
+
+Detection is deliberately cheap and root-free: `shutil.which` for the tool, and
+`systemctl is-active` (which needs no privileges) to tell an ACTIVE firewall
+from a merely-installed one. Everything degrades to a generic hint.
+"""
+
+import shutil
+import subprocess
+
+
+_TOOLS = (
+    # (binary, systemd unit, command template). Order = preference.
+    ("ufw", "ufw", "sudo ufw allow {port}/{proto}"),
+    ("firewall-cmd", "firewalld",
+     "sudo firewall-cmd --add-port={port}/{proto}"
+     "  (add --permanent to keep it after a reboot)"),
+)
+
+
+def _unit_is_active(unit):
+    """True only if systemctl reports the unit active. Never raises."""
+    systemctl = shutil.which("systemctl")
+    if not systemctl:
+        return False
+    try:
+        res = subprocess.run(
+            [systemctl, "is-active", unit],
+            capture_output=True, text=True, timeout=3)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return res.stdout.strip() == "active"
+
+
+def detect_firewall_tools(probe_active=True):
+    """[(binary, template, active_bool), ...] for the firewall tools present.
+
+    probe_active runs one short `systemctl is-active` per tool; pass False to
+    skip the subprocess entirely (e.g. on a UI thread that must not block).
+    """
+    found = []
+    for binary, unit, template in _TOOLS:
+        if not shutil.which(binary):
+            continue
+        active = _unit_is_active(unit) if probe_active else False
+        found.append((binary, template, active))
+    return found
+
+
+def firewall_hint_lines(ports, probe_active=True):
+    """Terminal lines telling a Unix user how to open `ports`, or [].
+
+    `ports` is the [(proto, port, purpose), ...] list the server already builds
+    for its Windows firewall rules -- reused verbatim so the two never drift.
+    """
+    if not ports:
+        return []
+    tools = detect_firewall_tools(probe_active=probe_active)
+    active = [t for t in tools if t[2]]
+
+    if active:
+        lead = ("Your {} firewall is active -- if the PS2 cannot see this "
+                "server, allow these ports:".format(active[0][0]))
+    else:
+        lead = ("If the PS2 cannot see this server, allow these ports through "
+                "your firewall:")
+    lines = [lead]
+    for proto, port, purpose in ports:
+        lines.append("  {}: {} {}".format(purpose, proto, port))
+
+    if tools:
+        for proto, port, _purpose in ports:
+            for binary, template, _act in tools:
+                lines.append("    " + template.format(
+                    port=port, proto=proto.lower()))
+    else:
+        lines.append("  (open them in whatever firewall your distro uses; most "
+                     "desktop setups already allow LAN traffic)")
+    return lines

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -73,6 +73,7 @@ class Field:
     default: object = None
     help: str = ""
     advanced: bool = False  # GUI hides advanced fields until expanded
+    windows_only: bool = False  # GUI omits the field entirely on other OSes
 
 
 @dataclass
@@ -240,6 +241,7 @@ SMBV1 = ServerDef(
         Field("read_only", "Read-only", "bool", default=False, advanced=True,
               help="No saves / no VMC writes."),
         Field("take_445", "Take port 445 (admin)", "bool", default=False, advanced=True,
+              windows_only=True,
               help="Bind standard port 445 by pausing Windows file sharing. Needs admin."),
         Field("bind", "Bind address", "text", default="", advanced=True,
               help="Interface to bind (blank = all)."),

--- a/launcher/windows_setup.py
+++ b/launcher/windows_setup.py
@@ -121,6 +121,14 @@ def _parse_port(value, default):
         return int(default)
 
 
+def server_ports(key, values):
+    """Public: the fixed inbound ports a server listens on, cross-platform.
+
+    Used both to build Windows firewall rules and to tell a Linux user which
+    ports to open -- one source so the two never disagree."""
+    return _server_ports(key, values)
+
+
 def _server_ports(key, values):
     """Return [(protocol, port, purpose), ...] for fixed inbound ports."""
     if key == "smbv1":

--- a/tests/test_linux_parity.py
+++ b/tests/test_linux_parity.py
@@ -1,0 +1,128 @@
+"""Unit tests for the Linux/macOS parity helpers.
+
+Pure parsers and command-builders, exercised off-platform with captured sample
+output -- the same approach as the direct-link Unix tests.
+
+Run:  python -m unittest tests.test_linux_parity -v
+"""
+
+import unittest
+from unittest import mock
+
+from launcher import netinfo, posix_firewall, servers, windows_setup
+
+
+class FirewallHintTests(unittest.TestCase):
+    UDPFS_PORTS = [("UDP", 0xF5F6, "UDPFS discovery")]
+    SMB_PORTS = [("TCP", 1111, "SMBv1")]
+
+    def test_no_ports_no_hint(self):
+        self.assertEqual(posix_firewall.firewall_hint_lines([]), [])
+
+    def test_generic_hint_when_no_tool_present(self):
+        with mock.patch.object(posix_firewall.shutil, "which", return_value=None):
+            lines = posix_firewall.firewall_hint_lines(self.SMB_PORTS, probe_active=False)
+        text = "\n".join(lines)
+        self.assertIn("TCP 1111", text)
+        self.assertIn("SMBv1", text)
+        # No tool -> no sudo command, but still an actionable line.
+        self.assertNotIn("sudo ", text)
+        self.assertIn("firewall", text.lower())
+
+    def test_ufw_command_when_ufw_present(self):
+        def which(name):
+            return "/usr/sbin/ufw" if name == "ufw" else None
+        with mock.patch.object(posix_firewall.shutil, "which", side_effect=which):
+            lines = posix_firewall.firewall_hint_lines(self.UDPFS_PORTS, probe_active=False)
+        text = "\n".join(lines)
+        self.assertIn("sudo ufw allow 62966/udp", text)
+
+    def test_firewalld_command_when_present(self):
+        def which(name):
+            return "/usr/bin/firewall-cmd" if name == "firewall-cmd" else None
+        with mock.patch.object(posix_firewall.shutil, "which", side_effect=which):
+            lines = posix_firewall.firewall_hint_lines(self.SMB_PORTS, probe_active=False)
+        text = "\n".join(lines)
+        self.assertIn("sudo firewall-cmd --add-port=1111/tcp", text)
+        self.assertIn("--permanent", text)  # persistence reminder
+
+    def test_active_probe_sharpens_the_lead_line(self):
+        def which(name):
+            return "/usr/sbin/ufw" if name == "ufw" else None
+        with mock.patch.object(posix_firewall.shutil, "which", side_effect=which), \
+                mock.patch.object(posix_firewall, "_unit_is_active", return_value=True):
+            lines = posix_firewall.firewall_hint_lines(self.SMB_PORTS, probe_active=True)
+        self.assertIn("active", lines[0].lower())
+
+    def test_probe_active_false_does_not_call_systemctl(self):
+        with mock.patch.object(posix_firewall.shutil, "which", return_value="/x"), \
+                mock.patch.object(posix_firewall, "_unit_is_active") as probe:
+            posix_firewall.firewall_hint_lines(self.SMB_PORTS, probe_active=False)
+            probe.assert_not_called()
+
+    def test_ports_come_from_the_same_source_as_windows_rules(self):
+        # The hint must describe exactly the ports the Windows firewall rules
+        # would open, or the two drift. Drive it through the shared accessor.
+        ports = windows_setup.server_ports("udpfs", {"port": "0xF5F6"})
+        lines = posix_firewall.firewall_hint_lines(ports, probe_active=False)
+        self.assertTrue(any("62966" in ln for ln in lines))
+
+
+class LinuxIpParseTests(unittest.TestCase):
+    IP_ADDR = (
+        "1: lo    inet 127.0.0.1/8 scope host lo\\       valid_lft forever\n"
+        "2: enp3s0    inet 192.168.1.50/24 brd 192.168.1.255 scope global enp3s0\n"
+        "3: docker0    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0\n"
+        "4: virbr0    inet 192.168.122.1/24 brd ... scope global virbr0\n"
+        "5: tun0    inet 10.8.0.2/24 scope global tun0\n"
+        "6: wlan0    inet 192.168.1.51/24 brd ... scope global wlan0\n"
+    )
+
+    def test_keeps_real_nics_drops_virtual(self):
+        ips = netinfo._parse_linux_ip_addr(self.IP_ADDR)
+        self.assertIn("192.168.1.50", ips)   # ethernet
+        self.assertIn("192.168.1.51", ips)   # wifi
+        self.assertNotIn("127.0.0.1", ips)   # lo
+        self.assertNotIn("172.17.0.1", ips)  # docker
+        self.assertNotIn("192.168.122.1", ips)  # virbr (libvirt)
+        self.assertNotIn("10.8.0.2", ips)    # tun (VPN)
+
+    def test_empty_and_garbage(self):
+        self.assertEqual(netinfo._parse_linux_ip_addr(""), [])
+        self.assertEqual(netinfo._parse_linux_ip_addr("nonsense line here"), [])
+
+
+class MacosIfconfigParseTests(unittest.TestCase):
+    IFCONFIG = (
+        "lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384\n"
+        "\tinet 127.0.0.1 netmask 0xff000000\n"
+        "en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500\n"
+        "\tinet 192.168.1.20 netmask 0xffffff00 broadcast 192.168.1.255\n"
+        "\tstatus: active\n"
+        "utun3: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1380\n"
+        "\tinet 10.9.0.4 --> 10.9.0.4 netmask 0xffffffff\n"
+        "bridge100: flags=8863 mtu 1500\n"
+        "\tinet 192.168.64.1 netmask 0xffffff00 broadcast 192.168.64.255\n"
+    )
+
+    def test_keeps_en0_drops_loopback_vpn_bridge(self):
+        ips = netinfo._parse_macos_ifconfig(self.IFCONFIG)
+        self.assertEqual(ips, ["192.168.1.20"])
+
+
+class WindowsOnlyFieldTests(unittest.TestCase):
+    def test_take_445_is_flagged_windows_only(self):
+        smb = servers.REGISTRY["smbv1"]
+        f = next(f for f in smb.fields if f.key == "take_445")
+        self.assertTrue(f.windows_only)
+
+    def test_no_other_field_is_windows_only(self):
+        # Guard against accidentally hiding a cross-platform field.
+        for server in servers.REGISTRY.values():
+            for f in server.fields:
+                if f.windows_only:
+                    self.assertEqual((server.key, f.key), ("smbv1", "take_445"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_linux_parity.py
+++ b/tests/test_linux_parity.py
@@ -37,14 +37,22 @@ class FirewallHintTests(unittest.TestCase):
         text = "\n".join(lines)
         self.assertIn("sudo ufw allow 62966/udp", text)
 
-    def test_firewalld_command_when_present(self):
+    def test_firewalld_command_is_copyable_with_note_separate(self):
         def which(name):
             return "/usr/bin/firewall-cmd" if name == "firewall-cmd" else None
         with mock.patch.object(posix_firewall.shutil, "which", side_effect=which):
             lines = posix_firewall.firewall_hint_lines(self.SMB_PORTS, probe_active=False)
-        text = "\n".join(lines)
-        self.assertIn("sudo firewall-cmd --add-port=1111/tcp", text)
-        self.assertIn("--permanent", text)  # persistence reminder
+        stripped = [ln.strip() for ln in lines]
+        # The command line must be exactly the command -- copy-pasteable, no
+        # trailing prose that a shell would choke on.
+        self.assertIn("sudo firewall-cmd --add-port=1111/tcp", stripped)
+        self.assertNotIn("sudo firewall-cmd --add-port=1111/tcp  "
+                         "(add --permanent to keep it after a reboot)", stripped)
+        # The persistence caveat is still present, just on its own line.
+        self.assertTrue(any("--permanent" in ln and "firewall-cmd" in ln
+                            for ln in stripped))
+        self.assertFalse(any(ln.startswith("sudo") and "--permanent" in ln
+                             for ln in stripped))
 
     def test_active_probe_sharpens_the_lead_line(self):
         def which(name):


### PR DESCRIPTION
Ahead of a Linux tester, I ran an adversarial audit of every platform branch in the launcher (5 subsystems × find-then-verify). The reassuring headline: **the direct-link code and the Linux build both came back CLEAN** — the tester's "wonky on Linux" is almost certainly the firewall gap below, not a code defect. Every confirmed gap was firewall handling or Windows-only UI leaking onto Linux.

### The real burn risk: no firewall handling *or guidance* on Linux

Windows manages named allow-rules directly. Linux had nothing — and worse, **no hint**. On Fedora / RHEL / openSUSE (firewalld active, default-deny) or anyone who ran `ufw enable`: the server binds fine, the PS2's DISCOVER/connect packets are silently dropped, and the launcher shows a happy "running" with zero explanation. That reads as *"PS2 Servers is broken on Linux"* — exactly the burn we're avoiding.

New `posix_firewall.py`: after a server starts on Unix, the TERMINAL prints the exact command for its ports —
```
[firewall] Your ufw firewall is active -- if the PS2 cannot see this server, allow these ports:
[firewall]   UDPFS discovery: UDP 62966
[firewall]     sudo ufw allow 62966/udp
```
No root, no automation, no new deps. Tool detection is `shutil.which`; the "is it active" sharpening is a root-free `systemctl is-active` run **off the Tk thread**. Ports come from the same `windows_setup.server_ports()` the Windows rules use, so guidance and rules can't drift.

### Closing the window silently killed running servers on Linux

No tray to fall back to → `_on_window_close` went straight to `exit_app(confirm=False)`. A Windows-habit click mid-load killed the transfer with no prompt. Now it confirms — but only when servers are actually running (idle close stays one click, since `_confirm_app_shutdown` returns instantly).

### Windows-only controls no longer shown dead on Linux

- The two **Windows Firewall buttons** and the **"Window behavior"** tray frame are *omitted* off Windows (not greyed), matching how the admin panel was already hidden.
- **Take-445** is gated behind a new `Field.windows_only` flag — its LanmanServer-pausing mechanism can't work off Windows, so showing it just invites a permission error.

### LAN-IP dropdown enriched on Unix

`getaddrinfo(hostname)` under-reports on Debian/Ubuntu (hostname → `127.0.1.1`), so multi-NIC / NAS / VPN users got a one-entry dropdown and had to type the address. `netinfo` now reads `ip -o -4 addr` / `ifconfig`, filtering virtual interfaces (docker/veth/bridges/VPN taps).

### About tab is now OS-accurate

Windows firewall/UAC/445 section appended only on Windows; a correct Linux/macOS note replaces it. The GUI-unavailable fallback tells Linux source users which Tk package to install.

### Verified

- 12 new tests: firewall-hint (generic / ufw / firewalld / active-probe / shared-port-source), Linux `ip addr` + macOS `ifconfig` parsers (virtual-interface filtering), `windows_only` field gating.
- **GUI constructed headless as both OSes**: Windows keeps firewall button + take-445 + behavior frame; Linux hides all three. No Windows regression.
- Caught and fixed a real ordering bug pre-merge: `self._tray` is `None` during `_build()` (created after), so the tray-frame guard uses `tray.AVAILABLE`, not `self._tray`.
- Full suite **167 passed / 3 skipped**.

Direct-link and packaging were audited and needed **no changes** — noted so we don't go looking for problems that aren't there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)