### PR TITLE
fix: add missing math import that broke every UDPFS launch

### DIFF
--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -1,5 +1,6 @@
 """Declarative registry for the server processes launched by PS2 Servers."""
 
+import math
 import os
 import platform
 import sys

--- a/tests/test_udpfs_config.py
+++ b/tests/test_udpfs_config.py
@@ -314,5 +314,70 @@ class LauncherCompressionArgTests(unittest.TestCase):
                 self.fail(f"short flag {a!r} would trip the Nuitka self-exec guard")
 
 
+class LauncherTxDelayArgTests(unittest.TestCase):
+    """tx_delay_ms ships with default='0', so every GUI launch walks this branch.
+
+    It was previously untested, which let a NameError ('math' was used without
+    being imported) reach users as "can't launch" on each attempt while CI
+    stayed green -- no test in this file passed tx_delay_ms at all.
+    """
+
+    @staticmethod
+    def _argv(tx_delay):
+        return servers._udpfs_argv({'root_dir': '/games', 'tx_delay_ms': tx_delay})
+
+    def test_field_default_builds_without_raising(self):
+        # The regression guard: build the way the GUI actually does, from the
+        # declared field defaults, so a default change keeps this honest.
+        values = {f.key: f.default for f in servers.UDPFS.fields}
+        values['root_dir'] = '/games'
+        self.assertIsNotNone(values['tx_delay_ms'])  # else this proves nothing
+        args = servers.UDPFS.build_argv(values)
+        self.assertIn('--tx-delay-ms', args)
+
+    def test_ordinary_value_is_forwarded(self):
+        args = self._argv('2.5')
+        self.assertIn('--tx-delay-ms', args)
+        self.assertEqual(args[args.index('--tx-delay-ms') + 1], '2.5')
+
+    def test_negative_is_dropped(self):
+        self.assertNotIn('--tx-delay-ms', self._argv('-1'))
+
+    def test_non_finite_is_dropped(self):
+        # float('inf')/float('nan') parse fine, so only an explicit finite check
+        # keeps them off the child process command line.
+        for bad in ('inf', '-inf', 'nan', float('inf'), float('nan')):
+            self.assertNotIn('--tx-delay-ms', self._argv(bad), repr(bad))
+
+    def test_garbage_is_ignored_not_raised(self):
+        for bad in ('abc', '', '  ', object()):
+            self.assertNotIn('--tx-delay-ms', self._argv(bad), repr(bad))
+
+    def test_absent_key_emits_nothing(self):
+        self.assertNotIn('--tx-delay-ms', servers._udpfs_argv({'root_dir': '/games'}))
+
+
+class LauncherModeLaunchTests(unittest.TestCase):
+    """Every registered mode must build an argv from its own field defaults.
+
+    A NameError in any one builder presents to the user as that mode simply
+    refusing to start, so cover the whole registry rather than UDPFS alone.
+    """
+
+    def test_every_mode_builds_argv_from_defaults(self):
+        for key, server in servers.REGISTRY.items():
+            values = {f.key: f.default for f in server.fields}
+            for f in server.fields:
+                if f.required and not values.get(f.key):
+                    values[f.key] = '/dummy.iso' if f.kind == 'file' else '/games'
+            # Folder-backed modes need a source even though it is not 'required'.
+            if key == 'udpfs':
+                values['root_dir'] = '/games'
+            if key == 'smbv1':
+                values['games_folder'] = '/games'
+            with self.subTest(mode=key):
+                self.assertIsInstance(server.build_argv(values), list)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
c495f92 applied a CodeRabbit follow-up that replaced max(0.0, float(tx_delay_ms)) with a math.isfinite() guard in _udpfs_argv, but never added the corresponding import.

The tx_delay_ms field is declared with default="0", so the `is not None` guard always passes and the branch runs on every UDPFS launch -- each attempt died with
NameError: name 'math' is not defined.

The isfinite() guard itself is correct and is kept: the old max() form let inf through onto the child command line. Only the import was missing.

CI stayed green because no test in tests/test_udpfs_config.py ever passed tx_delay_ms, so the changed line was never executed even though edge.yml does run that module on launcher/servers.py changes. Add LauncherTxDelayArgTests covering the GUI default path (built from the declared field defaults so a default change keeps it honest) plus finite/negative/NaN/inf/garbage handling, and LauncherModeLaunchTests asserting every registered mode can build an argv from its own defaults.

Verified: with the import removed the new tests fail with the reported NameError; with it, 43/43 pass.

# Pull Request

## Summary

Provide a clear and concise description of the change.

- What does this PR do?
- Why is it necessary?
- What problem does it solve?

---

## Type of Change

Select all that apply:

- [ ] Bug fix
- [ ] Feature addition
- [ ] Performance improvement
- [ ] Refactor (non-functional change)
- [ ] Documentation update
- [ ] Breaking change
- [ ] Other (explain below)

---

## Related Issues

Link related issues using:

Closes #  
Fixes #  
Related to #

---

## Scope

- [ ] This PR contains a single logical change.
- [ ] No unrelated refactoring is included.
- [ ] No formatting-only noise is included.

If this PR modifies multiple subsystems, explain why that is necessary:

---

## Technical Details

Describe:

- What files are affected
- What systems are impacted
- Why this approach was chosen
- Any alternative approaches considered

If modifying core logic, explain potential side effects.

---

## Testing

- [ ] Builds successfully
- [ ] No new warnings introduced
- [ ] Existing functionality tested
- [ ] Regression risk evaluated
- [ ] Tested on latest default branch

Describe how you tested this change:

---

## Breaking Changes

If this is a breaking change, describe:

- What breaks
- Why it is justified
- Migration path (if applicable)

If not applicable, state: "No breaking changes."

---

## Security Considerations

Does this change affect:

- Authentication
- External inputs
- File handling
- Device access
- Network behavior

If yes, explain impact.

---

## Checklist

- [ ] I have read CONTRIBUTING.md
- [ ] I have followed the project code standards
- [ ] I have rebased on the latest default branch
- [ ] CI passes locally or via GitHub
- [ ] This PR does not introduce hidden side effects

---

## Additional Notes

Provide any additional context here.
