### PR TITLE
Add a 32-bit Windows (x86) build target

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -305,14 +305,16 @@ jobs:
 
             ## Downloads
 
-            **On Windows, download the folder build** (`PS2Servers-windows-x64-folder.zip`)
-            and run `PS2Servers.exe` from inside the folder — it is the same app
-            without the self-extracting wrapper that trips antivirus heuristics, so
-            it comes up clean. A single-file `PS2Servers-windows-x64.zip` is also
-            published for convenience. **32-bit Windows** builds
-            (`PS2Servers-windows-x86*.zip`) are published for older / low-end PCs.
-            Linux: `PS2Servers-linux-x64` (or the `-folder.tar.gz` build if `/tmp`
-            is `noexec`). macOS ships as a `.app`.
+            **On 64-bit Windows, download the folder build**
+            (`PS2Servers-windows-x64-folder.zip`) and run `PS2Servers.exe` from
+            inside the folder — it is the same app without the self-extracting
+            wrapper that trips antivirus heuristics, so it comes up clean. A
+            single-file `PS2Servers-windows-x64.zip` is also published for
+            convenience. **On 32-bit Windows** (older / low-end PCs), download
+            `PS2Servers-windows-x86-folder.zip` (or the single-file
+            `PS2Servers-windows-x86.zip`) instead — the x64 build will not run
+            there. Linux: `PS2Servers-linux-x64` (or the `-folder.tar.gz` build if
+            `/tmp` is `noexec`). macOS ships as a `.app`.
 
             ## Security transparency
 

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -26,6 +26,11 @@ jobs:
           - os: windows-latest
             asset_name: PS2Servers-windows-x64.zip
             folder_asset: PS2Servers-windows-x64-folder.zip
+          # 32-bit Windows, for older / low-end PCs still used for SMB on OPL.
+          - os: windows-latest
+            asset_name: PS2Servers-windows-x86.zip
+            folder_asset: PS2Servers-windows-x86-folder.zip
+            win_arch: x86
           - os: ubuntu-latest
             asset_name: PS2Servers-linux-x64
             folder_asset: PS2Servers-linux-x64-folder.tar.gz
@@ -40,10 +45,19 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        if: matrix.macos_arch != 'x86_64'
+        if: matrix.macos_arch != 'x86_64' && matrix.win_arch != 'x86'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
+
+      # 32-bit Windows needs a 32-bit interpreter so Nuitka emits a 32-bit .exe
+      # and pip pulls the win32 wheels (lz4, zstandard).
+      - name: Set up Python (Windows x86)
+        if: matrix.win_arch == 'x86'
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+          architecture: 'x86'
 
       - name: Install universal2 Python (macOS x64)
         if: matrix.macos_arch == 'x86_64'
@@ -80,6 +94,7 @@ jobs:
         if: matrix.macos_arch != 'x86_64'
         env:
           MACOS_TARGET_ARCH: ${{ matrix.macos_arch }}
+          WINDOWS_TARGET_ARCH: ${{ matrix.win_arch }}
         run: python build/build_libchdr.py
 
       - name: Build bundled libchdr (macOS x64)
@@ -254,6 +269,8 @@ jobs:
             PS2Servers-source.zip
             PS2Servers-windows-x64.zip
             PS2Servers-windows-x64-folder.zip
+            PS2Servers-windows-x86.zip
+            PS2Servers-windows-x86-folder.zip
           )
           present=()
           for a in "${assets[@]}"; do
@@ -292,8 +309,10 @@ jobs:
             and run `PS2Servers.exe` from inside the folder — it is the same app
             without the self-extracting wrapper that trips antivirus heuristics, so
             it comes up clean. A single-file `PS2Servers-windows-x64.zip` is also
-            published for convenience. Linux: `PS2Servers-linux-x64` (or the
-            `-folder.tar.gz` build if `/tmp` is `noexec`). macOS ships as a `.app`.
+            published for convenience. **32-bit Windows** builds
+            (`PS2Servers-windows-x86*.zip`) are published for older / low-end PCs.
+            Linux: `PS2Servers-linux-x64` (or the `-folder.tar.gz` build if `/tmp`
+            is `noexec`). macOS ships as a `.app`.
 
             ## Security transparency
 
@@ -331,6 +350,8 @@ jobs:
             release-assets/PS2Servers-source.zip
             release-assets/PS2Servers-windows-x64.zip
             release-assets/PS2Servers-windows-x64-folder.zip
+            release-assets/PS2Servers-windows-x86.zip
+            release-assets/PS2Servers-windows-x86-folder.zip
             release-assets/SHA256SUMS.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -120,7 +120,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $packageDir = "PS2Servers-windows-x64"
+          $packageDir = "PS2Servers-windows-${{ matrix.win_arch || 'x64' }}"
           New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
           Copy-Item -Path dist/PS2Servers.exe -Destination "$packageDir/PS2Servers.exe" -Force
           Copy-Item -Path ANTIVIRUS-NOTICE.md -Destination $packageDir -Force
@@ -177,7 +177,7 @@ jobs:
         run: |
           $dist = Get-ChildItem dist -Directory -Filter *.dist | Select-Object -First 1
           if (-not $dist) { throw "standalone .dist folder not found in dist/" }
-          $packageDir = "PS2Servers-windows-x64-folder"
+          $packageDir = "PS2Servers-windows-${{ matrix.win_arch || 'x64' }}-folder"
           New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
           Copy-Item -Path "$($dist.FullName)/*" -Destination $packageDir -Recurse -Force
           Copy-Item -Path ANTIVIRUS-NOTICE.md -Destination $packageDir -Force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Path out -Force | Out-Null
-          $packageDir = "out/PS2Servers-windows-x64"
+          $packageDir = "out/PS2Servers-windows-${{ matrix.win_arch || 'x64' }}"
           New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
           Copy-Item -Path dist/PS2Servers.exe -Destination "$packageDir/PS2Servers.exe" -Force
           Copy-Item -Path ANTIVIRUS-NOTICE.md -Destination $packageDir -Force
@@ -175,7 +175,7 @@ jobs:
         run: |
           $dist = Get-ChildItem dist -Directory -Filter *.dist | Select-Object -First 1
           if (-not $dist) { throw "standalone .dist folder not found in dist/" }
-          $packageDir = "out/PS2Servers-windows-x64-folder"
+          $packageDir = "out/PS2Servers-windows-${{ matrix.win_arch || 'x64' }}-folder"
           New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
           Copy-Item -Path "$($dist.FullName)/*" -Destination $packageDir -Recurse -Force
           Copy-Item -Path ANTIVIRUS-NOTICE.md -Destination $packageDir -Force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
           - os: windows-latest
             asset: PS2Servers-windows-x64.zip
             folder_asset: PS2Servers-windows-x64-folder.zip
+          # 32-bit Windows, for older / low-end PCs still used for SMB on OPL.
+          - os: windows-latest
+            asset: PS2Servers-windows-x86.zip
+            folder_asset: PS2Servers-windows-x86-folder.zip
+            win_arch: x86
           - os: ubuntu-latest
             asset: PS2Servers-linux-x64
             folder_asset: PS2Servers-linux-x64-folder.tar.gz
@@ -44,9 +49,19 @@ jobs:
       # universal2 interpreter (with universal Tcl/Tk) and must execute Python as
       # x86_64 so compiled dependencies like lz4 match the Intel artifact.
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        if: matrix.macos_arch != 'x86_64'
+        if: matrix.macos_arch != 'x86_64' && matrix.win_arch != 'x86'
         with:
           python-version: "3.12"
+
+      # The 32-bit Windows build needs a 32-bit interpreter (with 32-bit Tcl/Tk)
+      # so Nuitka emits a 32-bit .exe and pip pulls the win32 wheels (lz4,
+      # zstandard). setup-python provides an official 32-bit CPython.
+      - name: Set up Python (Windows x86)
+        if: matrix.win_arch == 'x86'
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+          architecture: "x86"
 
       - name: Install universal2 Python (macOS x86_64 cross-build)
         if: matrix.macos_arch == 'x86_64'
@@ -85,6 +100,7 @@ jobs:
         if: matrix.macos_arch != 'x86_64'
         env:
           MACOS_TARGET_ARCH: ${{ matrix.macos_arch }}
+          WINDOWS_TARGET_ARCH: ${{ matrix.win_arch }}
         run: python build/build_libchdr.py
 
       - name: Build bundled libchdr (macOS x86_64)
@@ -274,6 +290,7 @@ jobs:
           | OS | Recommended | Also available |
           | --- | --- | --- |
           | Windows x64 | \`PS2Servers-windows-x64-folder.zip\` (folder, AV-clean) | \`PS2Servers-windows-x64.zip\` (single file) |
+          | Windows x86 (32-bit) | \`PS2Servers-windows-x86-folder.zip\` (folder, AV-clean) | \`PS2Servers-windows-x86.zip\` (single file) |
           | Linux x64 | \`PS2Servers-linux-x64\` (single file) | \`PS2Servers-x86_64.AppImage\` (desktop/menu integration, newer) or \`PS2Servers-linux-x64-folder.tar.gz\` (folder; use if /tmp is noexec) |
           | macOS — Apple Silicon | \`PS2Servers-macos-arm64.zip\` | |
           | macOS — Intel | \`PS2Servers-macos-x64.zip\` | |

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ than from any guide, since your address and port are specific to your machine.
   the folder. It is the same app, but without the self-extracting wrapper that
   makes the single-file `.exe` trip antivirus heuristics, so it comes up clean.
   A single-file `PS2Servers-windows-x64.zip` is still provided for convenience
-  if your AV doesn't object. (Linux: `PS2Servers-linux-x64`, or
-  `PS2Servers-linux-x64-folder.tar.gz` if `/tmp` is mounted `noexec`.)
+  if your AV doesn't object. **On 32-bit Windows, use the `PS2Servers-windows-x86`
+  builds** instead (same app, built for older / low-end PCs). (Linux:
+  `PS2Servers-linux-x64`, or `PS2Servers-linux-x64-folder.tar.gz` if `/tmp` is
+  mounted `noexec`.)
 - **From source:** double-click **`Start-Launcher.bat`** (Windows) or run
   `./start-launcher.sh` (Linux/macOS). Requires Python 3.
 
@@ -160,10 +162,10 @@ Python and no heavy runtime for the packaged app.
 
 | | Requirement |
 |---|---|
-| OS | Windows 10/11 (x64), Linux (x64), or macOS (Apple Silicon or Intel) |
+| OS | Windows (x64 **or 32-bit x86**), Linux (x64), or macOS (Apple Silicon or Intel) |
 | Packaged app | No Python required — the download bundles everything |
 | From source | Python 3 with Tkinter (Linux: `sudo apt install python3-tk`); official builds use Python 3.12 |
-| Hardware | Any modern 64-bit PC for the **packaged GUI app** (x64 / Apple Silicon). Running a server from source needs only Python 3 and works on any architecture — see "On a Raspberry Pi, NAS, or other non-x64 box" below. |
+| Hardware | The **packaged GUI app** ships for x64, **32-bit x86 Windows** (for older / low-end PCs), and Apple Silicon. Running a server from source needs only Python 3 and works on any architecture — see "On a Raspberry Pi, NAS, or other non-x64 box" below. |
 | Network | Wired or Wi‑Fi LAN on the same subnet as the PS2 (wired recommended for large games) |
 | Disk | A few hundred MB for the app, plus room for your game files |
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ than from any guide, since your address and port are specific to your machine.
   the folder. It is the same app, but without the self-extracting wrapper that
   makes the single-file `.exe` trip antivirus heuristics, so it comes up clean.
   A single-file `PS2Servers-windows-x64.zip` is still provided for convenience
-  if your AV doesn't object. **On 32-bit Windows, use the `PS2Servers-windows-x86`
+  if your AV doesn't object. **On 32-bit Windows, use the
+  `PS2Servers-windows-x86.zip` (or `PS2Servers-windows-x86-folder.zip`)
   builds** instead (same app, built for older / low-end PCs). (Linux:
   `PS2Servers-linux-x64`, or `PS2Servers-linux-x64-folder.tar.gz` if `/tmp` is
   mounted `noexec`.)

--- a/build/build_libchdr.py
+++ b/build/build_libchdr.py
@@ -56,6 +56,12 @@ def configure_and_build():
 
     system = platform.system()
     if system == "Windows":
+        # Target CPU for the Visual Studio generator. Default (unset) builds for
+        # the runner's native x64; a 32-bit release sets WINDOWS_TARGET_ARCH=x86
+        # so the DLL matches the 32-bit Python/Nuitka .exe and can actually load.
+        win_arch = os.environ.get("WINDOWS_TARGET_ARCH", "").strip().lower()
+        if win_arch in ("x86", "win32", "32"):
+            cmd.extend(["-A", "Win32"])
         # Prefer a self-contained runtime for the DLL where supported by CMake/MSVC.
         cmd.extend([
             "-DCMAKE_POLICY_DEFAULT_CMP0091=NEW",

--- a/build/build_libchdr.py
+++ b/build/build_libchdr.py
@@ -56,17 +56,25 @@ def configure_and_build():
 
     system = platform.system()
     if system == "Windows":
-        # Target CPU for the Visual Studio generator. Default (unset) builds for
-        # the runner's native x64; a 32-bit release sets WINDOWS_TARGET_ARCH=x86
-        # so the DLL matches the 32-bit Python/Nuitka .exe and can actually load.
+        # The libchdr DLL's bitness MUST match the interpreter's: a 32-bit Python
+        # (and the Nuitka .exe it builds) can only load a 32-bit DLL, and vice
+        # versa. CI sets WINDOWS_TARGET_ARCH explicitly (x86 for the 32-bit build,
+        # unset for x64); when it is unset (e.g. a local build) fall back to the
+        # running interpreter's bitness (sys.maxsize is 2**31-1 on 32-bit Python).
+        # An explicit value that disagrees with the interpreter -- or an unknown
+        # value -- would silently produce an unloadable DLL, so reject it loudly
+        # before invoking CMake rather than shipping a broken build.
         win_arch = os.environ.get("WINDOWS_TARGET_ARCH", "").strip().lower()
-        # The DLL's bitness must match the interpreter's: a 32-bit Python (and the
-        # Nuitka .exe it builds) can only load a 32-bit DLL. CI sets
-        # WINDOWS_TARGET_ARCH explicitly; when it's unset (e.g. a local build)
-        # fall back to the running interpreter's bitness (sys.maxsize is 2**31-1
-        # on 32-bit Python) so a manual 32-bit build doesn't get a 64-bit DLL.
-        want_win32 = win_arch in ("x86", "win32", "32") or (
-            not win_arch and sys.maxsize <= 2 ** 31 - 1)
+        is_32bit_python = sys.maxsize <= 2 ** 31 - 1
+        win32_arches = {"x86", "win32", "32"}
+        x64_arches = {"x64", "win64", "amd64", "64"}
+        if win_arch and win_arch not in win32_arches | x64_arches:
+            raise ValueError("Unsupported WINDOWS_TARGET_ARCH: {}".format(win_arch))
+        if win_arch in win32_arches and not is_32bit_python:
+            raise RuntimeError("WINDOWS_TARGET_ARCH=x86 needs a 32-bit Python interpreter")
+        if win_arch in x64_arches and is_32bit_python:
+            raise RuntimeError("WINDOWS_TARGET_ARCH=x64 needs a 64-bit Python interpreter")
+        want_win32 = win_arch in win32_arches or (not win_arch and is_32bit_python)
         if want_win32:
             cmd.extend(["-A", "Win32"])
         # Prefer a self-contained runtime for the DLL where supported by CMake/MSVC.

--- a/build/build_libchdr.py
+++ b/build/build_libchdr.py
@@ -60,7 +60,14 @@ def configure_and_build():
         # the runner's native x64; a 32-bit release sets WINDOWS_TARGET_ARCH=x86
         # so the DLL matches the 32-bit Python/Nuitka .exe and can actually load.
         win_arch = os.environ.get("WINDOWS_TARGET_ARCH", "").strip().lower()
-        if win_arch in ("x86", "win32", "32"):
+        # The DLL's bitness must match the interpreter's: a 32-bit Python (and the
+        # Nuitka .exe it builds) can only load a 32-bit DLL. CI sets
+        # WINDOWS_TARGET_ARCH explicitly; when it's unset (e.g. a local build)
+        # fall back to the running interpreter's bitness (sys.maxsize is 2**31-1
+        # on 32-bit Python) so a manual 32-bit build doesn't get a 64-bit DLL.
+        want_win32 = win_arch in ("x86", "win32", "32") or (
+            not win_arch and sys.maxsize <= 2 ** 31 - 1)
+        if want_win32:
             cmd.extend(["-A", "Win32"])
         # Prefer a self-contained runtime for the DLL where supported by CMake/MSVC.
         cmd.extend([

--- a/docs/antivirus-transparency.md
+++ b/docs/antivirus-transparency.md
@@ -15,6 +15,8 @@ information is published at [falsepositives.html](falsepositives.html).
 - Windows executable: PS2Servers.exe
 - Windows release package: PS2Servers-windows-x64.zip
 - Windows folder package (alternative): PS2Servers-windows-x64-folder.zip
+- 32-bit Windows release package: PS2Servers-windows-x86.zip
+- 32-bit Windows folder package (alternative): PS2Servers-windows-x86-folder.zip
 - Repository: https://github.com/NathanNeurotic/PS2-Servers
 
 Packaged Windows builds include version metadata: company name, product name,

--- a/docs/antivirus-transparency.md
+++ b/docs/antivirus-transparency.md
@@ -51,7 +51,8 @@ local network tool."
 ## Two download shapes (folder is recommended on Windows)
 
 **On Windows, the folder build is the recommended download.** Windows and Linux
-each ship a **folder** build (`PS2Servers-windows-x64-folder.zip` /
+each ship a **folder** build (`PS2Servers-windows-x64-folder.zip` — or
+`PS2Servers-windows-x86-folder.zip` on 32-bit Windows — and
 `PS2Servers-linux-x64-folder.tar.gz`): the same application laid out as a plain
 folder of the executable plus its libraries, with **no self-extracting
 bootstrap** — which is the thing that makes the single-file `.exe` trip

--- a/tools/check_release_compliance.py
+++ b/tools/check_release_compliance.py
@@ -96,6 +96,7 @@ def main():
     errors += require(
         ".github/workflows/release-on-main.yml",
         "PS2Servers-windows-x64.zip",
+        "PS2Servers-windows-x86.zip",
         "SHA256SUMS.txt",
         "GitHub artifact attestations",
         "does not enable Windows SMB1",
@@ -109,6 +110,7 @@ def main():
     errors += require(
         ".github/workflows/release.yml",
         "PS2Servers-windows-x64.zip",
+        "PS2Servers-windows-x86.zip",
         ".sha256.txt",
         "does not enable Windows SMB1",
         "does not enable or disable Windows optional features",
@@ -121,6 +123,7 @@ def main():
     errors += require(
         "README.md",
         "PS2Servers-windows-x64.zip",
+        "PS2Servers-windows-x86.zip",
         "Windows' built-in SMB1 optional",
         "Windows Firewall changes are limited to rules named `PS2 Servers - ...`",
         "docs/antivirus-transparency.md",
@@ -142,6 +145,7 @@ def main():
         "Vendor / company name: NathanNeurotic",
         "Windows executable: PS2Servers.exe",
         "Windows release package: PS2Servers-windows-x64.zip",
+        "32-bit Windows release package: PS2Servers-windows-x86.zip",
         "SMBv1/RiptOPL",
         "TCP port 1111",
         "UDP port 0xF5F6",


### PR DESCRIPTION
Our packaged downloads were **x64-only**, but a lot of OPL users — especially on older / low-end PCs, common for SMB-on-OPL — run **32-bit Windows**, which *cannot run a 64-bit exe at all*. This adds a native 32-bit build.

## What it does
- **`release.yml` + `release-on-main.yml`:** new `windows-latest` matrix entry (`win_arch: x86`) with a dedicated **32-bit `setup-python`** so Nuitka emits a 32-bit `.exe` and pip pulls the **win32 wheels**. Produces `PS2Servers-windows-x86.zip` + `-x86-folder.zip`, wired into checksums, release notes, and publish lists — for tagged releases **and** dev builds. Windows package folders are named by arch (not hardcoded x64).
- **`build_libchdr.py`:** `WINDOWS_TARGET_ARCH=x86` → CMake `-A Win32`, so the bundled **libchdr DLL is 32-bit** (CHD works). x64 path unchanged.
- **README:** OS/hardware table + quick-start now cover 32-bit x86.

## Feature coverage on 32-bit
- **SMB server** — pure Python, works fully (the main use case here).
- **UDPFS** — CSO always (stdlib); **ZSO** via the `lz4` win32 wheel; **CHD** via the 32-bit libchdr.

## CI-verified (can't run 32-bit locally)
A no-publish `release.yml` test build ran the full matrix. From the `windows-x86` job:
- ✅ 32-bit wheels installed: `lz4-4.4.5-cp312-cp312-win32`, `zstandard-0.25.0-cp312-cp312-win32`
- ✅ libchdr configured with `-A Win32`
- ✅ **the produced `PS2Servers.exe` PE machine type is `0x14c` = i386 (32-bit)** — downloaded and checked the header directly
- ✅ all 5 matrix jobs (win x64/x86, linux, mac arm64/x64) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)