### PR TITLE
chore: add CodeRabbit review config tuned to this repo

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,193 @@
+# CodeRabbit configuration for PS2-Servers.
+#
+# Docs:   https://docs.coderabbit.ai/guides/configure-coderabbit
+# Schema: https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+#
+# Goal: keep the findings that are worth acting on (real bugs, undefined names,
+# resource leaks, protocol and portability mistakes) and cut the style nitpicks
+# for tooling and conventions this repository has never adopted.
+#
+# Background: PR #125 fixed a NameError that broke every UDPFS launch. It was
+# introduced by applying an unverified CodeRabbit suggestion (a `math.isfinite`
+# guard added without the matching import). The same review then spent its one
+# actionable comment on a missing return type annotation, for a Ruff rule this
+# repo does not use. This file is aimed squarely at that imbalance.
+
+language: en-US
+
+# Hard limit: 250 characters. The detailed guidance lives in path_instructions
+# below, which allows 20000 per entry.
+tone_instructions: >-
+  Be direct and concise. Prioritise correctness, security and portability over
+  style. Verify each finding against this repo's real code before raising it,
+  and say so when you cannot. Never recommend tooling the repo does not use.
+
+reviews:
+  # 'assertive' (the current org-level setting) produces a high volume of
+  # low-value nitpicks. 'chill' keeps substantive findings and drops most
+  # style-only ones. Use 'quiet' if even this proves too noisy.
+  profile: chill
+
+  # CI is the merge gate, not CodeRabbit's opinion. Never let a review block a
+  # merge or mark a commit failed on its own.
+  request_changes_workflow: false
+  fail_commit_status: false
+
+  high_level_summary: true
+  changed_files_summary: true
+  sequence_diagrams: true
+  estimate_code_review_effort: true
+
+  # Cosmetic thread noise.
+  poem: false
+  in_progress_fortune: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+
+  # Unsolicited "here's a PR of docstrings / generated tests" offers. Tests in
+  # this repo are written to document a specific past failure; generated ones
+  # dilute that.
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+
+  tools:
+    # KEEP RUFF ENABLED. Its default `F` ruleset includes F821 (undefined name)
+    # -- precisely the check that would have caught the missing `import math`
+    # in c495f92 before it shipped. Disabling Ruff to silence style rules would
+    # throw away the one tool that catches that class of bug. The instructions
+    # below are what suppress the style-only output.
+    ruff:
+      enabled: true
+
+    # Useful on this repo: Go linting, workflow linting, shell in CI steps,
+    # and secret scanning.
+    golangci-lint:
+      enabled: true
+    actionlint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    gitleaks:
+      enabled: true
+
+    # Prose linting on docs generates a steady stream of subjective rewrites.
+    languagetool:
+      enabled: false
+    markdownlint:
+      enabled: false
+
+  path_instructions:
+    - path: "**"
+      instructions: >-
+        Cross-cutting rules for this repository. Verify every finding against
+        the actual code here before raising it, rather than applying general
+        best practice; if a claim cannot be verified from the code, say so
+        plainly instead of asserting it. When suggesting a change to executable
+        code, state how you checked it -- a suggestion that alters a code path
+        but has never been executed is how the c495f92 NameError shipped and
+        broke every server launch. Do not recommend adopting tooling,
+        frameworks or conventions this repository does not already use. Prefer
+        one well-verified finding over several speculative ones, and rank by
+        real user impact: this project is run by non-developers to serve games
+        to PlayStation 2 consoles, so a crash on launch matters enormously and
+        a style inconsistency does not.
+
+    - path: "**/*.py"
+      instructions: >-
+        This repository has NOT adopted Ruff, flake8, pylint, mypy, or any type
+        annotation standard. No linter or type checker runs in CI (see
+        .github/workflows/), and there is no pyproject.toml, ruff.toml,
+        setup.cfg, tox.ini or mypy.ini. Do not raise findings that exist only
+        because a linter default flagged them -- in particular missing type
+        annotations (ANN*), docstring rules (D*), import ordering (I*), or
+        naming conventions. Report a linter finding only when it indicates a
+        real defect: undefined or shadowed names (F821, F811), unused
+        assignments that reveal a bug, unreachable code, mutable default
+        arguments, bare or over-broad exception handlers that would swallow a
+        real error, or resource leaks. Correctness, portability and security
+        findings are always welcome regardless of tooling.
+
+    - path: "tests/**"
+      instructions: >-
+        Test helpers here intentionally follow the surrounding unannotated
+        style; the file-local convention wins over general best practice. Do
+        not suggest adding type annotations to individual helpers. Note that
+        `list[str]`-style annotations require Python 3.9+, and the README
+        documents run-from-source as only "Python 3 with Tkinter" with no
+        pinned floor. Each test documents a specific past failure -- when
+        reviewing, check that a test would actually FAIL against the bug it
+        claims to guard, and say so if it would not. That is far more valuable
+        here than style feedback.
+
+    - path: "launcher/**"
+      instructions: >-
+        This is the Tkinter launcher GUI. The `_*_argv` builders in servers.py
+        construct the command line for a child server process, and the packaged
+        app re-executes itself, so ONLY long flags (`--flag`) are safe -- a bare
+        `-c`/`-m` trips Nuitka's self-exec guard. Field defaults in the
+        ServerDef registry decide which argv branches actually execute at
+        runtime, so when reviewing a conditional check the declared default
+        before assuming a branch is rarely taken. Any change to these builders
+        must be executed, not just reasoned about; a suggestion that has not
+        been run is how the c495f92 NameError shipped.
+
+    - path: "udpfs_server/**"
+      instructions: >-
+        This implements a wire protocol served to real PlayStation 2 consoles
+        and to third-party clients (OPL, Modulo). Behaviour here is validated
+        against real hardware. Do not propose changes to packet layout, field
+        values, reserved fields, timing or negotiation based on what looks
+        cleaner or more standard -- a "correct" change can break real consoles.
+        Flag genuine defects (buffer bounds, integer overflow, unchecked
+        lengths, path traversal, resource leaks, races) and leave protocol
+        semantics alone unless the code is provably inconsistent with itself.
+
+    - path: "udpbd_server/**"
+      instructions: >-
+        Same as udpfs_server: a wire protocol served to real PS2 hardware,
+        validated against physical consoles. Report genuine defects; do not
+        propose protocol or timing changes on style or standards grounds.
+
+    - path: "smbv1_server/**"
+      instructions: >-
+        Deliberately speaks the OPL-compatible SMB1/CIFS subset, because that
+        is the only dialect the PS2 and OPL understand. Critically, it
+        implements that subset itself in userspace and does NOT enable the
+        Windows built-in SMB1 optional feature (README lines 51-52), so it
+        works on Windows 11 where the OS removed SMB1. Do not recommend
+        removing SMBv1, upgrading to SMB2/3, or flagging "SMB1 is enabled" as a
+        vulnerability -- none of those apply here and all three have been
+        considered and documented. Genuine implementation defects (path
+        traversal, bounds checks, auth handling) are still very much in scope.
+
+    - path: "native/ps2servers-edge/**"
+      instructions: >-
+        Go service that must cross-compile to eight targets, including
+        linux/mips and linux/mipsle with GOMIPS=softfloat and linux/riscv64,
+        and is built with CGO_ENABLED=0 for a static binary. Reject anything
+        that would introduce cgo, a non-portable syscall, unaligned 64-bit
+        atomics (which fault on 32-bit mips/arm), or an assumption of 64-bit
+        int. Concurrency findings on the session and transfer paths are
+        valuable; `go test -race` runs in CI.
+
+    - path: ".github/workflows/**"
+      instructions: >-
+        Third-party actions are pinned to full commit SHAs on purpose, for
+        supply-chain safety. Do not suggest replacing a pinned SHA with a
+        floating tag such as @v4. Flagging a genuinely outdated pinned action,
+        or an over-broad `permissions:` block, is welcome.
+
+  pre_merge_checks:
+    title:
+      mode: warning
+    description:
+      mode: warning
+
+knowledge_base:
+  learnings:
+    scope: local


### PR DESCRIPTION
Adds `.coderabbit.yaml` so CodeRabbit reviews match how this repo actually works.

## Why

PR #125 fixed a `NameError` that broke **every** UDPFS launch. It was introduced by applying an unverified CodeRabbit suggestion — a `math.isfinite()` guard added without the matching `import math`. That same review then spent its one actionable comment on a missing return type annotation, for a Ruff rule this repo has never adopted. CodeRabbit withdrew it once the context was explained, but the learning it saved is scoped to a single file, so this encodes the conventions repo-wide instead.

## The important decision: Ruff stays ON

The tempting fix is to disable CodeRabbit's bundled Ruff, since that's where the nitpick came from. **That would be a mistake.** Ruff's default `F` ruleset includes **F821 (undefined name)** — precisely the check that would have caught the missing `import math` before it shipped.

So Ruff stays enabled and the `path_instructions` suppress its *style-only* output instead. Net effect: we keep the linter that catches launch-breaking bugs and lose the one that argues about annotations.

## What changes

| Setting | Value | Why |
|---|---|---|
| `profile` | `chill` | Down from the org-level `assertive`, which drives the nitpick volume |
| `request_changes_workflow` / `fail_commit_status` | `false` | CI is the merge gate, not a bot's opinion |
| `poem`, `in_progress_fortune` | `false` | Thread noise |
| `finishing_touches.docstrings` / `unit_tests` | `false` | Unsolicited generated-code PRs; tests here document specific past failures |
| `languagetool`, `markdownlint` | `false` | Subjective prose rewrites on docs |
| `ruff`, `golangci-lint`, `actionlint`, `shellcheck`, `gitleaks` | `true` | Real defect and secret detection |
| `learnings.scope` | `local` | Keep learnings on this repo |

## path_instructions — all claims verified against the repo

- **`**`** — verify findings against real code; don't recommend unadopted tooling; rank by user impact (this is run by non-developers to serve games to PS2 consoles).
- **`**/*.py`** — no `pyproject.toml` / `ruff.toml` / `setup.cfg` / `tox.ini` / `mypy.ini` exists and no linter runs in any workflow (verified). Report linter findings only for real defects: F821/F811, unreachable code, mutable defaults, over-broad excepts, resource leaks.
- **`tests/**`** — unannotated helper style is intentional; `list[str]` needs 3.9+ and README:168 pins no floor for run-from-source. Asks it to check a test would actually *fail* against the bug it guards.
- **`launcher/**`** — argv builders feed a Nuitka self-exec (long flags only, a bare `-c`/`-m` trips the guard); field defaults decide which branches actually execute at runtime.
- **`udpfs_server/**`, `udpbd_server/**`** — wire protocols validated against real PS2 hardware; don't propose protocol/timing changes on style grounds.
- **`smbv1_server/**`** — implements the OPL SMB1/CIFS subset in userspace and does **not** enable the Windows SMB1 feature (README:51-52), so "SMB1 is a vulnerability" doesn't apply.
- **`native/ps2servers-edge/**`** — must cross-compile to 8 targets incl. mips softfloat and riscv64 with `CGO_ENABLED=0`; reject cgo, non-portable syscalls, unaligned 64-bit atomics.
- **`.github/workflows/**`** — action SHAs are pinned deliberately; don't suggest floating tags.

## Validation

Validated against the published schema (`schema.v2.json`) with `jsonschema` — **no errors**. Two problems were caught and fixed that way: a `version:` key that isn't allowed at root (`additionalProperties: false`), and `tone_instructions` exceeding its 250-char cap (now 227). All 9 `path_instructions` entries are well under the 20,000-char limit.

Docs-only change — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added repository-wide configuration for consistent automated review behavior.
  - Improved review coverage for correctness, security, portability, and tooling-specific checks.
  - Added safeguards so review feedback does not block merges or fail commit status on its own.
  - Configured warning-only validation for pre-merge checks and enabled concise summaries, changed-file overviews, and effort estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->