### PR TITLE
Address post-merge review findings (#107/#108/#109/#110/#111)

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -347,10 +347,23 @@ jobs:
         run: |
           set +e
           # A pre-release is never the "Latest" release, so this alone keeps the
-          # badge on the newest tagged vX.Y.Z.
-          gh release edit "$TAG" --prerelease \
-            || echo "note: could not re-assert pre-release flag on ${TAG}"
-          exit 0
+          # badge on the newest tagged vX.Y.Z. Retry once, then VERIFY -- GitHub
+          # has accepted this call without applying the flag before. If the build
+          # is still mis-flagged it would steal Latest right now, so fail loudly
+          # (the release is already published; a red run flags it for a human,
+          # and the prune keys on the tag so it is still cleaned up next run).
+          for attempt in 1 2; do
+            gh release edit "$TAG" --prerelease && break
+            echo "attempt ${attempt}: could not set --prerelease on ${TAG}"
+            sleep 5
+          done
+          pre=$(gh release view "$TAG" --json isPrerelease --jq .isPrerelease 2>/dev/null)
+          if [ "$pre" = "true" ]; then
+            echo "confirmed ${TAG} is a pre-release"
+            exit 0
+          fi
+          echo "::error::${TAG} is not flagged pre-release; it could steal the Latest badge"
+          exit 1
 
       - name: Prune old development pre-releases
         # Every push to main publishes one of these, and nothing used to remove
@@ -375,9 +388,11 @@ jobs:
           # Newest first. Selection is done here; "how many to keep" is applied
           # with tail below rather than inside jq, so the slice stays trivial to
           # reason about and needs no jq binary (gh has jq built in).
+          # Match the EXACT generated shape main-<run>-<7-hex-sha>, not just the
+          # prefix, so a hand-made tag like main-123-hotfix is never selected.
           gh release list --limit 200 --json tagName,isPrerelease,createdAt \
             --jq '[ .[]
-                    | select(.tagName | test("^main-[0-9]+-"))
+                    | select(.tagName | test("^main-[0-9]+-[0-9a-f]{7}$"))
                   ]
                   | sort_by(.createdAt) | reverse | .[].tagName' > all_dev.txt || exit 0
           total=$(grep -c . all_dev.txt)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,9 +207,18 @@ jobs:
             'exec "$HERE/usr/bin/PS2Servers" "$@"' \
             > "$APPDIR/AppRun"
           chmod +x "$APPDIR/AppRun" "$APPDIR/usr/bin/PS2Servers"
+          # Pin appimagetool to a tagged release and verify its digest before we
+          # execute it. 'continuous' is a rolling tag -- pinning + a checksum
+          # gate means a changed or tampered build can't silently run on the
+          # runner and wrap itself around our binary. set -e aborts the step on
+          # a mismatch (and the step is continue-on-error, so a bad hash drops
+          # the AppImage without blocking the real Linux downloads).
+          APPIMAGETOOL_VERSION="1.9.1"
+          APPIMAGETOOL_SHA256="ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0"
           TOOL="$RUNNER_TEMP/appimagetool"
           curl -fsSL -o "$TOOL" \
-            https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+            "https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VERSION}/appimagetool-x86_64.AppImage"
+          echo "${APPIMAGETOOL_SHA256}  ${TOOL}" | sha256sum -c -
           chmod +x "$TOOL"
           mkdir -p out
           # --appimage-extract-and-run runs the tool without needing FUSE on the runner.
@@ -256,11 +265,11 @@ jobs:
           | OS | Recommended | Also available |
           | --- | --- | --- |
           | Windows x64 | \`PS2Servers-windows-x64-folder.zip\` (folder, AV-clean) | \`PS2Servers-windows-x64.zip\` (single file) |
-          | Linux x64 | \`PS2Servers-x86_64.AppImage\` (desktop/menu integration) or \`PS2Servers-linux-x64\` | \`PS2Servers-linux-x64-folder.tar.gz\` (folder; use if /tmp is noexec) |
+          | Linux x64 | \`PS2Servers-linux-x64\` (single file) | \`PS2Servers-x86_64.AppImage\` (desktop/menu integration, newer) or \`PS2Servers-linux-x64-folder.tar.gz\` (folder; use if /tmp is noexec) |
           | macOS — Apple Silicon | \`PS2Servers-macos-arm64.zip\` | |
           | macOS — Intel | \`PS2Servers-macos-x64.zip\` | |
 
-          Run it: **Windows — unzip the folder build and run \`PS2Servers.exe\` from inside the folder.** The single-file \`.exe\` works too but trips some antivirus heuristics; the folder build comes up clean. Linux — the \`.AppImage\` gives you desktop/menu shortcuts (via AppImageLauncher); \`chmod +x\` it and run, or use the plain \`PS2Servers-linux-x64\`. macOS — unzip and right-click → Open (unsigned).
+          Run it: **Windows — unzip the folder build and run \`PS2Servers.exe\` from inside the folder.** The single-file \`.exe\` works too but trips some antivirus heuristics; the folder build comes up clean. Linux — \`chmod +x PS2Servers-linux-x64\` and run it; or try the newer \`.AppImage\` for desktop/menu shortcuts (via AppImageLauncher). macOS — unzip and right-click → Open (unsigned).
 
           Compression note: ZSO/LZ4 support is bundled. CHD support is backed by a libchdr native library built from source during release packaging.
 
@@ -310,6 +319,15 @@ jobs:
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4
         with:
           subject-path: out/${{ matrix.folder_asset }}
+
+      - name: Attest Linux AppImage provenance
+        # Same non-blocking contract as the AppImage build itself: only on Linux,
+        # and never fail the release if the AppImage wasn't produced.
+        if: runner.os == 'Linux' && matrix.folder_asset != ''
+        continue-on-error: true
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4
+        with:
+          subject-path: out/PS2Servers-x86_64.AppImage
 
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/README.md
+++ b/README.md
@@ -251,8 +251,7 @@ CSO decompression is built in (it uses the standard library). The *optional*
 compressed formats do have dependencies: ZSO needs the `lz4` package and CHD
 needs a native `libchdr` library — install those if you want ZSO/CHD, and any
 format whose library is missing is simply left untouched (uncompressed images
-are unaffected). This is the box that is already on 24/7 next to the console, so
-running the server there is often ideal.
+are unaffected).
 
 (The **minimum requirements** table above describes the *packaged GUI app*, which
 is x64/Apple-Silicon only. Running a server straight from source, as here, has no

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@
 
 Standard PS2 network servers — **SMBv1 (RiptOPL)**, **UDPFS**, and **UDPBD** — for
 loading PlayStation 2 games, apps, and media over a LAN. These are the protocols
-PS2 homebrew uses to load over a network, so they are not OPL-only: anything that
-speaks SMB, UDPFS, or UDPBD works — [Open PS2 Loader](https://github.com/ps2homebrew/Open-PS2-Loader)
+PS2 homebrew uses to load over a network, so they are not OPL-only. Loaders
+confirmed working include [Open PS2 Loader](https://github.com/ps2homebrew/Open-PS2-Loader)
 (OPL) and its forks (RiptOPL, wOPL), plus **NHDDL**, **wLaunchELF-R3Z**, **SMS**,
-**POPStarter / POPSLoader**, and other network-capable homebrew. A small
-**GUI launcher** runs them all without touching a terminal.
+and **POPStarter / POPSLoader**; other network-capable homebrew that speaks these
+protocols should work too. (One known exception: **Modulo** doesn't follow the
+UDPFS protocol and needs the launcher's dedicated Modulo mode — see below.) A
+small **GUI launcher** runs them all without touching a terminal.
 
 ## Quick start — the launcher
 
@@ -161,7 +163,7 @@ Python and no heavy runtime for the packaged app.
 | OS | Windows 10/11 (x64), Linux (x64), or macOS (Apple Silicon or Intel) |
 | Packaged app | No Python required — the download bundles everything |
 | From source | Python 3 with Tkinter (Linux: `sudo apt install python3-tk`); official builds use Python 3.12 |
-| Hardware | Any modern 64-bit PC — the launcher is a small Tkinter GUI, not Electron/Qt |
+| Hardware | Any modern 64-bit PC for the **packaged GUI app** (x64 / Apple Silicon). Running a server from source needs only Python 3 and works on any architecture — see "On a Raspberry Pi, NAS, or other non-x64 box" below. |
 | Network | Wired or Wi‑Fi LAN on the same subnet as the PS2 (wired recommended for large games) |
 | Disk | A few hundred MB for the app, plus room for your game files |
 
@@ -170,7 +172,7 @@ Python and no heavy runtime for the packaged app.
 | | Requirement |
 |---|---|
 | Console | A PS2 that boots homebrew (FreeMcBoot / FreeDVDBoot / modchip / etc.) |
-| Loader | Any network-capable PS2 homebrew — OPL, RiptOPL, wOPL, NHDDL, wLaunchELF-R3Z, SMS, POPStarter / POPSLoader, … |
+| Loader | Network-capable PS2 homebrew — confirmed with OPL, RiptOPL, wOPL, NHDDL, wLaunchELF-R3Z, SMS, POPStarter / POPSLoader (Modulo needs the launcher's Modulo mode) |
 | Network adapter | The PS2 Ethernet adapter — built into slims; SCPH‑10281 on fat units |
 | Emulator (optional) | PCSX2 with a configured network adapter also works for testing |
 
@@ -237,17 +239,24 @@ python -m launcher --list            # show servers available on this machine
 
 The servers are pure Python standard library, so they run on **any machine with
 Python 3** — a Raspberry Pi (any model), an ARM/MIPS NAS, an OpenWrt router —
-even where there is no packaged build for that architecture. No pip installs, no
-GUI needed; point a server at your games folder and it serves over the LAN just
-the same:
+even where there is no packaged build for that architecture. Baseline serving
+needs no pip installs and no GUI; point a server at your games folder and it
+serves over the LAN just the same:
 
 ```sh
 python3 udpfs_server/udpfs_server.py -d /srv/ps2games
 ```
 
-CSO decompression is built in (it uses the standard library); ZSO and CHD light
-up automatically if the optional `lz4` / `libchdr` libraries are present, and any
-format whose library is missing is simply left untouched. This is the box that is
+CSO decompression is built in (it uses the standard library). The *optional*
+compressed formats do have dependencies: ZSO needs the `lz4` package and CHD
+needs a native `libchdr` library — install those if you want ZSO/CHD, and any
+format whose library is missing is simply left untouched (uncompressed images
+are unaffected). This is the box that is already on 24/7 next to the console, so
+running the server there is often ideal.
+
+(The **minimum requirements** table above describes the *packaged GUI app*, which
+is x64/Apple-Silicon only. Running a server straight from source, as here, has no
+such limit — any architecture with Python 3 works.) This is the box that is
 already on 24/7 next to the console, so running the server there is often ideal.
 
 ## Build the packaged app

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -1002,7 +1002,7 @@ class LauncherApp:
                 self.stop_all()
                 if self._tray:
                     self._tray.stop()
-                self.root.destroy()
+                self._destroy_root()
             else:
                 self.saved.pop("pending_direct_link", None)
                 self._save()
@@ -1281,7 +1281,7 @@ class LauncherApp:
                 self.stop_all()
                 if self._tray:
                     self._tray.stop()
-                self.root.destroy()
+                self._destroy_root()
             else:
                 self.saved.pop("pending_direct_link_off", None)
                 self._save()
@@ -1383,7 +1383,7 @@ class LauncherApp:
                 self.stop_all()
                 if self._tray:
                     self._tray.stop()
-                self.root.destroy()
+                self._destroy_root()
             else:
                 self._set_direct_checkbox(False)
                 self._set_direct_status(
@@ -1541,7 +1541,7 @@ class LauncherApp:
                     self.stop_all()  # free ports before the elevated instance starts
                     if self._tray:
                         self._tray.stop()
-                    self.root.destroy()
+                    self._destroy_root()
                 else:
                     messagebox.showerror(
                         "Elevation failed",
@@ -1720,7 +1720,7 @@ class LauncherApp:
                 self.stop_all()
                 if self._tray:
                     self._tray.stop()
-                self.root.destroy()
+                self._destroy_root()
             else:
                 self.saved.pop("pending_firewall_allow", None)
                 self._save()
@@ -1813,7 +1813,7 @@ class LauncherApp:
                 self.stop_all()
                 if self._tray:
                     self._tray.stop()
-                self.root.destroy()
+                self._destroy_root()
             else:
                 self.saved.pop("pending_cleanup", None)
                 self._save()
@@ -2228,10 +2228,18 @@ class LauncherApp:
             "This will stop running servers:\n\n{}\n\nContinue?".format(
                 ", ".join(running)))
 
+    def _destroy_root(self):
+        """The ONLY place the root is destroyed. Sets _shutting_down first so the
+        periodic loops (_drain_tray / _drain_logs / _poll_status) and any pending
+        worker callback stop touching the root -- otherwise a reschedule or a
+        queued after() raises TclError. Every teardown path routes through here,
+        including the relaunch/elevation flows that used to destroy directly."""
+        self._shutting_down = True
+        self.root.destroy()
+
     def _shutdown_app(self):
-        # Stop the periodic loops (_drain_tray / _drain_logs / _poll_status) and
-        # any pending worker callback from rescheduling onto the root we are
-        # about to destroy -- otherwise the reschedule raises TclError.
+        # Stop the loops before the (up to a few seconds of) child termination,
+        # not just at destroy time, so nothing reschedules during stop_all.
         self._shutting_down = True
         self._save()
         # hide first so the (up to a few seconds of) child termination doesn't
@@ -2240,7 +2248,7 @@ class LauncherApp:
         self.stop_all()
         if self._tray:
             self._tray.stop()
-        self.root.destroy()
+        self._destroy_root()
 
     # -- system tray (Windows) -------------------------------------------- #
     def _on_window_close(self):

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -809,6 +809,18 @@ class LauncherLifecycleTests(unittest.TestCase):
             app.saved["direct_link"])
         app.root.after.assert_called_once_with(600, app._poll_status)
 
+    def test_poll_status_does_not_reschedule_during_shutdown(self):
+        # Once _shutdown_app/_destroy_root has flagged shutdown, the loop must
+        # not schedule another tick onto the root about to be destroyed.
+        app = self.app()
+        app.procs = {}
+        app._direct_expected = False
+        app._direct_proc = None
+        app.root = mock.Mock()
+        app._shutting_down = True
+        LauncherApp._poll_status(app)
+        app.root.after.assert_not_called()
+
     def test_rehome_exit_triggers_coexist_not_rollback(self):
         app = self.app()
         app.saved["direct_link"]["enabled"] = True

--- a/tests/test_linux_parity.py
+++ b/tests/test_linux_parity.py
@@ -124,12 +124,14 @@ class ServerRecommendationTests(unittest.TestCase):
     def test_udpfs_is_recommended(self):
         udpfs = servers.REGISTRY["udpfs"]
         self.assertEqual(udpfs.recommendation_kind, "good")
-        self.assertTrue(udpfs.recommendation)
+        self.assertEqual(udpfs.recommendation, "Recommended for most setups")
 
     def test_udpbd_is_legacy(self):
         udpbd = servers.REGISTRY["udpbd"]
         self.assertEqual(udpbd.recommendation_kind, "legacy")
-        self.assertIn("UDPFS", udpbd.recommendation + udpbd.blurb)
+        # Assert the badge text itself, not badge-or-blurb, so a missing badge
+        # can't be masked by the blurb still mentioning UDPFS.
+        self.assertEqual(udpbd.recommendation, "Legacy — prefer UDPFS")
 
     def test_smbv1_is_neutral(self):
         # The classic; not badged either way so it doesn't read as second-class.
@@ -138,7 +140,9 @@ class ServerRecommendationTests(unittest.TestCase):
     def test_bind_help_says_you_need_not_set_it(self):
         # The tester assumed he had to set 0.0.0.0; discovery is already all-iface.
         bind = next(f for f in servers.REGISTRY["udpfs"].fields if f.key == "bind")
+        self.assertIn("Leave blank", bind.help)
         self.assertIn("every network interface", bind.help)
+        self.assertIn("source address", bind.help)
 
 
 class WindowsOnlyFieldTests(unittest.TestCase):


### PR DESCRIPTION
Consolidated follow-up for the legit CodeRabbit findings on the just-merged checkpoint PRs.

### Prune workflow (from #107)
- **Tag selector now matches the exact `main-<run>-<7hex>` shape**, so a hand-made tag like `main-123-hotfix` can never be selected for deletion.
- **The "ensure pre-release" step now retries + verifies** `isPrerelease`, failing the run if the dev build is still mis-flagged (it would steal Latest), instead of silently `exit 0`.

### Shutdown race (from #108)
Several relaunch/elevation paths called `self.root.destroy()` **directly** without setting `_shutting_down`, so a queued worker `after(0,…)` could race the destroy → `TclError`. All **7** destroy sites now route through one `_destroy_root()` helper that sets the flag first. Added a test that `_poll_status` doesn't reschedule once shutting down.

### AppImage hardening (from #110)
- **Supply chain (Major):** stop pulling `appimagetool` from the rolling `continuous` tag — pin to **1.9.1** and **verify its SHA-256** (`sha256sum -c`) before executing it. Still `continue-on-error`, so a hash mismatch drops the AppImage without blocking the real Linux downloads.
- **Release notes (Minor):** the AppImage is new/CI-smoke-tested only, so Recommended for Linux is now the plain `PS2Servers-linux-x64`; the AppImage moves to "Also available (newer)".
- **Provenance (Trivial):** added an `actions/attest` step for the AppImage, matching the primary and folder builds.

### Tests + README accuracy (from #111 / #109)
- Recommendation tests assert the **exact badge text** (not truthiness / badge-or-blurb).
- README: softened "anything that speaks the protocol works" → confirmed loaders + the **Modulo exception**; qualified "no pip installs" (baseline only; ZSO→lz4, CHD→libchdr); scoped "64-bit PC" to the packaged GUI (from-source runs any arch).

### Deliberately NOT changed — with reason
A reviewer claimed setting `--bind` restricts the whole server. **Verified against the code: it doesn't here.** The discovery/listening socket binds to `''` (all interfaces, `udpfs_server.py:502`); only the *data* socket uses the bind address (`:523`). So "only pins the source address of the data connection" is accurate — applying the suggestion would make the docs *wrong*. (Replied on that thread.)

**179 tests pass; both workflow YAMLs parse.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)