### PR TITLE
GUI: modernize the theme (one palette, cleaner surfaces, keep top tabs)

### DIFF
--- a/launcher/asset_skin.py
+++ b/launcher/asset_skin.py
@@ -67,14 +67,17 @@ def _soften_styles(root, gui):
         "bg": p["bg"],
         "surface": p["panel"],
         "surface2": p["panel2"],
+        "panel3": p["panel3"],
         "edge": p["edge"],
         "text": p["text"],
         "muted": p["muted"],
         "accent": p["accent"],
+        "accent_hover": p["accent_hover"],
         "accent2": p["accent2"],
         "warn": p["warn"],
         "ok": p["ok"],
         "danger": p["error"],
+        "disabled": p["disabled"],
     }
 
     root.configure(background=palette["bg"])
@@ -126,14 +129,17 @@ def _soften_styles(root, gui):
                     focuscolor=palette["accent"], bordercolor=palette["edge"],
                     lightcolor=palette["edge"], darkcolor=palette["surface"])
     style.map("TButton",
-              background=[("active", palette["surface2"]), ("pressed", p["panel3"])],
-              foreground=[("disabled", p["disabled"]), ("pressed", "#ffffff")])
+              background=[("active", palette["surface2"]), ("pressed", palette["panel3"])],
+              foreground=[("disabled", palette["disabled"]), ("pressed", "#ffffff")])
     style.configure("Accent.TButton", background=palette["accent"], foreground="#ffffff",
                     padding=(12, 6), borderwidth=0)
+    # Hover/press DARKEN to accent_hover -- white text stays well above WCAG AA on
+    # both. (The light accent2 is a text colour for dark surfaces, not a fill for
+    # white text, so it is deliberately not used here.)
     style.map("Accent.TButton",
-              background=[("active", palette["accent2"]), ("pressed", palette["accent"]),
+              background=[("active", palette["accent_hover"]), ("pressed", palette["accent_hover"]),
                           ("disabled", palette["surface2"])],
-              foreground=[("disabled", p["disabled"]), ("!disabled", "#ffffff")])
+              foreground=[("disabled", palette["disabled"]), ("!disabled", "#ffffff")])
 
     # NOTE: the notebook tab bar is deliberately NOT restyled here -- main.py's
     # apply_theme is the single owner of Server.TNotebook / .Tab, so the tabs

--- a/launcher/asset_skin.py
+++ b/launcher/asset_skin.py
@@ -58,18 +58,23 @@ def _install_tab_icons(app, gui):
 
 def _soften_styles(root, gui):
     style = gui.ttk.Style(root)
+    # Share ONE palette with main.py (launcher/theme.py). This layer runs last
+    # and wins for the styles below, so sourcing the same colours here is what
+    # keeps the two theme layers from drifting into two different-looking skins.
+    from . import theme
+    p = theme.PALETTE
     palette = {
-        "bg": "#040915",
-        "surface": "#081427",
-        "surface2": "#0c1b33",
-        "edge": "#15365f",
-        "text": "#e7f2ff",
-        "muted": "#b4c6df",
-        "accent": "#009cff",
-        "accent2": "#46d9ff",
-        "warn": "#ffd45f",
-        "ok": "#5ff0bc",
-        "danger": "#ff5676",
+        "bg": p["bg"],
+        "surface": p["panel"],
+        "surface2": p["panel2"],
+        "edge": p["edge"],
+        "text": p["text"],
+        "muted": p["muted"],
+        "accent": p["accent"],
+        "accent2": p["accent2"],
+        "warn": p["warn"],
+        "ok": p["ok"],
+        "danger": p["error"],
     }
 
     root.configure(background=palette["bg"])
@@ -113,23 +118,26 @@ def _soften_styles(root, gui):
     style.configure("PageActions.TFrame", background=palette["surface"], relief="flat")
     style.configure("PageActions.TLabel", background=palette["surface"], foreground=palette["muted"])
 
-    style.configure("TButton", background=palette["surface2"], foreground=palette["text"],
-                    padding=(10, 5), borderwidth=1, focusthickness=1,
-                    focuscolor=palette["accent"])
+    # Secondary buttons: flat surface with a subtle slate edge; hover lifts one
+    # elevation step rather than jumping to a bright fill. The solid accent fill
+    # is reserved for Accent.TButton (the primary action).
+    style.configure("TButton", background=palette["surface"], foreground=palette["text"],
+                    padding=(12, 6), borderwidth=1, focusthickness=1,
+                    focuscolor=palette["accent"], bordercolor=palette["edge"],
+                    lightcolor=palette["edge"], darkcolor=palette["surface"])
     style.map("TButton",
-              background=[("active", "#12305a"), ("pressed", palette["accent"])],
-              foreground=[("disabled", "#6f7f98"), ("pressed", "#ffffff")])
+              background=[("active", palette["surface2"]), ("pressed", p["panel3"])],
+              foreground=[("disabled", p["disabled"]), ("pressed", "#ffffff")])
     style.configure("Accent.TButton", background=palette["accent"], foreground="#ffffff",
                     padding=(12, 6), borderwidth=0)
+    style.map("Accent.TButton",
+              background=[("active", palette["accent2"]), ("pressed", palette["accent"]),
+                          ("disabled", palette["surface2"])],
+              foreground=[("disabled", p["disabled"]), ("!disabled", "#ffffff")])
 
-    style.configure("Server.TNotebook", background=palette["bg"], borderwidth=0, tabmargins=(14, 8, 14, 0))
-    style.configure("Server.TNotebook.Tab", padding=(14, 8), font=("", 10, "bold"),
-                    background=palette["surface"], foreground=palette["muted"], borderwidth=1)
-    style.map("Server.TNotebook.Tab",
-              background=[("selected", "#102b53"), ("active", palette["surface2"]),
-                          ("!selected", palette["surface"])],
-              foreground=[("selected", palette["accent2"]), ("active", palette["text"]),
-                          ("!selected", palette["muted"])])
+    # NOTE: the notebook tab bar is deliberately NOT restyled here -- main.py's
+    # apply_theme is the single owner of Server.TNotebook / .Tab, so the tabs
+    # have exactly one definition to reason about.
 
 
 def _install_page_controls(app, gui):

--- a/launcher/asset_skin.py
+++ b/launcher/asset_skin.py
@@ -128,8 +128,11 @@ def _soften_styles(root, gui):
                     padding=(12, 6), borderwidth=1, focusthickness=1,
                     focuscolor=palette["accent"], bordercolor=palette["edge"],
                     lightcolor=palette["edge"], darkcolor=palette["surface"])
+    # State order matters: a pressed widget is ALSO active, and ttk uses the
+    # first matching statespec -- so pressed must come before active or the
+    # click feedback (panel3) never shows.
     style.map("TButton",
-              background=[("active", palette["surface2"]), ("pressed", palette["panel3"])],
+              background=[("pressed", palette["panel3"]), ("active", palette["surface2"])],
               foreground=[("disabled", palette["disabled"]), ("pressed", "#ffffff")])
     style.configure("Accent.TButton", background=palette["accent"], foreground="#ffffff",
                     padding=(12, 6), borderwidth=0)
@@ -137,8 +140,8 @@ def _soften_styles(root, gui):
     # both. (The light accent2 is a text colour for dark surfaces, not a fill for
     # white text, so it is deliberately not used here.)
     style.map("Accent.TButton",
-              background=[("active", palette["accent_hover"]), ("pressed", palette["accent_hover"]),
-                          ("disabled", palette["surface2"])],
+              background=[("disabled", palette["surface2"]), ("pressed", palette["accent_hover"]),
+                          ("active", palette["accent_hover"])],
               foreground=[("disabled", palette["disabled"]), ("!disabled", "#ffffff")])
 
     # NOTE: the notebook tab bar is deliberately NOT restyled here -- main.py's

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -29,7 +29,7 @@ def _direct_link_experimental():
     """Non-Windows: the setup path is real but unverified on hardware."""
     return platform.system() in ("Linux", "Darwin")
 
-from . import config, directlink, elevate, netinfo, posix_firewall, tray, windows_setup
+from . import config, directlink, elevate, netinfo, posix_firewall, theme, tray, windows_setup
 from .process import ServerProcess
 from .release_metadata import DISPLAY_VERSION
 from .servers import REGISTRY, REPO_ROOT, frozen_self_exe, is_frozen, serve_command
@@ -222,7 +222,7 @@ class ServerCard(ttk.LabelFrame):
                                 style="CardStatus.TLabel")
         self.status.grid(row=row, column=0, sticky="w", padx=4, pady=(0, 4))
         self.toggle_btn = ttk.Button(self, text="Start", width=10,
-                                     command=self.on_toggle)
+                                     command=self.on_toggle, style="Accent.TButton")
         self.toggle_btn.grid(row=row, column=2, sticky="e", padx=4, pady=(0, 4))
         if not self.server.is_available():
             self.status.config(text="n/a on this OS", foreground=COLOR_ERROR)
@@ -666,9 +666,12 @@ class LauncherApp:
         self.terminal_tab = ttk.Frame(self.nb)
         self.terminal_tab.rowconfigure(0, weight=1)
         self.terminal_tab.columnconfigure(0, weight=1)
+        _p = theme.PALETTE
         self.terminal = tk.Text(self.terminal_tab, height=16, wrap="none",
-                                state="disabled", background="#101418",
-                                foreground="#d8dee9", insertbackground="#d8dee9")
+                                state="disabled", background=_p["entry"],
+                                foreground=_p["text"], insertbackground=_p["accent"],
+                                selectbackground=_p["panel3"], selectforeground=_p["text"],
+                                borderwidth=0, highlightthickness=0)
         scroll = ttk.Scrollbar(self.terminal_tab, orient="vertical",
                                command=self.terminal.yview)
         self.terminal.configure(yscrollcommand=scroll.set)
@@ -775,7 +778,12 @@ class LauncherApp:
         text_frame.grid(row=row, column=0, sticky="nsew", padx=8, pady=8)
         text_frame.rowconfigure(0, weight=1)
         text_frame.columnconfigure(0, weight=1)
-        text = tk.Text(text_frame, wrap="word", height=18, state="normal")
+        _p = theme.PALETTE
+        text = tk.Text(text_frame, wrap="word", height=18, state="normal",
+                       background=_p["panel"], foreground=_p["text"],
+                       insertbackground=_p["accent"], selectbackground=_p["panel3"],
+                       selectforeground=_p["text"], borderwidth=0,
+                       highlightthickness=0, padx=12, pady=10)
         scroll = ttk.Scrollbar(text_frame, orient="vertical", command=text.yview)
         text.configure(yscrollcommand=scroll.set)
         text.grid(row=0, column=0, sticky="nsew")

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -149,16 +149,18 @@ def _apply_gui_review_fixes(gui):
         style.configure("AdminNo.TLabel", background=palette["panel"], foreground=palette["warn"])
         style.configure("TButton", background=palette["panel2"], foreground=palette["text"],
                         borderwidth=1, focusthickness=1, focuscolor=palette["accent"])
+        # pressed before active: a pressed widget is also active, and ttk uses
+        # the first matching statespec, so pressed must be listed first.
         style.map("TButton",
-                  background=[("active", palette["panel3"]), ("pressed", palette["accent"])],
+                  background=[("pressed", palette["accent"]), ("active", palette["panel3"])],
                   foreground=[("disabled", palette["disabled"]), ("pressed", "#ffffff")])
         style.configure("Accent.TButton", background=palette["accent"], foreground="#ffffff",
                         borderwidth=1, focusthickness=1, focuscolor=palette["accent2"])
         # Hover/press darken to accent_hover so white text keeps its AA contrast
         # (a lighter hover would drop it below 4.5:1).
         style.map("Accent.TButton",
-                  background=[("active", palette["accent_hover"]),
-                              ("pressed", palette["accent_hover"])],
+                  background=[("pressed", palette["accent_hover"]),
+                              ("active", palette["accent_hover"])],
                   foreground=[("disabled", palette["disabled"]), ("!disabled", "#ffffff")])
         style.configure("TEntry", fieldbackground=palette["entry"], foreground=palette["text"],
                         insertcolor=palette["text"], bordercolor=palette["panel3"])

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -12,7 +12,7 @@ for testing:
 import platform
 import sys
 
-from . import app_icon
+from . import app_icon, theme
 
 
 def main(argv=None):
@@ -89,21 +89,9 @@ def _apply_gui_review_fixes(gui):
     original_launcher_init = gui.LauncherApp.__init__
     original_build = gui.LauncherApp._build
 
-    palette = {
-        "bg": "#030713",
-        "panel": "#071226",
-        "panel2": "#0b1a35",
-        "panel3": "#10254b",
-        "text": "#d9ecff",
-        "muted": "#8aa9d6",
-        "accent": "#0094ff",
-        "accent2": "#37d7ff",
-        "ok": "#46f6b1",
-        "warn": "#ffcf5a",
-        "error": "#ff426d",
-        "entry": "#07101f",
-        "disabled": "#5f6f8d",
-    }
+    # One canonical palette, shared with asset_skin._soften_styles via
+    # launcher/theme.py so the two theme layers can never drift apart again.
+    palette = theme.PALETTE
 
     # The admin section is about Windows Firewall rules, UAC, and 445 mode --
     # none of which apply on Linux/macOS. Append it only on Windows; elsewhere
@@ -129,6 +117,14 @@ def _apply_gui_review_fixes(gui):
             style.theme_use("clam")
         except gui.tk.TclError:
             pass
+
+        # The list that drops from a ttk.Combobox is a classic Tk Listbox that
+        # clam does not colour, so the LAN-IP dropdown used to open light-on-dark.
+        # option_add reaches it where ttk styling cannot.
+        root.option_add("*TCombobox*Listbox.background", palette["entry"])
+        root.option_add("*TCombobox*Listbox.foreground", palette["text"])
+        root.option_add("*TCombobox*Listbox.selectBackground", palette["accent"])
+        root.option_add("*TCombobox*Listbox.selectForeground", "#ffffff")
 
         style.configure(".",
                         background=palette["bg"],
@@ -171,11 +167,13 @@ def _apply_gui_review_fixes(gui):
         style.configure("TCheckbutton", background=palette["bg"], foreground=palette["text"])
         style.map("TCheckbutton", background=[("active", palette["panel"])])
         style.configure("TLabelframe", background=palette["panel"], foreground=palette["text"],
-                        bordercolor=palette["accent"], relief="solid")
+                        bordercolor=palette["edge"], lightcolor=palette["edge"],
+                        darkcolor=palette["panel"], relief="solid")
         style.configure("TLabelframe.Label", background=palette["bg"], foreground=palette["accent2"],
                         font=("", 10, "bold"))
         style.configure("Card.TLabelframe", background=palette["panel"], foreground=palette["text"],
-                        bordercolor="#18416f", relief="solid", borderwidth=1)
+                        bordercolor=palette["edge"], lightcolor=palette["edge"],
+                        darkcolor=palette["panel"], relief="solid", borderwidth=1)
         style.configure("Card.TLabelframe.Label", background=palette["bg"],
                         foreground=palette["accent2"], font=("", 10, "bold"))
         style.configure("Card.TFrame", background=palette["panel"])
@@ -189,16 +187,18 @@ def _apply_gui_review_fixes(gui):
         style.configure("PageActions.TFrame", background=palette["panel"], relief="flat")
         style.configure("PageActions.TLabel", background=palette["panel"], foreground=palette["muted"])
         style.configure("Admin.TFrame", background=palette["panel"], relief="solid", borderwidth=1)
+        # main.py is the single owner of the tab bar (asset_skin no longer
+        # restyles it), so this block alone decides how tabs look.
         style.configure("Server.TNotebook", background=palette["bg"], borderwidth=0,
-                        tabmargins=(6, 4, 6, 0))
+                        tabmargins=(8, 6, 8, 0))
         # Inactive tabs sit flat and muted; the selected tab is lifted with a
         # brighter fill, accent2 text, and an accent outline that ties it to the
         # page below. clam otherwise blends its own lighter fill onto the raised
         # selected tab (a washed-out, low-contrast box), so light/dark/bordercolor
         # are pinned per state to keep every tab exactly the colour asked for.
-        style.configure("Server.TNotebook.Tab", padding=(16, 8), font=("", 10, "bold"),
+        style.configure("Server.TNotebook.Tab", padding=(18, 9), font=("", 10, "bold"),
                         background=palette["panel"], foreground=palette["muted"],
-                        borderwidth=1, bordercolor="#18416f",
+                        borderwidth=1, bordercolor=palette["edge"],
                         lightcolor=palette["panel"], darkcolor=palette["panel"])
         style.map("Server.TNotebook.Tab",
                   background=[("selected", palette["panel3"]),
@@ -208,7 +208,7 @@ def _apply_gui_review_fixes(gui):
                               ("active", palette["text"]),
                               ("!selected", palette["muted"])],
                   bordercolor=[("selected", palette["accent"]),
-                               ("!selected", "#18416f")],
+                               ("!selected", palette["edge"])],
                   lightcolor=[("selected", palette["panel3"]),
                               ("!selected", palette["panel"])],
                   darkcolor=[("selected", palette["panel3"]),

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -154,8 +154,11 @@ def _apply_gui_review_fixes(gui):
                   foreground=[("disabled", palette["disabled"]), ("pressed", "#ffffff")])
         style.configure("Accent.TButton", background=palette["accent"], foreground="#ffffff",
                         borderwidth=1, focusthickness=1, focuscolor=palette["accent2"])
+        # Hover/press darken to accent_hover so white text keeps its AA contrast
+        # (a lighter hover would drop it below 4.5:1).
         style.map("Accent.TButton",
-                  background=[("active", "#12b8ff"), ("pressed", "#006fd0")],
+                  background=[("active", palette["accent_hover"]),
+                              ("pressed", palette["accent_hover"])],
                   foreground=[("disabled", palette["disabled"]), ("!disabled", "#ffffff")])
         style.configure("TEntry", fieldbackground=palette["entry"], foreground=palette["text"],
                         insertcolor=palette["text"], bordercolor=palette["panel3"])

--- a/launcher/theme.py
+++ b/launcher/theme.py
@@ -25,16 +25,16 @@ PALETTE = {
     "edge":     "#31415d",   # subtle hairline border (was a neon blue)
     "text":     "#e9eef7",   # primary text
     "muted":    "#93a3bd",   # secondary / helper text
-    "accent":   "#3f8cff",   # primary blue -- buttons, selected accents
-    "accent2":  "#74b6ff",   # lighter blue -- hints, selected-tab text
+    "accent":   "#2563eb",   # primary blue -- button fill; dark enough that
+                             # white text clears WCAG AA (~4.5:1) on it
+    "accent_hover": "#1b57d1",  # darker primary for button hover/press (keeps
+                                # white text well above AA on the active state)
+    "accent2":  "#74b6ff",   # lighter blue -- used as TEXT on dark surfaces
+                             # (hints, selected-tab label), never as a fill under
+                             # white text, so it stays bright
     "ok":       "#43d597",   # running / recommended (green)
     "warn":     "#e7b750",   # warning (amber)
     "error":    "#f16d7f",   # error / stopped-in-error (red)
     "entry":    "#0f1826",   # input fields + terminal background
     "disabled": "#5c6c88",   # disabled text
 }
-
-# Elevation aliases used by the asset-skin layer, so its local names
-# (surface/surface2/danger) map onto the canonical palette above.
-SURFACE = PALETTE["panel"]
-SURFACE2 = PALETTE["panel2"]

--- a/launcher/theme.py
+++ b/launcher/theme.py
@@ -1,0 +1,40 @@
+"""Single source of truth for the launcher's visual theme.
+
+Historically the look came from TWO palettes that drifted apart: one in
+``main.py``'s ``apply_theme`` and a second, slightly different one in
+``asset_skin._soften_styles`` (which runs later and wins for cards, strips,
+footer, buttons and tabs). That split made the UI look half-themed and made a
+restyle need edits in two places that had to be kept in sync by hand.
+
+Both layers now import ``PALETTE`` from here, so they can never diverge again.
+Keeping this module pure data -- no imports from the rest of ``launcher`` -- makes
+it safe to import from anywhere in the package (``main``, ``asset_skin``,
+``gui``) without risking an import cycle.
+
+The palette is a calm, modern dark theme. It keeps the PS2 blue identity but
+trades the old near-black + neon look for lifted slate surfaces, a clear
+elevation scale (bg -> panel -> panel2 -> panel3), subtle slate hairlines
+instead of glowing borders, and one confident accent used sparingly.
+"""
+
+PALETTE = {
+    "bg":       "#0d1420",   # window background (deep slate-navy)
+    "panel":    "#161f2e",   # card / strip surface
+    "panel2":   "#1f2a3d",   # hover / slightly elevated surface
+    "panel3":   "#293850",   # selected tab / pressed surface
+    "edge":     "#31415d",   # subtle hairline border (was a neon blue)
+    "text":     "#e9eef7",   # primary text
+    "muted":    "#93a3bd",   # secondary / helper text
+    "accent":   "#3f8cff",   # primary blue -- buttons, selected accents
+    "accent2":  "#74b6ff",   # lighter blue -- hints, selected-tab text
+    "ok":       "#43d597",   # running / recommended (green)
+    "warn":     "#e7b750",   # warning (amber)
+    "error":    "#f16d7f",   # error / stopped-in-error (red)
+    "entry":    "#0f1826",   # input fields + terminal background
+    "disabled": "#5c6c88",   # disabled text
+}
+
+# Elevation aliases used by the asset-skin layer, so its local names
+# (surface/surface2/danger) map onto the canonical palette above.
+SURFACE = PALETTE["panel"]
+SURFACE2 = PALETTE["panel2"]

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -22,25 +22,47 @@ REQUIRED_KEYS = {
 }
 
 
+def _wcag_contrast(fg, bg):
+    """Proper WCAG 2.x contrast ratio between two #rrggbb colours."""
+    def _lin(hexc):
+        chan = []
+        for i in (1, 3, 5):
+            c = int(hexc[i:i + 2], 16) / 255.0
+            chan.append(c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4)
+        r, g, b = chan
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b
+    l1, l2 = _lin(fg), _lin(bg)
+    hi, lo = max(l1, l2), min(l1, l2)
+    return (hi + 0.05) / (lo + 0.05)
+
+
 class PaletteContractTests(unittest.TestCase):
-    def test_required_keys_present(self):
-        missing = REQUIRED_KEYS - set(theme.PALETTE)
-        self.assertEqual(missing, set(), "PALETTE missing keys: %s" % missing)
+    def test_key_set_is_exactly_required(self):
+        # Exact set, not just a subset: this also catches a stale/extra key being
+        # reintroduced (the SURFACE-alias problem), not only a missing one.
+        self.assertEqual(set(theme.PALETTE), REQUIRED_KEYS)
 
     def test_all_values_are_six_digit_hex(self):
         for key, value in theme.PALETTE.items():
             self.assertRegex(value, HEX, "%s=%r is not a 6-digit hex colour" % (key, value))
 
-    def test_accent_hover_is_darker_than_accent(self):
-        # The hover shade must be at least as dark as the base accent so white
-        # button text keeps its AA contrast on the active state (a lighter hover
-        # was the original accessibility bug).
-        def _luminance(hex_colour):
-            r, g, b = (int(hex_colour[i:i + 2], 16) for i in (1, 3, 5))
-            return 0.2126 * r + 0.7152 * g + 0.0722 * b
-        self.assertLessEqual(
-            _luminance(theme.PALETTE["accent_hover"]),
-            _luminance(theme.PALETTE["accent"]))
+    def test_white_text_on_accents_meets_wcag_aa(self):
+        # White is the Accent.TButton foreground on both the base accent and the
+        # hover/press accent_hover; both must clear WCAG AA (4.5:1) for normal
+        # text. This is the accessibility fix the review flagged.
+        for key in ("accent", "accent_hover"):
+            ratio = _wcag_contrast("#ffffff", theme.PALETTE[key])
+            self.assertGreaterEqual(
+                ratio, 4.5,
+                "white on %s (%s) is %.2f:1, below WCAG AA 4.5:1"
+                % (key, theme.PALETTE[key], ratio))
+
+    def test_accent_hover_is_no_lighter_than_accent(self):
+        # Guards the hover from regressing to a lighter fill (which would drop
+        # white-text contrast, the original bug).
+        self.assertGreaterEqual(
+            _wcag_contrast("#ffffff", theme.PALETTE["accent_hover"]),
+            _wcag_contrast("#ffffff", theme.PALETTE["accent"]))
 
 
 class AssetSkinSharesThePaletteTests(unittest.TestCase):

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -18,7 +18,7 @@ HEX = re.compile(r"^#[0-9a-fA-F]{6}$")
 # here too, so a missing key fails loudly in tests instead of at paint time.
 REQUIRED_KEYS = {
     "bg", "panel", "panel2", "panel3", "edge", "text", "muted",
-    "accent", "accent2", "ok", "warn", "error", "entry", "disabled",
+    "accent", "accent_hover", "accent2", "ok", "warn", "error", "entry", "disabled",
 }
 
 
@@ -31,10 +31,16 @@ class PaletteContractTests(unittest.TestCase):
         for key, value in theme.PALETTE.items():
             self.assertRegex(value, HEX, "%s=%r is not a 6-digit hex colour" % (key, value))
 
-    def test_surface_aliases_track_the_palette(self):
-        # asset_skin maps surface/surface2 onto these; keep them honest.
-        self.assertEqual(theme.SURFACE, theme.PALETTE["panel"])
-        self.assertEqual(theme.SURFACE2, theme.PALETTE["panel2"])
+    def test_accent_hover_is_darker_than_accent(self):
+        # The hover shade must be at least as dark as the base accent so white
+        # button text keeps its AA contrast on the active state (a lighter hover
+        # was the original accessibility bug).
+        def _luminance(hex_colour):
+            r, g, b = (int(hex_colour[i:i + 2], 16) for i in (1, 3, 5))
+            return 0.2126 * r + 0.7152 * g + 0.0722 * b
+        self.assertLessEqual(
+            _luminance(theme.PALETTE["accent_hover"]),
+            _luminance(theme.PALETTE["accent"]))
 
 
 class AssetSkinSharesThePaletteTests(unittest.TestCase):

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,77 @@
+"""Guards for the single-source-of-truth palette (launcher/theme.py).
+
+The look used to come from two divergent palettes (main.py and asset_skin.py);
+these tests lock in that there is now ONE palette and that the asset-skin layer
+maps its local names onto it, so the two theme layers can never drift back into
+two different-looking skins.
+"""
+
+import re
+import unittest
+
+from launcher import theme
+
+
+HEX = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+# Every key both theme layers reference. If a consumer needs a new key, it goes
+# here too, so a missing key fails loudly in tests instead of at paint time.
+REQUIRED_KEYS = {
+    "bg", "panel", "panel2", "panel3", "edge", "text", "muted",
+    "accent", "accent2", "ok", "warn", "error", "entry", "disabled",
+}
+
+
+class PaletteContractTests(unittest.TestCase):
+    def test_required_keys_present(self):
+        missing = REQUIRED_KEYS - set(theme.PALETTE)
+        self.assertEqual(missing, set(), "PALETTE missing keys: %s" % missing)
+
+    def test_all_values_are_six_digit_hex(self):
+        for key, value in theme.PALETTE.items():
+            self.assertRegex(value, HEX, "%s=%r is not a 6-digit hex colour" % (key, value))
+
+    def test_surface_aliases_track_the_palette(self):
+        # asset_skin maps surface/surface2 onto these; keep them honest.
+        self.assertEqual(theme.SURFACE, theme.PALETTE["panel"])
+        self.assertEqual(theme.SURFACE2, theme.PALETTE["panel2"])
+
+
+class AssetSkinSharesThePaletteTests(unittest.TestCase):
+    """asset_skin._soften_styles must colour cards/buttons from theme.PALETTE,
+    not a private copy -- that shared reference is the whole point of theme.py.
+    A fake ttk.Style records what colours get configured; we assert they are the
+    canonical ones, so a future edit that reintroduces a second palette fails."""
+
+    def test_soften_styles_uses_theme_colours(self):
+        from launcher import asset_skin
+
+        configured = {}
+
+        class FakeStyle:
+            def configure(self, name, **kw):
+                configured.setdefault(name, {}).update(kw)
+
+            def map(self, name, **kw):
+                pass
+
+        class FakeGui:
+            class ttk:
+                @staticmethod
+                def Style(root):
+                    return FakeStyle()
+
+        class FakeRoot:
+            def configure(self, **kw):
+                configured.setdefault("__root__", {}).update(kw)
+
+        asset_skin._soften_styles(FakeRoot(), FakeGui)
+
+        # The card surface must be the shared panel colour, and the root
+        # background the shared bg colour -- proof it read from theme.PALETTE.
+        self.assertEqual(configured["Card.TFrame"]["background"], theme.PALETTE["panel"])
+        self.assertEqual(configured["__root__"]["background"], theme.PALETTE["bg"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -8,6 +8,7 @@ two different-looking skins.
 
 import re
 import unittest
+from unittest import mock
 
 from launcher import theme
 
@@ -93,12 +94,17 @@ class AssetSkinSharesThePaletteTests(unittest.TestCase):
             def configure(self, **kw):
                 configured.setdefault("__root__", {}).update(kw)
 
-        asset_skin._soften_styles(FakeRoot(), FakeGui)
+        # Patch the palette with SENTINEL colours that appear nowhere in the real
+        # theme, then assert the configured styles use them. Matching the sentinel
+        # proves asset_skin read live from theme.PALETTE -- a hardcoded private
+        # copy (even one with today's exact values) would fail this.
+        sentinels = {"panel": "#010203", "bg": "#040506", "accent": "#070809"}
+        with mock.patch.dict(theme.PALETTE, sentinels, clear=False):
+            asset_skin._soften_styles(FakeRoot(), FakeGui)
 
-        # The card surface must be the shared panel colour, and the root
-        # background the shared bg colour -- proof it read from theme.PALETTE.
-        self.assertEqual(configured["Card.TFrame"]["background"], theme.PALETTE["panel"])
-        self.assertEqual(configured["__root__"]["background"], theme.PALETTE["bg"])
+        self.assertEqual(configured["Card.TFrame"]["background"], "#010203")
+        self.assertEqual(configured["__root__"]["background"], "#040506")
+        self.assertEqual(configured["Accent.TButton"]["background"], "#070809")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The tester wanted the launcher to feel **more modern, cleaner, and easier**. Structure is unchanged — **tabs stay on top** — this is a visual refresh, previewed on Windows (it renders identically on Linux since the theme forces `clam` with a shared palette).

## The core problem: two fighting palettes
The look came from **two divergent palettes** — one in `main.py`'s `apply_theme`, a second slightly-different one in `asset_skin._soften_styles` (which runs later and *wins* for cards/strips/footer/buttons/tabs). The app rendered half-themed, and any restyle meant hand-syncing two files.

**Fix:** [`launcher/theme.py`](launcher/theme.py) is now the single source of truth; both layers import `PALETTE` from it. A test drives `asset_skin` with a fake `ttk.Style` and asserts it colours from `theme.PALETTE`, so the two layers can never drift apart again.

## What changed
| Area | Before | After |
|---|---|---|
| Palette | 2 divergent navy palettes | 1 shared palette |
| Background | near-black `#030713` + neon | calmer lifted slate `#0d1420` |
| Cards | glowing blue borders | flat + subtle slate hairline |
| Tabs | tight, neon-outlined (styled in *both* files) | roomier; `main.py` is now the **sole** owner |
| Start/Stop | plain — identical to "Browse…" | **Accent** primary button |
| About text box | unstyled → **white-on-dark break** | themed light-on-dark |
| Terminal | hardcoded off-palette greys | palette-driven |
| LAN IP dropdown | light-on-dark popup | themed dark popup (`option_add`) |

## Verification
- **183 tests pass** (179 + 4 new palette-contract / no-drift tests).
- Previewed on Windows via a screenshot harness (before/after captured for the UDPFS card, terminal, and About tab).

Palette is a one-file change ([`theme.py`](launcher/theme.py)) if the owner wants it tuned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)