### PR TITLE
GUI: recommend a server, and clarify the confusing bind field

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -201,6 +201,16 @@ class ServerCard(ttk.LabelFrame):
         self.columnconfigure(1, weight=1)
         row = 0
 
+        # A one-line recommendation badge so a beginner knows which server to
+        # reach for (UDPFS recommended, UDPBD legacy) instead of guessing.
+        if self.server.recommendation:
+            colour = (COLOR_RUNNING if self.server.recommendation_kind == "good"
+                      else COLOR_STOPPED)
+            ttk.Label(self, text=self.server.recommendation,
+                      foreground=colour, style="CardStatus.TLabel").grid(
+                row=row, column=0, columnspan=3, sticky="w", padx=4, pady=(2, 0))
+            row += 1
+
         # header: blurb + status + start/stop
         ttk.Label(self, text=self.server.blurb, wraplength=560,
                   style="CardMuted.TLabel").grid(row=row, column=0, columnspan=3,

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -86,6 +86,11 @@ class ServerDef:
     _build_argv: Callable
     default_port: Optional[int] = None
     port_is_hex: bool = False  # UDP servers are conventionally written in hex
+    # A short guidance badge shown on the tab/card so a beginner isn't choosing
+    # between three equal-looking servers. kind drives the colour: "good" for
+    # the recommended one, "legacy" for a superseded one, "" for neutral.
+    recommendation: str = ""
+    recommendation_kind: str = ""
     share_hint: str = ""  # what the user types into OPL's "Share" field, if any
     module_file: Optional[str] = None  # python: file to import
     module_dir: Optional[str] = None  # python: dir added to sys.path (sibling imports)
@@ -253,8 +258,11 @@ SMBV1 = ServerDef(
 UDPFS = ServerDef(
     key="udpfs",
     label="UDPFS server",
-    blurb="Serve a folder and/or a disk image over UDP. Newer protocol; can "
-    "transparently decompress CHD/CSO/ZSO.",
+    blurb="Serve a folder and/or a disk image over UDP. The newer protocol and "
+    "the best choice for most setups; can transparently decompress CHD/CSO/ZSO. "
+    "The PS2 finds it automatically — nothing to type in your loader.",
+    recommendation="Recommended for most setups",
+    recommendation_kind="good",
     runtime="python",
     default_port=0xF5F6,
     port_is_hex=True,
@@ -288,7 +296,11 @@ UDPFS = ServerDef(
                    "manual firewall rule, port forwarding, or a strict NAT can't "
                    "follow the auto port, which changes every launch. Setting it "
                    "also adds a matching firewall rule. Ignored in Modulo mode."),
-        Field("bind", "Bind address", "text", default="", advanced=True),
+        Field("bind", "Bind address", "text", default="", advanced=True,
+              help="Leave blank. The server already listens for the PS2 on every "
+                   "network interface — you do NOT need to set 0.0.0.0. This only "
+                   "pins the source address of the data connection, for unusual "
+                   "multi-NIC setups."),
         Field("peer_timeout", "Idle timeout (seconds)", "text", default="3600",
               advanced=True,
               help="Drop a console after this long with no traffic, closing the "
@@ -307,8 +319,11 @@ UDPFS = ServerDef(
 UDPBD = ServerDef(
     key="udpbd",
     label="UDPBD server",
-    blurb="Serve a single disk image as a block device over UDP. The PS2 finds "
-    "the server automatically (broadcast).",
+    blurb="Serve a single disk image as a block device over UDP. Largely "
+    "superseded by UDPFS — use UDPFS unless you specifically need UDPBD. The "
+    "PS2 finds the server automatically (broadcast).",
+    recommendation="Legacy — prefer UDPFS",
+    recommendation_kind="legacy",
     runtime="python",
     default_port=0xBDBD,
     port_is_hex=True,

--- a/tests/test_linux_parity.py
+++ b/tests/test_linux_parity.py
@@ -118,6 +118,29 @@ class MacosIfconfigParseTests(unittest.TestCase):
         self.assertEqual(ips, ["192.168.1.20"])
 
 
+class ServerRecommendationTests(unittest.TestCase):
+    """A beginner shouldn't have to guess between three equal-looking servers."""
+
+    def test_udpfs_is_recommended(self):
+        udpfs = servers.REGISTRY["udpfs"]
+        self.assertEqual(udpfs.recommendation_kind, "good")
+        self.assertTrue(udpfs.recommendation)
+
+    def test_udpbd_is_legacy(self):
+        udpbd = servers.REGISTRY["udpbd"]
+        self.assertEqual(udpbd.recommendation_kind, "legacy")
+        self.assertIn("UDPFS", udpbd.recommendation + udpbd.blurb)
+
+    def test_smbv1_is_neutral(self):
+        # The classic; not badged either way so it doesn't read as second-class.
+        self.assertEqual(servers.REGISTRY["smbv1"].recommendation, "")
+
+    def test_bind_help_says_you_need_not_set_it(self):
+        # The tester assumed he had to set 0.0.0.0; discovery is already all-iface.
+        bind = next(f for f in servers.REGISTRY["udpfs"].fields if f.key == "bind")
+        self.assertIn("every network interface", bind.help)
+
+
 class WindowsOnlyFieldTests(unittest.TestCase):
     def test_take_445_is_flagged_windows_only(self):
         smb = servers.REGISTRY["smbv1"]


### PR DESCRIPTION
**Checkpoint 6/6.** Addresses the tester's "the GUI isn't clear" + the bind-field confusion.

**Recommend a server.** A beginner faced three equal-looking tabs with no steer. A one-line badge now sits in the card header, from two new `ServerDef` fields:
- **UDPFS** → "Recommended for most setups" (green)
- **UDPBD** → "Legacy — prefer UDPFS" (muted)
- **SMBv1** → neutral (the classic; not badged, so it doesn't read as second-class)

Blurbs updated to match.

**Fix the exact bind confusion.** Flying Spike set the bind address to `0.0.0.0`, assuming discovery needed it — it doesn't; the server already listens on every interface. That field had **no help text**; it now says so plainly and explains it only pins the data connection's source address.

Note: *progressive disclosure already exists* — port/bind/data-port/timeout are behind the **Advanced** toggle — so the real gap was guidance, not hiding.

**Verified:** headless GUI build confirms the badges render on UDPFS/UDPBD and not SMB. New tests lock the recommendation metadata + the bind help. **178 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)