### PR TITLE
fix: ship ps2servers_core.py so packaged UDPFS starts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,14 @@ jobs:
       - name: Compile Python sources
         run: python -m compileall -q launcher smbv1_server udpbd_server udpfs_server ps2servers.py
 
+      - name: Check the packaged build ships every server source
+        # The launcher loads each server by file path, so Nuitka cannot see
+        # those imports and build.py has to list them as data. When that list
+        # drifted from the registry a release shipped whose UDPFS mode died
+        # with FileNotFoundError on ps2servers_core.py -- invisible from
+        # source, since the file is simply on disk there.
+        run: python -m unittest tests.test_packaging_data_files -v
+
       - name: Check release compliance posture
         run: python tools/check_release_compliance.py
 

--- a/build/build.py
+++ b/build/build.py
@@ -38,14 +38,42 @@ if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
 from launcher import app_icon, release_metadata
+from launcher.servers import REGISTRY
+
+# Support modules that a server entry point imports by name rather than being
+# an entry point itself, so they cannot be discovered from the registry.
+# udpfs_server/ps2servers_core.py does `from udpfs_server import (...)`.
+SUPPORT_FILES = [
+    "udpfs_server/udpfs_server.py",
+]
+
+
+def _server_entry_points():
+    """Every Python server module the launcher loads by file path at runtime.
+
+    Derived from REGISTRY rather than hand-listed: this list previously drifted
+    when the UDPFS entry point moved to ps2servers_core.py and build.py was not
+    updated, which shipped a packaged build whose UDPFS mode died with
+    FileNotFoundError on that exact file. Reading the registry means adding or
+    moving a server can no longer silently break the packaged app.
+    """
+    paths = set()
+    for server in REGISTRY.values():
+        if server.runtime != "python" or not server.module_file:
+            continue
+        rel = os.path.relpath(server.module_file, ROOT).replace(os.sep, "/")
+        paths.add(rel)
+    return paths
+
 
 # Server sources shipped as data at their original relative paths -- the launcher
 # loads these by file path at runtime (Nuitka can't see those dynamic imports).
-DATA_FILES = [
-    "smbv1_server/smbserver_opl.py",
-    "udpfs_server/udpfs_server.py",
-    "udpbd_server/udpbd_server.py",
-]
+DATA_FILES = sorted(_server_entry_points() | set(SUPPORT_FILES))
+
+_missing = [rel for rel in DATA_FILES if not os.path.isfile(os.path.join(ROOT, rel))]
+if _missing:
+    raise SystemExit(
+        "build.py: server sources missing from the tree: " + ", ".join(_missing))
 # udpfs_server.py does `from compressed_iso import ...` on load. --include-data-dir
 # skips .py files, so compile it in as a real package instead (importable anywhere).
 # lz4 is optional in source mode, but bundled in packaged releases so normal users

--- a/tests/test_packaging_data_files.py
+++ b/tests/test_packaging_data_files.py
@@ -1,0 +1,121 @@
+"""The packaged build must ship every server source the launcher loads.
+
+The launcher loads each Python server by FILE PATH at runtime, so Nuitka cannot
+see those imports and the files have to be listed as data. Nothing at build time
+notices when that list falls out of step with the registry, and the failure only
+appears in a packaged build -- running from source always works because the file
+is sitting on disk.
+
+That is exactly how a release shipped with UDPFS broken: the UDPFS entry point
+moved to udpfs_server/ps2servers_core.py, build.py still listed only
+udpfs_server/udpfs_server.py, and the packaged app died with
+
+    FileNotFoundError: ...\\udpfs_server\\ps2servers_core.py
+
+the moment anyone selected UDPFS. These tests fail in CI instead.
+
+Run:  python -m unittest tests.test_packaging_data_files -v
+"""
+
+import ast
+import importlib.util
+import os
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from launcher.servers import REGISTRY  # noqa: E402
+
+
+def _load_build_module():
+    """Import build/build.py by path; it is a script, not an installed module."""
+    spec = importlib.util.spec_from_file_location(
+        "_ps2_build", os.path.join(ROOT, "build", "build.py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+BUILD = _load_build_module()
+
+
+def _rel(path):
+    return os.path.relpath(path, ROOT).replace(os.sep, "/")
+
+
+class DataFilesCoverRegistryTests(unittest.TestCase):
+    def test_every_python_server_entry_point_is_shipped(self):
+        for key, server in REGISTRY.items():
+            if server.runtime != "python" or not server.module_file:
+                continue
+            with self.subTest(server=key):
+                self.assertIn(
+                    _rel(server.module_file), BUILD.DATA_FILES,
+                    "{} loads {} at runtime but the packaged build does not ship "
+                    "it; the packaged app will raise FileNotFoundError when this "
+                    "server is selected".format(key, _rel(server.module_file)))
+
+    def test_every_shipped_file_exists(self):
+        for rel in BUILD.DATA_FILES:
+            with self.subTest(path=rel):
+                self.assertTrue(
+                    os.path.isfile(os.path.join(ROOT, rel)),
+                    "{} is listed for packaging but is not in the tree".format(rel))
+
+    def test_registry_module_dirs_exist(self):
+        # module_dir goes on sys.path so a server's sibling imports resolve.
+        for key, server in REGISTRY.items():
+            if server.runtime != "python" or not server.module_dir:
+                continue
+            with self.subTest(server=key):
+                self.assertTrue(os.path.isdir(server.module_dir),
+                                "{} module_dir is missing".format(key))
+
+
+class SiblingImportsAreShippedTests(unittest.TestCase):
+    """A shipped entry point may import a sibling module by name.
+
+    udpfs_server/ps2servers_core.py does `from udpfs_server import (...)`. That
+    sibling is not a registry entry, so deriving the list from REGISTRY alone
+    would miss it and reproduce the same class of failure one level down.
+    """
+
+    @staticmethod
+    def _imported_names(path):
+        with open(path, "r", encoding="utf-8") as handle:
+            tree = ast.parse(handle.read(), filename=path)
+        names = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    names.add(alias.name.split(".")[0])
+            elif isinstance(node, ast.ImportFrom):
+                if node.level == 0 and node.module:
+                    names.add(node.module.split(".")[0])
+        return names
+
+    def test_sibling_modules_of_shipped_files_are_also_shipped(self):
+        shipped = set(BUILD.DATA_FILES)
+        packages = set(getattr(BUILD, "INCLUDE_PACKAGES", []))
+        for rel in sorted(shipped):
+            path = os.path.join(ROOT, rel)
+            directory = os.path.dirname(path)
+            for name in self._imported_names(path):
+                sibling = os.path.join(directory, name + ".py")
+                if not os.path.isfile(sibling):
+                    continue  # stdlib, third-party, or a package
+                if name in packages:
+                    continue  # compiled in as a real package instead
+                with self.subTest(source=rel, imports=name):
+                    self.assertIn(
+                        _rel(sibling), shipped,
+                        "{} imports sibling module '{}' but {} is not shipped; "
+                        "the packaged build would fail to import it".format(
+                            rel, name, _rel(sibling)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Shipped bug — packaged UDPFS is dead on arrival.** Reported by a user on `PS2Servers-windows-x64`.

## Symptom

Selecting UDPFS in a packaged build exits immediately with code 1:

```
[UDPFS] [launcher] server exited (code 1)
[UDPFS] FileNotFoundError: [Errno 2] No such file or directory:
        'C:\...\onefile_..._\udpfs_server\ps2servers_core.py'
```

## Cause

The launcher loads each Python server **by file path** at runtime, so Nuitka cannot see the import and `build/build.py` has to list the file as data.

When Edge landed, the UDPFS entry point moved to `udpfs_server/ps2servers_core.py` ([servers.py:217](../blob/main/launcher/servers.py#L217)), but `build/build.py` still listed only `udpfs_server/udpfs_server.py`. The new file was never bundled.

It is **invisible from source** — there the file is simply on disk — and nothing at build time noticed, so it shipped. Note this is *not* the `math` NameError from #125; the reporter's log shows `--tx-delay-ms 0.0` being passed correctly, so that fix is working. This is the next failure behind it.

## Fix

Rather than add one filename and wait for the next drift, `DATA_FILES` is now **derived from `REGISTRY`** — the same thing the launcher actually loads. Adding or moving a Python server can no longer silently break the packaged app.

`udpfs_server.py` stays as an explicit `SUPPORT_FILES` entry because `ps2servers_core.py` imports it by name, so it isn't discoverable from the registry. `build.py` also now fails loudly if a listed source is missing from the tree, rather than producing a quietly broken package.

## Regression test

`tests/test_packaging_data_files.py` asserts:

- every `REGISTRY` Python entry point appears in `DATA_FILES`
- every listed file actually exists
- every **sibling module a shipped file imports** is shipped too — this catches the same class of failure one level down, and specifically covers the `ps2servers_core.py` → `udpfs_server.py` dependency that a registry-only derivation would miss

**Proven to bite:** with the old hardcoded list restored, the suite fails with

```
AssertionError: 'udpfs_server/ps2servers_core.py' not found in [...]
: udpfs loads udpfs_server/ps2servers_core.py at runtime but the packaged
  build does not ship it; the packaged app will raise FileNotFoundError
  when this server is selected
```

With the fix, 4/4 pass.

Wired into `ci.yml` so this gates every PR instead of surfacing in a release.

## Verification

- New tests pass; proven to fail against the broken list
- `compileall`, release compliance, and the full Python suite (180 tests) pass
- actionlint clean

Kept deliberately small and separate from the Edge work in #127 so it can merge and cut a rolling build immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)