### PR TITLE
Linux system tray (experimental, pystray)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,15 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y python3-tk tk-dev
 
+      # Optional Linux system-tray backend, bundled into the Linux build so the
+      # AppImage has a working tray. best-effort: if this fails the build still
+      # succeeds and the launcher just keeps close-to-quit (build.py only bundles
+      # what is actually installed).
+      - name: Install Linux tray backend (pystray)
+        if: runner.os == 'Linux'
+        continue-on-error: true
+        run: python -m pip install pystray Pillow python-xlib
+
       - name: Install Nuitka
         if: matrix.macos_arch != 'x86_64'
         run: python -m pip install --upgrade pip -r requirements-build.txt

--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ Packaged builds bundle CHD (libchdr) and ZSO (lz4) support, so CHD/CSO/ZSO image
 `libchdr` native library for CHD; CSO always works (Python standard library). See
 [docs/optional-compression-dependencies.md](docs/optional-compression-dependencies.md).
 
+**Optional — system tray (Linux, experimental)**
+
+On Windows the launcher can close/minimize to the system tray so the servers keep
+running without a window. On Linux this is now available too (experimental): the
+packaged **AppImage** bundles it, and from source it turns on if you
+`pip install pystray` (Pillow is also needed for the icon). It shows a tray icon on
+desktops with a system tray — XFCE, Cinnamon, MATE, KDE, or GNOME with the
+AppIndicator extension — where you can enable **Close/Minimize to tray** in the
+About tab. It is **off by default** on Linux; enable it once you see the icon
+appear. Desktops without a tray simply show no icon, and closing the window quits
+as normal. macOS has no tray (closing the window quits).
+
 ## Direct PS2-to-PC link (no router)
 
 A PS2 cabled straight into the PC has no router on the wire, so nothing hands the

--- a/README.md
+++ b/README.md
@@ -187,8 +187,9 @@ Packaged builds bundle CHD (libchdr) and ZSO (lz4) support, so CHD/CSO/ZSO image
 
 On Windows the launcher can close/minimize to the system tray so the servers keep
 running without a window. On Linux this is now available too (experimental): the
-packaged **AppImage** bundles it, and from source it turns on if you
-`pip install pystray` (Pillow is also needed for the icon). It shows a tray icon on
+packaged **AppImage** normally bundles it (the tray dependency is best-effort at
+build time, so an occasional build may ship without it), and from source it turns
+on if you `pip install pystray` (Pillow is also needed for the icon). It shows a tray icon on
 desktops with a system tray — XFCE, Cinnamon, MATE, KDE, or GNOME with the
 AppIndicator extension — where you can enable **Close/Minimize to tray** in the
 About tab. It is **off by default** on Linux; enable it once you see the icon

--- a/build/build.py
+++ b/build/build.py
@@ -55,6 +55,23 @@ INCLUDE_PACKAGES = [
     "lz4",
 ]
 
+# Optional Linux system-tray backend. pystray (+ Pillow for the icon, + the
+# pure-Python Xlib xorg fallback) is bundled so the packaged Linux build has a
+# working tray. Each is included only if actually installed in the build
+# environment, so a build without them still succeeds and the launcher simply
+# degrades to close-to-quit. pystray's AppIndicator/GTK backends import `gi` at
+# runtime from the system (Nuitka can't bundle a gobject-introspection stack);
+# where gi is absent, pystray falls back to the bundled xorg backend.
+LINUX_TRAY_PACKAGES = ["pystray", "PIL", "Xlib", "six"]
+
+
+def _installed(module_name):
+    import importlib.util
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, AttributeError, ValueError):
+        return False
+
 
 def main():
     system = platform.system()
@@ -94,6 +111,15 @@ def main():
 
     for pkg in INCLUDE_PACKAGES:
         cmd.append("--include-package=" + pkg)
+
+    if system == "Linux":
+        for pkg in LINUX_TRAY_PACKAGES:
+            if _installed(pkg):
+                cmd.append("--include-package=" + pkg)
+        # gi (PyGObject) is a system gobject-introspection stack, not a bundle-
+        # able Python package; pystray imports it only at runtime. Tell Nuitka
+        # not to try to follow it so the build never fails on a missing gi.
+        cmd.append("--nofollow-import-to=gi")
 
     build_mode = os.environ.get("PS2_BUILD_MODE", "onefile").strip().lower()
 

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -417,10 +417,17 @@ class LauncherApp:
         self._shutting_down = False
         self._tray = None
         self._tray_option_widgets = []
+        # Default close/minimize-to-tray ON only where the tray icon appears
+        # reliably and synchronously (Windows). On Linux the tray is opt-in even
+        # when available: the icon shows on most desktops (XFCE/Cinnamon/MATE/
+        # KDE) but we don't want a first-run user's window-close to silently hide
+        # the window before they've seen the icon work. A saved preference still
+        # wins, so a Linux user who turns it on keeps it.
+        _tray_default = tray.AVAILABLE and windows_setup.is_windows()
         self.close_to_tray_var = tk.BooleanVar(
-            value=self._saved_bool("close_to_tray", tray.AVAILABLE))
+            value=self._saved_bool("close_to_tray", _tray_default))
         self.minimize_to_tray_var = tk.BooleanVar(
-            value=self._saved_bool("minimize_to_tray", tray.AVAILABLE))
+            value=self._saved_bool("minimize_to_tray", _tray_default))
 
         root.title("PS2 Servers " + APP_VERSION_LABEL)
         self._configure_window()

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -74,7 +74,8 @@ Linux and macOS
 PS2 Servers runs the same three servers here as on Windows. A few things differ:
 
 - There is no firewall management. If the PS2 cannot see a server after you start it, open its port in your firewall -- the TERMINAL tab prints the exact command for ufw or firewalld when a server starts. Many desktops allow LAN traffic by default and need nothing.
-- System tray, and the "Take port 445" SMB option, are Windows-only and are not shown here.
+- The "Take port 445" SMB option is Windows-only and is not shown here.
+- System tray on Linux is experimental. When your desktop has a system tray (XFCE, Cinnamon, MATE, KDE, or GNOME with the AppIndicator extension), you can turn on "Close to tray" / "Minimize to tray" below to keep the servers running without a window. It is off by default -- enable it once you see the tray icon appear. Desktops with no tray simply show no icon, and closing the window quits normally.
 - Direct link mode is experimental on Linux and macOS: it runs a small helper as administrator (via your system's password prompt) to configure the port, and removes that configuration again when it stops.
 """
 

--- a/launcher/tray.py
+++ b/launcher/tray.py
@@ -250,3 +250,21 @@ class SystemTray:
         if self._hwnd:
             user32.PostMessageW(self._hwnd, WM_CLOSE, 0, 0)
             self._hwnd = None
+
+
+# -- Linux backend ----------------------------------------------------------- #
+# On Linux the tray is optional (pystray, bundled in the AppImage). When the
+# pieces are present, expose it through the SAME ``AVAILABLE`` flag and
+# ``SystemTray(tooltip, on_open, on_quit)`` / ``start()`` / ``stop()`` contract as
+# Windows, so the GUI wiring in gui.py is identical on both. On macOS -- and on
+# Linux without pystray/Pillow/a session bus -- ``AVAILABLE`` stays False and the
+# launcher keeps its normal close-to-quit behaviour (the Windows ctypes class
+# above is defined but never instantiated there).
+if platform.system() == "Linux":
+    try:
+        from . import tray_linux
+        if tray_linux.available():
+            AVAILABLE = True
+            SystemTray = tray_linux.SystemTray
+    except Exception:
+        pass

--- a/launcher/tray_linux.py
+++ b/launcher/tray_linux.py
@@ -1,0 +1,175 @@
+"""Linux system-tray backend (pystray), matching the Windows tray contract.
+
+The Windows tray in ``tray.py`` is a pure-ctypes Shell_NotifyIcon. Linux has no
+single tray API, so this backend leans on ``pystray`` -- a small, mature library
+that speaks the modern StatusNotifierItem/AppIndicator protocol (KDE, XFCE,
+Cinnamon, MATE, Budgie, GNOME-with-extension) and falls back to the legacy XEMBED
+tray (which XFCE/MATE still accept). pystray is an OPTIONAL dependency: the
+packaged AppImage bundles it, and everywhere it is absent this module simply
+reports itself unavailable and the launcher keeps its normal close-to-quit
+behaviour.
+
+The public surface mirrors ``tray.SystemTray`` exactly -- ``SystemTray(tooltip,
+on_open, on_quit)`` with ``start() -> bool`` and ``stop()`` -- so ``gui.py`` wires
+the Linux tray through the identical code path as Windows. ``on_open`` /
+``on_quit`` fire on pystray's own thread and MUST only hand off to the GUI thread
+(the launcher gives them callbacks that just push to a queue the Tk loop drains).
+
+Safety: ``start()`` returns True only after pystray reports the icon set up. That
+is still weaker than Win32's synchronous NIM_ADD result -- a tray host that is
+absent cannot always be detected -- so the launcher additionally defaults
+close/minimize-to-tray OFF on Linux, making the user opt in only once they can
+see the icon actually appears. That combination means a missing tray can never
+trap the user with a hidden, unrecoverable window.
+"""
+
+import importlib.util
+import os
+import platform
+import threading
+
+
+def _has_module(name):
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, AttributeError, ValueError):
+        return False
+
+
+def _has_session_bus():
+    """A tray only means anything with a session message bus. Without one
+    (headless, some minimal/CI environments) there is nothing to register with,
+    so report unavailable rather than spawn a pointless icon thread."""
+    if os.environ.get("DBUS_SESSION_BUS_ADDRESS"):
+        return True
+    uid = getattr(os, "getuid", lambda: None)()
+    if uid is not None and os.path.exists("/run/user/{}/bus".format(uid)):
+        return True
+    return False
+
+
+def available():
+    """True only if a Linux tray could plausibly work here: Linux, pystray and
+    Pillow importable, and a session bus present. This gates ``tray.AVAILABLE``,
+    so a machine without the pieces shows no tray options at all."""
+    return (platform.system() == "Linux"
+            and _has_session_bus()
+            and _has_module("pystray")
+            and _has_module("PIL"))
+
+
+def _icon_image():
+    """A PIL image for the tray icon. Prefer the shipped LOGO.png; fall back to a
+    small generated PS2-blue badge so the tray still has an icon in source trees
+    without the theme assets."""
+    try:
+        from PIL import Image
+    except Exception:
+        return None
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    logo = os.path.join(here, "assets", "theme", "LOGO.png")
+    if os.path.exists(logo):
+        try:
+            return Image.open(logo).convert("RGBA").resize((64, 64))
+        except Exception:
+            pass
+
+    try:
+        from PIL import Image, ImageDraw
+        img = Image.new("RGBA", (64, 64), (13, 20, 32, 255))
+        draw = ImageDraw.Draw(img)
+        draw.rounded_rectangle([5, 5, 58, 58], radius=10,
+                               outline=(63, 140, 255, 255), width=3)
+        draw.text((15, 24), "PS2", fill=(116, 182, 255, 255))
+        return img
+    except Exception:
+        return None
+
+
+class SystemTray:
+    """A single tray icon with an Open / Quit menu, pystray-backed.
+
+    Same contract as ``tray.SystemTray`` on Windows: callbacks fire on the tray's
+    own thread and should only marshal to the GUI thread.
+    """
+
+    def __init__(self, tooltip, on_open, on_quit):
+        self.tooltip = tooltip
+        self.on_open = on_open
+        self.on_quit = on_quit
+        self._icon = None
+        self._thread = None
+        self._ready = threading.Event()
+        self._ok = False
+
+    def start(self):
+        try:
+            import pystray
+        except Exception:
+            return False
+        image = _icon_image()
+        if image is None:
+            return False
+
+        def _open(icon=None, item=None):
+            self._safe(self.on_open)
+
+        def _quit(icon=None, item=None):
+            self._safe(self.on_quit)
+
+        # default=True makes a left click (or double click) invoke Open, matching
+        # the Windows tray where left-click restores the window.
+        menu = pystray.Menu(
+            pystray.MenuItem("Open PS2 Servers", _open, default=True),
+            pystray.MenuItem("Quit", _quit),
+        )
+        try:
+            self._icon = pystray.Icon("ps2servers", image, self.tooltip, menu)
+        except Exception:
+            return False
+
+        def _setup(icon):
+            # Runs on pystray's loop thread once the backend is up. Marking the
+            # icon visible here is the closest signal we get that it registered.
+            try:
+                icon.visible = True
+                self._ok = True
+            except Exception:
+                self._ok = False
+            finally:
+                self._ready.set()
+
+        def _run():
+            try:
+                self._icon.run(setup=_setup)
+            except Exception:
+                self._ok = False
+                self._ready.set()
+
+        self._thread = threading.Thread(target=_run, daemon=True)
+        self._thread.start()
+        # Give the backend a moment to come up; if it never signals, treat the
+        # tray as failed so the caller falls back to close-to-quit.
+        self._ready.wait(timeout=4.0)
+        return bool(self._ok)
+
+    @staticmethod
+    def _safe(fn):
+        try:
+            fn()
+        except Exception:
+            pass
+
+    def stop(self):
+        icon = self._icon
+        if icon is not None:
+            try:
+                icon.visible = False
+            except Exception:
+                pass
+            try:
+                icon.stop()
+            except Exception:
+                pass
+        self._icon = None

--- a/launcher/tray_linux.py
+++ b/launcher/tray_linux.py
@@ -81,7 +81,12 @@ def _icon_image():
         draw = ImageDraw.Draw(img)
         draw.rounded_rectangle([5, 5, 58, 58], radius=10,
                                outline=(63, 140, 255, 255), width=3)
-        draw.text((15, 24), "PS2", fill=(116, 182, 255, 255))
+        # The default bitmap font can be missing in some Pillow builds; the badge
+        # (rounded rect) is still a usable icon without the "PS2" text.
+        try:
+            draw.text((15, 24), "PS2", fill=(116, 182, 255, 255))
+        except Exception:
+            pass
         return img
     except Exception:
         return None
@@ -112,16 +117,31 @@ class SystemTray:
         if image is None:
             return False
 
+        # pystray backends differ in what they support (checked at runtime):
+        #   AppIndicator (preferred on XFCE/Cinnamon/MATE/KDE): menu YES,
+        #       default/left-click action NO.
+        #   GTK: menu YES, default action YES.
+        #   xorg (fallback): menu NO, default action YES.
+        # If a backend supports NEITHER a menu nor a default action it can offer
+        # neither Open nor Quit -- decline so the launcher keeps close-to-quit
+        # instead of showing a dead icon the user can't act on.
+        has_menu = bool(getattr(pystray.Icon, "HAS_MENU", True))
+        has_default = bool(getattr(pystray.Icon, "HAS_DEFAULT_ACTION", True))
+        if not has_menu and not has_default:
+            return False
+
         def _open(icon=None, item=None):
             self._safe(self.on_open)
 
         def _quit(icon=None, item=None):
             self._safe(self.on_quit)
 
-        # default=True makes a left click (or double click) invoke Open, matching
-        # the Windows tray where left-click restores the window.
+        # Mark Open as the default (left-click) action only where the backend
+        # supports one. The Open/Quit menu shows on backends with a menu
+        # (AppIndicator/GTK); on the menu-less xorg fallback left-click still
+        # invokes Open and Quit is done from the app window.
         menu = pystray.Menu(
-            pystray.MenuItem("Open PS2 Servers", _open, default=True),
+            pystray.MenuItem("Open PS2 Servers", _open, default=has_default),
             pystray.MenuItem("Quit", _quit),
         )
         try:
@@ -149,10 +169,13 @@ class SystemTray:
 
         self._thread = threading.Thread(target=_run, daemon=True)
         self._thread.start()
-        # Give the backend a moment to come up; if it never signals, treat the
-        # tray as failed so the caller falls back to close-to-quit.
-        self._ready.wait(timeout=4.0)
-        return bool(self._ok)
+        # If the backend never comes up (timeout) or reports failure, stop the
+        # icon/thread so we never leave an orphaned tray icon behind, and fall
+        # back to close-to-quit.
+        if not self._ready.wait(timeout=4.0) or not self._ok:
+            self.stop()
+            return False
+        return True
 
     @staticmethod
     def _safe(fn):

--- a/tests/test_tray_linux.py
+++ b/tests/test_tray_linux.py
@@ -36,6 +36,11 @@ def _fake_pystray():
 
     class Icon:
         instances = []
+        # Backend capability flags (like the real pystray.Icon). Tests override
+        # these to simulate AppIndicator (menu, no default), xorg (default, no
+        # menu), and a backend that supports neither.
+        HAS_MENU = True
+        HAS_DEFAULT_ACTION = True
 
         def __init__(self, name, image, title, menu):
             self.name = name
@@ -91,6 +96,7 @@ class AvailableTests(unittest.TestCase):
 
 class SystemTrayContractTests(unittest.TestCase):
     def setUp(self):
+        self._previous_pystray = sys.modules.get("pystray")
         self.fake, self.Icon = _fake_pystray()
         self.Icon.instances = []
         sys.modules["pystray"] = self.fake
@@ -101,7 +107,12 @@ class SystemTrayContractTests(unittest.TestCase):
 
     def tearDown(self):
         self._icon_patch.stop()
-        sys.modules.pop("pystray", None)
+        # Restore any real pystray that was imported before this fixture, rather
+        # than blindly deleting it and breaking later tests.
+        if self._previous_pystray is None:
+            sys.modules.pop("pystray", None)
+        else:
+            sys.modules["pystray"] = self._previous_pystray
 
     def test_start_returns_true_and_marks_icon_visible(self):
         tray = tray_linux.SystemTray("PS2 Servers", lambda: None, lambda: None)
@@ -139,6 +150,38 @@ class SystemTrayContractTests(unittest.TestCase):
         icon = self.Icon.instances[-1]
         tray.stop()
         self.assertTrue(icon.stopped)
+
+    def test_appindicator_backend_marks_open_non_default(self):
+        # AppIndicator: menu yes, default action no. Open must NOT be the default
+        # item (left-click won't fire it), but the menu still starts fine.
+        self.Icon.HAS_MENU = True
+        self.Icon.HAS_DEFAULT_ACTION = False
+        tray = tray_linux.SystemTray("PS2 Servers", lambda: None, lambda: None)
+        self.assertTrue(tray.start())
+        icon = self.Icon.instances[-1]
+        items = {i.text: i for i in icon.menu.items}
+        self.assertFalse(items["Open PS2 Servers"].default)
+        self.assertIn("Quit", items)  # Quit still reachable via the menu
+
+    def test_xorg_backend_starts_with_default_action(self):
+        # xorg: menu no, default action yes. Still usable (left-click Open), so
+        # it must start, with Open as the default item.
+        self.Icon.HAS_MENU = False
+        self.Icon.HAS_DEFAULT_ACTION = True
+        tray = tray_linux.SystemTray("PS2 Servers", lambda: None, lambda: None)
+        self.assertTrue(tray.start())
+        icon = self.Icon.instances[-1]
+        items = {i.text: i for i in icon.menu.items}
+        self.assertTrue(items["Open PS2 Servers"].default)
+
+    def test_declines_backend_with_neither_menu_nor_default(self):
+        # A backend that can offer neither Open nor Quit is a dead icon -- start()
+        # must decline (return False) and never create an icon.
+        self.Icon.HAS_MENU = False
+        self.Icon.HAS_DEFAULT_ACTION = False
+        tray = tray_linux.SystemTray("PS2 Servers", lambda: None, lambda: None)
+        self.assertFalse(tray.start())
+        self.assertEqual(self.Icon.instances, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_tray_linux.py
+++ b/tests/test_tray_linux.py
@@ -1,0 +1,145 @@
+"""Contract tests for the Linux tray backend (launcher/tray_linux.py).
+
+The real pystray + a live session bus only exist on a Linux desktop, which this
+suite can't assume. So these drive the backend against a FAKE pystray injected
+into sys.modules, verifying the parts that matter regardless of platform:
+
+  * available() gates correctly on platform / modules / session bus,
+  * start() spins up an icon and returns True once it reports set up,
+  * the Open/Quit menu items marshal to the on_open/on_quit callbacks,
+  * stop() tears the icon down.
+
+The actual icon rendering on a given desktop is what the Linux tester validates;
+this locks the wiring so a regression there fails in CI, not on his machine.
+"""
+
+import sys
+import types
+import unittest
+from unittest import mock
+
+from launcher import tray_linux
+
+
+def _fake_pystray():
+    mod = types.ModuleType("pystray")
+
+    class MenuItem:
+        def __init__(self, text, action, default=False):
+            self.text = text
+            self.action = action
+            self.default = default
+
+    class Menu:
+        def __init__(self, *items):
+            self.items = list(items)
+
+    class Icon:
+        instances = []
+
+        def __init__(self, name, image, title, menu):
+            self.name = name
+            self.image = image
+            self.title = title
+            self.menu = menu
+            self.visible = False
+            self.stopped = False
+            Icon.instances.append(self)
+
+        def run(self, setup=None):
+            # Real run() blocks on the backend loop; the fake just reports the
+            # icon came up (via setup) and returns, ending the daemon thread.
+            if setup:
+                setup(self)
+
+        def stop(self):
+            self.stopped = True
+
+    mod.MenuItem = MenuItem
+    mod.Menu = Menu
+    mod.Icon = Icon
+    return mod, Icon
+
+
+class AvailableTests(unittest.TestCase):
+    def test_available_true_when_all_pieces_present(self):
+        with mock.patch.object(tray_linux.platform, "system", return_value="Linux"), \
+                mock.patch.object(tray_linux, "_has_session_bus", return_value=True), \
+                mock.patch.object(tray_linux, "_has_module", return_value=True):
+            self.assertTrue(tray_linux.available())
+
+    def test_unavailable_off_linux(self):
+        with mock.patch.object(tray_linux.platform, "system", return_value="Darwin"), \
+                mock.patch.object(tray_linux, "_has_session_bus", return_value=True), \
+                mock.patch.object(tray_linux, "_has_module", return_value=True):
+            self.assertFalse(tray_linux.available())
+
+    def test_unavailable_without_session_bus(self):
+        with mock.patch.object(tray_linux.platform, "system", return_value="Linux"), \
+                mock.patch.object(tray_linux, "_has_session_bus", return_value=False), \
+                mock.patch.object(tray_linux, "_has_module", return_value=True):
+            self.assertFalse(tray_linux.available())
+
+    def test_unavailable_without_pystray(self):
+        def has(name):
+            return name != "pystray"
+        with mock.patch.object(tray_linux.platform, "system", return_value="Linux"), \
+                mock.patch.object(tray_linux, "_has_session_bus", return_value=True), \
+                mock.patch.object(tray_linux, "_has_module", side_effect=has):
+            self.assertFalse(tray_linux.available())
+
+
+class SystemTrayContractTests(unittest.TestCase):
+    def setUp(self):
+        self.fake, self.Icon = _fake_pystray()
+        self.Icon.instances = []
+        sys.modules["pystray"] = self.fake
+        # Keep the test independent of the theme assets / Pillow.
+        self._icon_patch = mock.patch.object(
+            tray_linux, "_icon_image", return_value=object())
+        self._icon_patch.start()
+
+    def tearDown(self):
+        self._icon_patch.stop()
+        sys.modules.pop("pystray", None)
+
+    def test_start_returns_true_and_marks_icon_visible(self):
+        tray = tray_linux.SystemTray("PS2 Servers", lambda: None, lambda: None)
+        self.assertTrue(tray.start())
+        icon = self.Icon.instances[-1]
+        self.assertTrue(icon.visible)
+
+    def test_menu_items_marshal_to_callbacks(self):
+        opened, quit_ = [], []
+        tray = tray_linux.SystemTray(
+            "PS2 Servers", lambda: opened.append(1), lambda: quit_.append(1))
+        self.assertTrue(tray.start())
+        icon = self.Icon.instances[-1]
+        items = {i.text: i for i in icon.menu.items}
+        self.assertIn("Open PS2 Servers", items)
+        self.assertIn("Quit", items)
+        # Left-click should invoke Open, so it must be the default item.
+        self.assertTrue(items["Open PS2 Servers"].default)
+        items["Open PS2 Servers"].action(icon, items["Open PS2 Servers"])
+        items["Quit"].action(icon, items["Quit"])
+        self.assertEqual(opened, [1])
+        self.assertEqual(quit_, [1])
+
+    def test_start_returns_false_when_no_icon_image(self):
+        self._icon_patch.stop()
+        with mock.patch.object(tray_linux, "_icon_image", return_value=None):
+            tray = tray_linux.SystemTray("PS2 Servers", lambda: None, lambda: None)
+            self.assertFalse(tray.start())
+        self._icon_patch.start()  # keep tearDown balanced
+
+    def test_stop_is_safe_before_and_after_start(self):
+        tray = tray_linux.SystemTray("PS2 Servers", lambda: None, lambda: None)
+        tray.stop()  # never started -- must not raise
+        tray.start()
+        icon = self.Icon.instances[-1]
+        tray.stop()
+        self.assertTrue(icon.stopped)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Linux gets the same **close/minimize-to-tray** the Windows build has had, so the servers can keep running without a window. The tester (on XFCE/Cinnamon/MATE) has a native system tray, which is exactly what this targets.

## How it fits
`gui.py` already keyed everything off `tray.AVAILABLE` + the `SystemTray(tooltip, on_open, on_quit)` / `start()->bool` / `stop()` contract with a graceful `_tray=None` fallback. The Linux backend just satisfies that same contract — **no structural GUI change**.

- **[`launcher/tray_linux.py`](launcher/tray_linux.py) (new):** a `pystray`-backed `SystemTray`. pystray speaks the modern StatusNotifierItem/AppIndicator protocol (XFCE, Cinnamon, MATE, KDE, GNOME+extension) and falls back to legacy XEMBED. `available()` gates on Linux + pystray + Pillow + a session bus.
- **[`launcher/tray.py`](launcher/tray.py):** on Linux, flip `AVAILABLE` and point `SystemTray` at the backend. **The Windows ctypes path is byte-for-byte intact** (Linux branch is appended, platform-guarded).

## Trap-safety (this is the piece the owner can't test on Windows)
Close/minimize-to-tray now default **ON only on Windows**, where the icon appears synchronously. On Linux the tray is **opt-in** — the icon shows on most desktops, but a first-run window-close must never silently hide the window before the user has seen the icon work. `start()` must report the icon up, `_tray=None` on any failure keeps close-to-quit, and a saved preference still wins. Worst case on a desktop with no tray: **no icon shows, nothing breaks, closing quits normally.**

## Packaging (AppImage bundles it, per the owner's choice)
- **[`build/build.py`](build/build.py):** bundle `pystray` (+ Pillow + the pure-Python Xlib xorg fallback) into the Linux build, only when installed, so a build without them still succeeds. `gi` is a runtime system import (`--nofollow-import-to=gi`).
- **[`release.yml`](.github/workflows/release.yml):** best-effort install of the deps on the Linux runner so the AppImage carries the tray.
- From source: turns on if the user `pip install pystray`.

## Verification
- **187 tests pass** (179 + 8 new). `pystray` + a live session bus only exist on a Linux desktop, so [`tests/test_tray_linux.py`](tests/test_tray_linux.py) drives the backend against a **fake pystray** to lock the wiring — `available()` gating, start/stop, and that the Open/Quit menu items marshal to the callbacks.
- The **Windows tray path is unchanged** and still launches clean (verified on Windows).
- The actual icon on a given desktop is what **Flying Spike validates** — it ships experimental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)