### PR TITLE
UDPFS: reject truncated compressed headers; validate the data-port range

### DIFF
--- a/tests/test_udpfs_config.py
+++ b/tests/test_udpfs_config.py
@@ -7,9 +7,12 @@ duration/bind cases below was an unhandled traceback before.
 Run:  python -m unittest tests.test_udpfs_config -v
 """
 
+import argparse
 import os
 import socket
+import struct
 import sys
+import tempfile
 import unittest
 
 # udpfs_server/ is not a package; the server module and its compressed_iso
@@ -140,7 +143,7 @@ class PortRangeTests(unittest.TestCase):
         self.assertEqual(parse('0'), 0)
         self.assertEqual(parse('0xF5F7'), 0xF5F7)  # hex like the CLI accepts
         for bad in ('99999', '-1', '70000'):
-            with self.assertRaises(Exception):  # argparse.ArgumentTypeError
+            with self.assertRaises(argparse.ArgumentTypeError):
                 parse(bad)
 
 
@@ -149,45 +152,34 @@ class TruncatedCompressedHeaderTests(unittest.TestCase):
     _resolve_compressed_sibling would prefer this unopenable candidate over a
     good later sibling and OPEN would then fail with EIO."""
 
-    def _write(self, path, data):
+    @staticmethod
+    def _write(directory, name, data):
+        path = os.path.join(directory, name)
         with open(path, 'wb') as f:
             f.write(data)
+        return path
 
     def test_truncated_cso_with_valid_magic_is_rejected(self):
-        import struct as _struct
-        import tempfile
-        d = tempfile.mkdtemp()
-        try:
+        with tempfile.TemporaryDirectory() as d:
             # Valid CISO magic + a size field, but only 16 bytes -- shorter than
             # the 24-byte header the wrapper needs.
-            magic = _struct.pack('<I', udpfs.CSO_MAGIC)
-            truncated = magic + b'\x00' * 4 + _struct.pack('<Q', 700 * 1024 * 1024)
+            magic = struct.pack('<I', udpfs.CSO_MAGIC)
+            truncated = magic + b'\x00' * 4 + struct.pack('<Q', 700 * 1024 * 1024)
             self.assertEqual(len(truncated), 16)
-            p = os.path.join(d, 'Game.cso')
-            self._write(p, truncated)
+            p = self._write(d, 'Game.cso', truncated)
             self.assertIsNone(udpfs.get_compressed_info(p))
-        finally:
-            import shutil as _shutil
-            _shutil.rmtree(d, ignore_errors=True)
 
     def test_full_length_header_still_parses(self):
-        import struct as _struct
-        import tempfile
-        d = tempfile.mkdtemp()
-        try:
-            magic = _struct.pack('<I', udpfs.CSO_MAGIC)
-            header = (magic + _struct.pack('<I', 24)
-                      + _struct.pack('<Q', 700 * 1024 * 1024)
-                      + _struct.pack('<I', 2048) + b'\x01\x00\x00\x00')
+        with tempfile.TemporaryDirectory() as d:
+            magic = struct.pack('<I', udpfs.CSO_MAGIC)
+            header = (magic + struct.pack('<I', 24)
+                      + struct.pack('<Q', 700 * 1024 * 1024)
+                      + struct.pack('<I', 2048) + b'\x01\x00\x00\x00')
             self.assertEqual(len(header), 24)
-            p = os.path.join(d, 'Game.cso')
-            self._write(p, header)
+            p = self._write(d, 'Game.cso', header)
             info = udpfs.get_compressed_info(p)
             self.assertIsNotNone(info)
             self.assertEqual(info[1], 'CSO')
-        finally:
-            import shutil as _shutil
-            _shutil.rmtree(d, ignore_errors=True)
 
 
 class ExtensionAliasTests(unittest.TestCase):

--- a/tests/test_udpfs_config.py
+++ b/tests/test_udpfs_config.py
@@ -96,18 +96,15 @@ class BindTests(unittest.TestCase):
 
 
 class DataPortPrecedenceTests(unittest.TestCase):
-    """--data-port beats a port embedded in --bind; the parse must tell an
-    explicit 0 ('pick ephemeral') apart from the flag being absent."""
+    """Exercise the PRODUCTION resolver, not a copy of it, so the test can't
+    pass while main() diverges. --data-port beats a port in --bind, which beats
+    DATA_PORT; an explicit 0 ('pick ephemeral') is distinct from the flag being
+    absent."""
 
     @staticmethod
-    def _resolve(data_port_arg, bind_arg):
-        # Mirror main()'s resolution without standing a server up. args.data_port
-        # is None when --data-port was not passed; 0 is a real, explicit value.
-        data_port = data_port_arg
+    def _resolve(data_port_arg, bind_arg, env_value=None):
         _bind_ip, bind_port = udpfs.split_bind(bind_arg)
-        if data_port is None:
-            data_port = bind_port if bind_port is not None else 0
-        return data_port
+        return udpfs.resolve_data_port(data_port_arg, bind_port, env_value)
 
     def test_explicit_data_port_beats_bind_port(self):
         self.assertEqual(self._resolve(50000, ':41233'), 50000)
@@ -119,8 +116,78 @@ class DataPortPrecedenceTests(unittest.TestCase):
     def test_bind_port_used_when_data_port_absent(self):
         self.assertEqual(self._resolve(None, ':41233'), 41233)
 
-    def test_auto_when_neither_given(self):
+    def test_env_used_when_cli_and_bind_absent(self):
+        self.assertEqual(self._resolve(None, '192.168.1.5', env_value='51000'), 51000)
+
+    def test_cli_beats_env(self):
+        self.assertEqual(self._resolve(50000, '192.168.1.5', env_value='51000'), 50000)
+
+    def test_bind_beats_env(self):
+        self.assertEqual(self._resolve(None, ':41233', env_value='51000'), 41233)
+
+    def test_auto_when_nothing_given(self):
         self.assertEqual(self._resolve(None, '192.168.1.5'), 0)
+
+    def test_out_of_range_env_raises(self):
+        with self.assertRaises(ValueError):
+            self._resolve(None, '192.168.1.5', env_value='99999')
+
+
+class PortRangeTests(unittest.TestCase):
+    def test_data_port_arg_rejects_out_of_range(self):
+        parse = udpfs._port_arg('--data-port')
+        self.assertEqual(parse('41233'), 41233)
+        self.assertEqual(parse('0'), 0)
+        self.assertEqual(parse('0xF5F7'), 0xF5F7)  # hex like the CLI accepts
+        for bad in ('99999', '-1', '70000'):
+            with self.assertRaises(Exception):  # argparse.ArgumentTypeError
+                parse(bad)
+
+
+class TruncatedCompressedHeaderTests(unittest.TestCase):
+    """A truncated compressed file with valid magic must not report metadata --
+    _resolve_compressed_sibling would prefer this unopenable candidate over a
+    good later sibling and OPEN would then fail with EIO."""
+
+    def _write(self, path, data):
+        with open(path, 'wb') as f:
+            f.write(data)
+
+    def test_truncated_cso_with_valid_magic_is_rejected(self):
+        import struct as _struct
+        import tempfile
+        d = tempfile.mkdtemp()
+        try:
+            # Valid CISO magic + a size field, but only 16 bytes -- shorter than
+            # the 24-byte header the wrapper needs.
+            magic = _struct.pack('<I', udpfs.CSO_MAGIC)
+            truncated = magic + b'\x00' * 4 + _struct.pack('<Q', 700 * 1024 * 1024)
+            self.assertEqual(len(truncated), 16)
+            p = os.path.join(d, 'Game.cso')
+            self._write(p, truncated)
+            self.assertIsNone(udpfs.get_compressed_info(p))
+        finally:
+            import shutil as _shutil
+            _shutil.rmtree(d, ignore_errors=True)
+
+    def test_full_length_header_still_parses(self):
+        import struct as _struct
+        import tempfile
+        d = tempfile.mkdtemp()
+        try:
+            magic = _struct.pack('<I', udpfs.CSO_MAGIC)
+            header = (magic + _struct.pack('<I', 24)
+                      + _struct.pack('<Q', 700 * 1024 * 1024)
+                      + _struct.pack('<I', 2048) + b'\x01\x00\x00\x00')
+            self.assertEqual(len(header), 24)
+            p = os.path.join(d, 'Game.cso')
+            self._write(p, header)
+            info = udpfs.get_compressed_info(p)
+            self.assertIsNotNone(info)
+            self.assertEqual(info[1], 'CSO')
+        finally:
+            import shutil as _shutil
+            _shutil.rmtree(d, ignore_errors=True)
 
 
 class ExtensionAliasTests(unittest.TestCase):

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -290,9 +290,15 @@ def get_compressed_info(file_path: str) -> Optional[Tuple[int, str]]:
                 return (uncompressed_size, 'CHD')
             
             header = f.read(24)
-            if len(header) < 16:
+            # The ZSO/CSO wrappers need the full 24-byte header (magic, header
+            # size, uncompressed size, block size, version, align) before they
+            # can open the file. A shorter read -- a truncated or interrupted
+            # download that happens to carry valid magic -- must NOT report
+            # metadata: _resolve_compressed_sibling would then prefer this
+            # unopenable candidate over a good later sibling and OPEN would fail.
+            if len(header) < 24:
                 return None
-            
+
             magic = header[0:4]
             magic_int = struct.unpack('<I', magic)[0]
             
@@ -2397,6 +2403,44 @@ def _duration_arg(label):
     return parse
 
 
+def _parse_port(value):
+    """A UDP port in range. int(x, 0) so 0x.. hex is accepted, like the CLI."""
+    port = int(value, 0) if isinstance(value, str) else int(value)
+    if not 0 <= port <= 65535:
+        raise ValueError("port {} out of range 0-65535".format(port))
+    return port
+
+
+def _port_arg(label):
+    """argparse type for a port: reject an out-of-range value with a clean usage
+    error instead of letting it reach socket.bind() and raise there."""
+    def parse(value):
+        try:
+            return _parse_port(value)
+        except ValueError as e:
+            raise argparse.ArgumentTypeError(
+                "invalid {} {!r}: {}".format(label, value, e))
+    return parse
+
+
+def resolve_data_port(cli_data_port, bind_port, env_value):
+    """The data port, by precedence: explicit --data-port > a port in --bind >
+    DATA_PORT env > auto (0).
+
+    cli_data_port is None when --data-port was absent -- 0 is a real value
+    ("pick an ephemeral port") and must not be treated as unset. env_value is
+    the raw DATA_PORT string (or None). Raises ValueError on an out-of-range
+    env value so the caller can turn it into a clean usage error.
+    """
+    if cli_data_port is not None:
+        return cli_data_port
+    if bind_port is not None:
+        return bind_port
+    if env_value:
+        return _parse_port(env_value)
+    return 0
+
+
 def split_bind(value) -> Tuple[str, Optional[int]]:
     """(ip, port|None) from 'IP', 'IP:PORT' or ':PORT'.
 
@@ -2485,7 +2529,7 @@ def main():
         help='Number of decompressed blocks to cache per file (default: 32; env: COMPRESSION_CACHE_SIZE)'
     )
     parser.add_argument(
-        '--data-port', type=lambda x: int(x, 0), default=None,
+        '--data-port', type=_port_arg('--data-port'), default=None,
         help='Pin the UDP data port instead of using an ephemeral one (default: 0 = '
              'auto). Use when the data endpoint must be predictable for a manual '
              'firewall rule, port forwarding, or NAT. Ignored with --single-port '
@@ -2552,11 +2596,13 @@ def main():
     except ValueError as e:
         parser.error(str(e))
     args.bind = bind_ip
-    if args.data_port is None:
-        if bind_port is not None:
-            args.data_port = bind_port
-        else:
-            args.data_port = _env_int('DATA_PORT', 0)
+    # DATA_PORT (env) skips argparse's type check, so its range is validated
+    # inside resolve_data_port -- DATA_PORT=99999 must fail here, not at bind().
+    try:
+        args.data_port = resolve_data_port(
+            args.data_port, bind_port, os.environ.get('DATA_PORT'))
+    except ValueError as e:
+        parser.error("invalid DATA_PORT: {}".format(e))
 
     if not args.block_device and not args.root_dir:
         parser.error("At least one of --block-device or --root-dir is required")


### PR DESCRIPTION
Follow-up to the udpfsd-parity work (#104). CodeRabbit flagged these on #105, but they're on UDPFS code that's already in `main`, so they land here.

### Truncated compressed header → wrong sibling → EIO (the real one)

`get_compressed_info()` read 24 bytes but only required **16** before reporting `(size, 'CSO'/'ZSO')`. A truncated or interrupted `.cso`/`.zso` that still carried valid magic therefore looked valid. Because `_resolve_compressed_sibling()` prefers a *parseable* sibling, that unopenable candidate could be chosen over a good later sibling of the same name — and OPEN would then fail with `EIO` on the console.

Now it requires the full 24-byte header. Regression fixtures: a 16-byte truncated header (rejected) and a real 24-byte header (parses).

### `--data-port 99999` died at `socket.bind()`

`--data-port` and `DATA_PORT` accepted out-of-range values that reached `socket.bind()` and raised an uncaught `OSError`. Added a range-validating argparse type, applied to the env value on the same path:
```
$ udpfs_server.py --data-port 99999 ...
udpfs_server.py: error: argument --data-port: invalid --data-port '99999': port 99999 out of range 0-65535
```

### Test the resolver, not a copy of it

The data-port precedence test mirrored `main()`'s logic (and omitted the `DATA_PORT` branch), so it could pass while `main()` drifted. Extracted the precedence into `resolve_data_port()` (CLI > port-in-`--bind` > `DATA_PORT` > auto) and pointed the test at it, adding env-precedence and out-of-range cases.

Full suite passes; compression/pathguard/multiclient selftests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)