### PR TITLE
GUI: theme the scrollbars (the tester's "awful" one)

### DIFF
--- a/launcher/main.py
+++ b/launcher/main.py
@@ -214,6 +214,36 @@ def _apply_gui_review_fixes(gui):
                   darkcolor=[("selected", palette["panel3"]),
                              ("!selected", palette["panel"])])
 
+        # Scrollbars: clam's default is a chunky, arrowed, pale bar that clashes
+        # with the dark theme (nothing styled it before). Drop the arrow buttons
+        # for a clean trough + thumb, colour the thumb to the theme, and brighten
+        # it to the accent on hover/drag. The layout override is wrapped because
+        # element names can differ across ttk builds -- if it fails we still get
+        # the colours, just with the default arrows.
+        for _orient, _trough in (("Vertical", "ns"), ("Horizontal", "ew")):
+            _name = _orient + ".TScrollbar"
+            try:
+                style.layout(_name, [
+                    (_orient + ".Scrollbar.trough", {
+                        "sticky": _trough,
+                        "children": [(_orient + ".Scrollbar.thumb",
+                                      {"expand": "1", "sticky": "nswe"})],
+                    }),
+                ])
+            except gui.tk.TclError:
+                pass
+            style.configure(_name, gripcount=0, borderwidth=0, relief="flat",
+                            troughcolor=palette["panel"],
+                            background=palette["panel3"],
+                            bordercolor=palette["panel"],
+                            lightcolor=palette["panel3"],
+                            darkcolor=palette["panel3"],
+                            arrowcolor=palette["muted"])
+            style.map(_name,
+                      background=[("pressed", palette["accent"]),
+                                  ("active", palette["accent2"]),
+                                  ("!active", palette["panel3"])])
+
     def configure_window(self):
         screen_width = max(640, self.root.winfo_screenwidth())
         screen_height = max(480, self.root.winfo_screenheight())


### PR DESCRIPTION
**Checkpoint 7/7** (targeted visual polish — the bounded, non-subjective slice).

Nothing styled the scrollbars, so they fell back to clam's chunky, arrowed, pale default — jarring against the dark PS2 theme, and the exact thing Flying Spike called "awful."

Restyled both orientations: arrow buttons dropped for a clean **trough + thumb**, thumb coloured to the theme (`panel3` on `panel`), brightening to the accent on hover/drag. The arrowless layout override is wrapped in `try/except` so an unusual ttk build just keeps default arrows with the new colours instead of erroring.

**Verified:** headless build confirms the style resolves (thumb/trough colours applied, layout arrowless) and the GUI constructs cleanly. **178 tests pass.**

The bigger *"make it unique"* redesign and a **Linux system tray** are taste-/dependency-decisions, not one-shot work — I wrote up options + feasibility separately (Linux tray needs a D-Bus dep + has a stock-GNOME caveat; redesign is best prototyped one direction at a time). See the summary in chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)