### PR TITLE
chore: rename the "folder" download to "portable"

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -25,15 +25,15 @@ jobs:
         include:
           - os: windows-latest
             asset_name: PS2Servers-windows-x64.zip
-            folder_asset: PS2Servers-windows-x64-folder.zip
+            portable_asset: PS2Servers-windows-x64-portable.zip
           # 32-bit Windows, for older / low-end PCs still used for SMB on OPL.
           - os: windows-latest
             asset_name: PS2Servers-windows-x86.zip
-            folder_asset: PS2Servers-windows-x86-folder.zip
+            portable_asset: PS2Servers-windows-x86-portable.zip
             win_arch: x86
           - os: ubuntu-latest
             asset_name: PS2Servers-linux-x64
-            folder_asset: PS2Servers-linux-x64-folder.tar.gz
+            portable_asset: PS2Servers-linux-x64-portable.tar.gz
           - os: macos-latest
             asset_name: PS2Servers-macos-arm64.zip
           - os: macos-latest
@@ -164,52 +164,52 @@ jobs:
       # app, no extraction bootstrap. Windows/Linux only; macOS already ships a
       # standalone .app.
       - name: Build standalone folder
-        if: matrix.folder_asset != ''
+        if: matrix.portable_asset != ''
         continue-on-error: true
         env:
           PS2_BUILD_MODE: standalone
         run: python build/build.py
 
       - name: Package Windows folder build
-        if: runner.os == 'Windows' && matrix.folder_asset != ''
+        if: runner.os == 'Windows' && matrix.portable_asset != ''
         continue-on-error: true
         shell: pwsh
         run: |
           $dist = Get-ChildItem dist -Directory -Filter *.dist | Select-Object -First 1
           if (-not $dist) { throw "standalone .dist folder not found in dist/" }
-          $packageDir = "PS2Servers-windows-${{ matrix.win_arch || 'x64' }}-folder"
+          $packageDir = "PS2Servers-windows-${{ matrix.win_arch || 'x64' }}-portable"
           New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
           Copy-Item -Path "$($dist.FullName)/*" -Destination $packageDir -Recurse -Force
           Copy-Item -Path ANTIVIRUS-NOTICE.md -Destination $packageDir -Force
           if (Test-Path build/native) {
             Copy-Item -Path build/native -Destination $packageDir -Recurse -Force
           }
-          Compress-Archive -Path $packageDir -DestinationPath ${{ matrix.folder_asset }} -Force
+          Compress-Archive -Path $packageDir -DestinationPath ${{ matrix.portable_asset }} -Force
 
       - name: Package Linux folder build
-        if: runner.os == 'Linux' && matrix.folder_asset != ''
+        if: runner.os == 'Linux' && matrix.portable_asset != ''
         continue-on-error: true
         shell: bash
         run: |
           dist=$(ls -d dist/*.dist 2>/dev/null | head -1)
           test -n "$dist"
           cp ANTIVIRUS-NOTICE.md "$dist/"
-          ( cd "$(dirname "$dist")" && tar -czf "$GITHUB_WORKSPACE/${{ matrix.folder_asset }}" "$(basename "$dist")" )
+          ( cd "$(dirname "$dist")" && tar -czf "$GITHUB_WORKSPACE/${{ matrix.portable_asset }}" "$(basename "$dist")" )
 
       - name: Generate folder artifact attestation
-        if: matrix.folder_asset != ''
+        if: matrix.portable_asset != ''
         continue-on-error: true
         uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
         with:
-          subject-path: ${{ matrix.folder_asset }}
+          subject-path: ${{ matrix.portable_asset }}
 
       - name: Upload folder release asset artifact
-        if: matrix.folder_asset != ''
+        if: matrix.portable_asset != ''
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ matrix.folder_asset }}
-          path: ${{ matrix.folder_asset }}
+          name: ${{ matrix.portable_asset }}
+          path: ${{ matrix.portable_asset }}
           if-no-files-found: error
 
   source:
@@ -263,14 +263,14 @@ jobs:
           # never blocks the release of the primary downloads.
           assets=(
             PS2Servers-linux-x64
-            PS2Servers-linux-x64-folder.tar.gz
+            PS2Servers-linux-x64-portable.tar.gz
             PS2Servers-macos-arm64.zip
             PS2Servers-macos-x64.zip
             PS2Servers-source.zip
             PS2Servers-windows-x64.zip
-            PS2Servers-windows-x64-folder.zip
+            PS2Servers-windows-x64-portable.zip
             PS2Servers-windows-x86.zip
-            PS2Servers-windows-x86-folder.zip
+            PS2Servers-windows-x86-portable.zip
           )
           present=()
           for a in "${assets[@]}"; do
@@ -306,14 +306,14 @@ jobs:
             ## Downloads
 
             **On 64-bit Windows, download the folder build**
-            (`PS2Servers-windows-x64-folder.zip`) and run `PS2Servers.exe` from
+            (`PS2Servers-windows-x64-portable.zip`) and run `PS2Servers.exe` from
             inside the folder — it is the same app without the self-extracting
             wrapper that trips antivirus heuristics, so it comes up clean. A
             single-file `PS2Servers-windows-x64.zip` is also published for
             convenience. **On 32-bit Windows** (older / low-end PCs), download
-            `PS2Servers-windows-x86-folder.zip` (or the single-file
+            `PS2Servers-windows-x86-portable.zip` (or the single-file
             `PS2Servers-windows-x86.zip`) instead — the x64 build will not run
-            there. Linux: `PS2Servers-linux-x64` (or the `-folder.tar.gz` build if
+            there. Linux: `PS2Servers-linux-x64` (or the `-portable.tar.gz` build if
             `/tmp` is `noexec`). macOS ships as a `.app`.
 
             ## Security transparency
@@ -346,14 +346,14 @@ jobs:
             https://github.com/NathanNeurotic/PS2-Servers
           files: |
             release-assets/PS2Servers-linux-x64
-            release-assets/PS2Servers-linux-x64-folder.tar.gz
+            release-assets/PS2Servers-linux-x64-portable.tar.gz
             release-assets/PS2Servers-macos-arm64.zip
             release-assets/PS2Servers-macos-x64.zip
             release-assets/PS2Servers-source.zip
             release-assets/PS2Servers-windows-x64.zip
-            release-assets/PS2Servers-windows-x64-folder.zip
+            release-assets/PS2Servers-windows-x64-portable.zip
             release-assets/PS2Servers-windows-x86.zip
-            release-assets/PS2Servers-windows-x86-folder.zip
+            release-assets/PS2Servers-windows-x86-portable.zip
             release-assets/SHA256SUMS.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,15 +28,15 @@ jobs:
         include:
           - os: windows-latest
             asset: PS2Servers-windows-x64.zip
-            folder_asset: PS2Servers-windows-x64-folder.zip
+            portable_asset: PS2Servers-windows-x64-portable.zip
           # 32-bit Windows, for older / low-end PCs still used for SMB on OPL.
           - os: windows-latest
             asset: PS2Servers-windows-x86.zip
-            folder_asset: PS2Servers-windows-x86-folder.zip
+            portable_asset: PS2Servers-windows-x86-portable.zip
             win_arch: x86
           - os: ubuntu-latest
             asset: PS2Servers-linux-x64
-            folder_asset: PS2Servers-linux-x64-folder.tar.gz
+            portable_asset: PS2Servers-linux-x64-portable.tar.gz
           - os: macos-latest
             asset: PS2Servers-macos-arm64.zip
           - os: macos-latest
@@ -162,37 +162,37 @@ jobs:
       # onefile: a plain standalone folder (no extraction bootstrap). Built only
       # for Windows/Linux (macOS already ships a standalone .app).
       - name: Build standalone folder
-        if: matrix.folder_asset != ''
+        if: matrix.portable_asset != ''
         continue-on-error: true
         env:
           PS2_BUILD_MODE: standalone
         run: python build/build.py
 
       - name: Stage Windows folder artifact
-        if: runner.os == 'Windows' && matrix.folder_asset != ''
+        if: runner.os == 'Windows' && matrix.portable_asset != ''
         continue-on-error: true
         shell: pwsh
         run: |
           $dist = Get-ChildItem dist -Directory -Filter *.dist | Select-Object -First 1
           if (-not $dist) { throw "standalone .dist folder not found in dist/" }
-          $packageDir = "out/PS2Servers-windows-${{ matrix.win_arch || 'x64' }}-folder"
+          $packageDir = "out/PS2Servers-windows-${{ matrix.win_arch || 'x64' }}-portable"
           New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
           Copy-Item -Path "$($dist.FullName)/*" -Destination $packageDir -Recurse -Force
           Copy-Item -Path ANTIVIRUS-NOTICE.md -Destination $packageDir -Force
           if (Test-Path build/native) {
             Copy-Item -Path build/native -Destination $packageDir -Recurse -Force
           }
-          Compress-Archive -Path $packageDir -DestinationPath "out/${{ matrix.folder_asset }}" -Force
+          Compress-Archive -Path $packageDir -DestinationPath "out/${{ matrix.portable_asset }}" -Force
 
       - name: Stage Linux folder artifact
-        if: runner.os == 'Linux' && matrix.folder_asset != ''
+        if: runner.os == 'Linux' && matrix.portable_asset != ''
         continue-on-error: true
         shell: bash
         run: |
           dist=$(ls -d dist/*.dist 2>/dev/null | head -1)
           test -n "$dist"
           cp ANTIVIRUS-NOTICE.md "$dist/"
-          ( cd "$(dirname "$dist")" && tar -czf "$GITHUB_WORKSPACE/out/${{ matrix.folder_asset }}" "$(basename "$dist")" )
+          ( cd "$(dirname "$dist")" && tar -czf "$GITHUB_WORKSPACE/out/${{ matrix.portable_asset }}" "$(basename "$dist")" )
 
       # An AppImage wraps the same standalone build so Linux users get desktop /
       # menu shortcuts and AppImageLauncher integration (a tester request).
@@ -201,7 +201,7 @@ jobs:
       # affects the primary Linux downloads. Files are written with printf, not
       # a heredoc, to avoid YAML indentation leaking into .desktop / AppRun.
       - name: Build Linux AppImage
-        if: runner.os == 'Linux' && matrix.folder_asset != ''
+        if: runner.os == 'Linux' && matrix.portable_asset != ''
         continue-on-error: true
         shell: bash
         run: |
@@ -253,7 +253,7 @@ jobs:
           ls -la "out/PS2Servers-x86_64.AppImage"
 
       - name: Write AppImage checksum
-        if: runner.os == 'Linux' && matrix.folder_asset != ''
+        if: runner.os == 'Linux' && matrix.portable_asset != ''
         continue-on-error: true
         shell: python
         run: |
@@ -267,14 +267,14 @@ jobs:
                   f"{digest}  {asset.name}\n", encoding="utf-8")
 
       - name: Write folder asset checksum
-        if: matrix.folder_asset != ''
+        if: matrix.portable_asset != ''
         continue-on-error: true
         shell: python
         run: |
           import hashlib
           from pathlib import Path
 
-          asset = Path("out") / "${{ matrix.folder_asset }}"
+          asset = Path("out") / "${{ matrix.portable_asset }}"
           digest = hashlib.sha256(asset.read_bytes()).hexdigest()
           checksum = asset.with_name(asset.name + ".sha256.txt")
           checksum.write_text(f"{digest}  {asset.name}\n", encoding="utf-8")
@@ -289,9 +289,9 @@ jobs:
 
           | OS | Recommended | Also available |
           | --- | --- | --- |
-          | Windows x64 | \`PS2Servers-windows-x64-folder.zip\` (folder, AV-clean) | \`PS2Servers-windows-x64.zip\` (single file) |
-          | Windows x86 (32-bit) | \`PS2Servers-windows-x86-folder.zip\` (folder, AV-clean) | \`PS2Servers-windows-x86.zip\` (single file) |
-          | Linux x64 | \`PS2Servers-linux-x64\` (single file) | \`PS2Servers-x86_64.AppImage\` (desktop/menu integration, newer) or \`PS2Servers-linux-x64-folder.tar.gz\` (folder; use if /tmp is noexec) |
+          | Windows x64 | \`PS2Servers-windows-x64-portable.zip\` (folder, AV-clean) | \`PS2Servers-windows-x64.zip\` (single file) |
+          | Windows x86 (32-bit) | \`PS2Servers-windows-x86-portable.zip\` (folder, AV-clean) | \`PS2Servers-windows-x86.zip\` (single file) |
+          | Linux x64 | \`PS2Servers-linux-x64\` (single file) | \`PS2Servers-x86_64.AppImage\` (desktop/menu integration, newer) or \`PS2Servers-linux-x64-portable.tar.gz\` (folder; use if /tmp is noexec) |
           | macOS — Apple Silicon | \`PS2Servers-macos-arm64.zip\` | |
           | macOS — Intel | \`PS2Servers-macos-x64.zip\` | |
 
@@ -340,16 +340,16 @@ jobs:
           subject-path: out/${{ matrix.asset }}
 
       - name: Attest folder build provenance
-        if: matrix.folder_asset != ''
+        if: matrix.portable_asset != ''
         continue-on-error: true
         uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
         with:
-          subject-path: out/${{ matrix.folder_asset }}
+          subject-path: out/${{ matrix.portable_asset }}
 
       - name: Attest Linux AppImage provenance
         # Same non-blocking contract as the AppImage build itself: only on Linux,
         # and never fail the release if the AppImage wasn't produced.
-        if: runner.os == 'Linux' && matrix.folder_asset != ''
+        if: runner.os == 'Linux' && matrix.portable_asset != ''
         continue-on-error: true
         uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
         with:
@@ -364,14 +364,14 @@ jobs:
             out/${{ matrix.asset }}.sha256.txt
 
       - name: Upload folder build artifact
-        if: matrix.folder_asset != ''
+        if: matrix.portable_asset != ''
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ matrix.folder_asset }}
+          name: ${{ matrix.portable_asset }}
           path: |
-            out/${{ matrix.folder_asset }}
-            out/${{ matrix.folder_asset }}.sha256.txt
+            out/${{ matrix.portable_asset }}
+            out/${{ matrix.portable_asset }}.sha256.txt
 
       # A tag with a '-' qualifier (v0.4.5-rc1, v0.5.0-beta2) is a pre-release:
       # publish it as such and never let it take the "Latest" badge from the
@@ -389,7 +389,7 @@ jobs:
             out/${{ matrix.asset }}.sha256.txt
 
       - name: Attach folder build to release
-        if: startsWith(github.ref, 'refs/tags/') && matrix.folder_asset != ''
+        if: startsWith(github.ref, 'refs/tags/') && matrix.portable_asset != ''
         continue-on-error: true
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
@@ -398,13 +398,13 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-') }}
           make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
           files: |
-            out/${{ matrix.folder_asset }}
-            out/${{ matrix.folder_asset }}.sha256.txt
+            out/${{ matrix.portable_asset }}
+            out/${{ matrix.portable_asset }}.sha256.txt
 
       - name: Attach Linux AppImage to release
         # Only if the build actually produced one -- the glob attaches nothing
         # when absent, so a failed AppImage build never blocks the release.
-        if: startsWith(github.ref, 'refs/tags/') && runner.os == 'Linux' && matrix.folder_asset != ''
+        if: startsWith(github.ref, 'refs/tags/') && runner.os == 'Linux' && matrix.portable_asset != ''
         continue-on-error: true
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:

--- a/ANTIVIRUS-NOTICE.md
+++ b/ANTIVIRUS-NOTICE.md
@@ -4,8 +4,7 @@
 homebrew tool that runs small local-network servers. Some antivirus engines flag
 the single-file build with *generic, machine-learning* warnings. This is a
 **false positive** caused by how the file is packaged — not by anything the
-program does. If you'd rather not see the warning at all, use the **folder
-build** (see below); it is the same app and comes up clean.
+program does. If you'd rather not see the warning at all, use the **portable build** (see below); it is the same app and comes up clean.
 
 ## What you might see
 
@@ -47,15 +46,15 @@ All three are normal for this kind of utility. None of them is malware.
   persistence/autostart, adware, browser modification, crypto-mining, or remote
   control. The only network activity is the LAN server(s) *you* choose to start.
 
-## If you'd rather be cautious — use the folder build
+## If you'd rather be cautious — use the portable build
 
-The release also includes a **folder build** named
-`PS2Servers-windows-x64-folder.zip`. It is the **same application**, just laid out
+The release also includes a **portable build** named
+`PS2Servers-windows-x64-portable.zip`. It is the **same application**, just laid out
 as an ordinary folder of files instead of one self-extracting `.exe`. Because it
 has no self-extraction step, it does **not** trip the heuristics above and comes
 up **clean** on antivirus.
 
-1. Download `PS2Servers-windows-x64-folder.zip` from the release page.
+1. Download `PS2Servers-windows-x64-portable.zip` from the release page.
 2. Unzip it and run `PS2Servers.exe` from inside the folder.
 
 (You can also skip the prebuilt binaries entirely and run from the Python source.)
@@ -74,7 +73,7 @@ The one thing that reliably stops these heuristic flags on the single-file `.exe
 is an **Authenticode code-signing certificate** from a certificate authority
 (OV or EV). That is a recurring paid cost — and EV also needs a hardware token —
 which is out of scope for a free hobby project. A standard certificate still has
-to *earn* SmartScreen reputation over time. Until then, the **folder build**
+to *earn* SmartScreen reputation over time. Until then, the **portable build**
 avoids the problem today, and reporting the false positive to your vendor helps
 clear it for everyone.
 

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ It detects your PC's LAN IP and shows the exact settings to enter in your loader
 than from any guide, since your address and port are specific to your machine.
 
 - **Packaged app (no Python needed):** download the release for your OS.
-  **On Windows, prefer the folder build** — unzip
-  `PS2Servers-windows-x64-folder.zip` and run **`PS2Servers.exe`** from inside
+  **On Windows, prefer the portable build** — unzip
+  `PS2Servers-windows-x64-portable.zip` and run **`PS2Servers.exe`** from inside
   the folder. It is the same app, but without the self-extracting wrapper that
   makes the single-file `.exe` trip antivirus heuristics, so it comes up clean.
   A single-file `PS2Servers-windows-x64.zip` is still provided for convenience
   if your AV doesn't object. **On 32-bit Windows, use the
-  `PS2Servers-windows-x86.zip` (or `PS2Servers-windows-x86-folder.zip`)
+  `PS2Servers-windows-x86.zip` (or `PS2Servers-windows-x86-portable.zip`)
   builds** instead (same app, built for older / low-end PCs). (Linux:
-  `PS2Servers-linux-x64`, or `PS2Servers-linux-x64-folder.tar.gz` if `/tmp` is
+  `PS2Servers-linux-x64`, or `PS2Servers-linux-x64-portable.tar.gz` if `/tmp` is
   mounted `noexec`.)
 - **From source:** double-click **`Start-Launcher.bat`** (Windows) or run
   `./start-launcher.sh` (Linux/macOS). Requires Python 3.
@@ -73,7 +73,7 @@ If a download is flagged, the antivirus statement
 version at [docs/falsepositives.html](docs/falsepositives.html)) explains exactly
 why heuristics fire, what the app does and does not do, how to verify a download,
 and how to report a false positive to each vendor. A non-self-extracting
-**folder** build is offered as an alternative download for AV-wary users.
+**portable** build is offered as an alternative download for AV-wary users.
 
 See [SECURITY.md](SECURITY.md) for verification, cleanup, and reporting details.
 See [docs/antivirus-transparency.md](docs/antivirus-transparency.md) for the
@@ -299,7 +299,7 @@ gh attestation verify PS2Servers-windows-x64.zip -R NathanNeurotic/PS2-Servers
 Checksums prove the file was downloaded intact. Attestations prove build
 provenance. Neither is a magic safety certificate. Because the app is plain
 Python and `build/build.py` rebuilds the release from source (single-file or
-`PS2_BUILD_MODE=standalone` folder build), the lowest-trust path is to inspect
+`PS2_BUILD_MODE=standalone` portable build), the lowest-trust path is to inspect
 the source and build/run it yourself — see
 [docs/antivirus-transparency.md](docs/antivirus-transparency.md) for the full
 verification, "build it yourself", and false-positive-reporting guide.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -92,9 +92,9 @@ Release assets are built by GitHub Actions from this public repository.
 Automatic releases (built on every push to `main`) include:
 
 - packaged Windows/Linux/macOS assets — for Windows the recommended download is
-  the standalone **folder** build (the single-file `.exe` can trip antivirus
-  heuristics; the folder build comes up clean), plus a single-file build per OS
-  and a standalone **folder** build for Linux (`PS2Servers-linux-x64-folder.tar.gz`);
+  the standalone **portable** build (the single-file `.exe` can trip antivirus
+  heuristics; the portable build comes up clean), plus a single-file build per OS
+  and a standalone **portable** build for Linux (`PS2Servers-linux-x64-portable.tar.gz`);
 - a portable source ZIP;
 - `SHA256SUMS.txt` for release asset checksums;
 - GitHub artifact attestations for build provenance.

--- a/docs/antivirus-transparency.md
+++ b/docs/antivirus-transparency.md
@@ -48,7 +48,7 @@ Characteristics that can trip heuristics:
 None of these is malicious behavior; each is inherent to "an unsigned, bundled,
 local network tool."
 
-## Two download shapes (folder is recommended on Windows)
+## Two download shapes (portable is recommended on Windows)
 
 **On Windows, the portable build is the recommended download.** Windows and Linux
 each ship a **portable** build (`PS2Servers-windows-x64-portable.zip` — or

--- a/docs/antivirus-transparency.md
+++ b/docs/antivirus-transparency.md
@@ -14,9 +14,9 @@ information is published at [falsepositives.html](falsepositives.html).
 - Product name: PS2 Servers
 - Windows executable: PS2Servers.exe
 - Windows release package: PS2Servers-windows-x64.zip
-- Windows folder package (alternative): PS2Servers-windows-x64-folder.zip
+- Windows portable package (alternative): PS2Servers-windows-x64-portable.zip
 - 32-bit Windows release package: PS2Servers-windows-x86.zip
-- 32-bit Windows folder package (alternative): PS2Servers-windows-x86-folder.zip
+- 32-bit Windows portable package (alternative): PS2Servers-windows-x86-portable.zip
 - Repository: https://github.com/NathanNeurotic/PS2-Servers
 
 Packaged Windows builds include version metadata: company name, product name,
@@ -50,13 +50,13 @@ local network tool."
 
 ## Two download shapes (folder is recommended on Windows)
 
-**On Windows, the folder build is the recommended download.** Windows and Linux
-each ship a **folder** build (`PS2Servers-windows-x64-folder.zip` — or
-`PS2Servers-windows-x86-folder.zip` on 32-bit Windows — and
-`PS2Servers-linux-x64-folder.tar.gz`): the same application laid out as a plain
+**On Windows, the portable build is the recommended download.** Windows and Linux
+each ship a **portable** build (`PS2Servers-windows-x64-portable.zip` — or
+`PS2Servers-windows-x86-portable.zip` on 32-bit Windows — and
+`PS2Servers-linux-x64-portable.tar.gz`): the same application laid out as a plain
 folder of the executable plus its libraries, with **no self-extracting
 bootstrap** — which is the thing that makes the single-file `.exe` trip
-antivirus/SmartScreen heuristics. The folder build comes up clean where the
+antivirus/SmartScreen heuristics. The portable build comes up clean where the
 single file does not. Unzip it and run `PS2Servers.exe` (Windows) or
 `PS2Servers` (Linux) from inside the folder. A single-file build is also
 published per platform for convenience. macOS already ships as a standalone
@@ -189,7 +189,7 @@ read, and the packaged build is reproducible from source:
 ```sh
 python -m pip install -r requirements-build.txt
 python build/build.py                       # single file -> dist/PS2Servers(.exe)
-PS2_BUILD_MODE=standalone python build/build.py   # folder build -> dist/ps2servers.dist/
+PS2_BUILD_MODE=standalone python build/build.py   # portable build -> dist/ps2servers.dist/
 ```
 
 The official builds use Python 3.12 and the Nuitka version pinned in

--- a/docs/falsepositives.html
+++ b/docs/falsepositives.html
@@ -499,7 +499,7 @@
       <ul class="checks">
         <li>Automatic (main) releases include a <code>SHA256SUMS.txt</code> manifest.</li>
         <li>Tagged releases include a <code>&lt;asset&gt;.sha256.txt</code> file next to each download.</li>
-        <li>On Windows the recommended download is the standalone <strong>portable</strong> build (no self-extracting wrapper) — it comes up clean on antivirus where the single file does not. A single-file build is also published, and Linux offers a folder build too.</li>
+        <li>On Windows the recommended download is the standalone <strong>portable</strong> build (no self-extracting wrapper) — it comes up clean on antivirus where the single file does not. A single-file build is also published, and Linux offers a portable build too.</li>
       </ul>
       <p>
         Compare the file you downloaded against the value published on that
@@ -562,7 +562,7 @@
         <li>It starts local network services by design, including UDP broadcast for PS2 auto-discovery.</li>
         <li>It may request firewall-rule changes after user consent, via a short hidden PowerShell command (without <code>-ExecutionPolicy Bypass</code>).</li>
         <li>It includes bundled runtime/application content.</li>
-        <li>The single-file build self-extracts to a temporary folder on launch and re-executes itself to run a server with the embedded interpreter — a generic packer/dropper heuristic. The <strong>folder</strong> download avoids this self-extraction step.</li>
+        <li>The single-file build self-extracts to a temporary folder on launch and re-executes itself to run a server with the embedded interpreter — a generic packer/dropper heuristic. The <strong>portable</strong> download avoids this self-extraction step.</li>
         <li>It is not yet a widely reputation-established Windows binary.</li>
       </ol>
 

--- a/docs/falsepositives.html
+++ b/docs/falsepositives.html
@@ -499,7 +499,7 @@
       <ul class="checks">
         <li>Automatic (main) releases include a <code>SHA256SUMS.txt</code> manifest.</li>
         <li>Tagged releases include a <code>&lt;asset&gt;.sha256.txt</code> file next to each download.</li>
-        <li>On Windows the recommended download is the standalone <strong>folder</strong> build (no self-extracting wrapper) — it comes up clean on antivirus where the single file does not. A single-file build is also published, and Linux offers a folder build too.</li>
+        <li>On Windows the recommended download is the standalone <strong>portable</strong> build (no self-extracting wrapper) — it comes up clean on antivirus where the single file does not. A single-file build is also published, and Linux offers a folder build too.</li>
       </ul>
       <p>
         Compare the file you downloaded against the value published on that
@@ -567,7 +567,7 @@
       </ol>
 
       <div class="callout">
-        On Windows, prefer the standalone <strong>folder</strong> build (<code>PS2Servers-windows-x64-folder.zip</code>): the same app with no self-extracting wrapper, which comes up clean on antivirus. (<code>PS2Servers-linux-x64-folder.tar.gz</code> is the Linux equivalent.) The single-file build is the one flagged by heuristics.
+        On Windows, prefer the standalone <strong>portable</strong> build (<code>PS2Servers-windows-x64-portable.zip</code>): the same app with no self-extracting wrapper, which comes up clean on antivirus. (<code>PS2Servers-linux-x64-portable.tar.gz</code> is the Linux equivalent.) The single-file build is the one flagged by heuristics.
       </div>
 
       <p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -175,10 +175,10 @@ Password          leave blank
         <div class="terminal">
           <div class="terminal-bar"><span></span><span></span><span></span></div>
           <pre><b>release assets</b>
-PS2Servers-windows-x64-folder.zip      # recommended on Windows (AV-clean)
+PS2Servers-windows-x64-portable.zip      # recommended on Windows (AV-clean)
 PS2Servers-windows-x64.zip             # single-file convenience build
 PS2Servers-linux-x64
-PS2Servers-linux-x64-folder.tar.gz
+PS2Servers-linux-x64-portable.tar.gz
 PS2Servers-macos-arm64.zip
 PS2Servers-macos-x64.zip
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -171,7 +171,7 @@ Password          leave blank
     <section class="section" id="download">
       <div class="container">
         <h2>Downloads</h2>
-        <p class="section-intro"><b>On Windows, the folder build is the recommended download</b> — it is the same app without the self-extracting wrapper that makes the single-file <code>.exe</code> trip antivirus heuristics, so it comes up clean. A single-file build is also published per OS for convenience, and macOS ships as architecture-specific app zips.</p>
+        <p class="section-intro"><b>On Windows, the portable build is the recommended download</b> — it is the same app without the self-extracting wrapper that makes the single-file <code>.exe</code> trip antivirus heuristics, so it comes up clean. A single-file build is also published per OS for convenience, and macOS ships as architecture-specific app zips.</p>
         <div class="terminal">
           <div class="terminal-bar"><span></span><span></span><span></span></div>
           <pre><b>release assets</b>


### PR DESCRIPTION
Tester feedback: *"rename folders to portable, makes it easier to understand without reading up."*

Agreed. "Folder build" describes how the download is laid out **internally** — it only means anything once you already know the single-file build exists and why it trips antivirus. "Portable" says what it is *for*. Since this is the build Windows users are actively steered toward, its name shouldn't need a footnote.

| Before | After |
| --- | --- |
| `PS2Servers-windows-x64-folder.zip` | `PS2Servers-windows-x64-portable.zip` |
| `PS2Servers-windows-x86-folder.zip` | `PS2Servers-windows-x86-portable.zip` |
| `PS2Servers-linux-x64-folder.tar.gz` | `PS2Servers-linux-x64-portable.tar.gz` |

## Scope

Renames the assets, the matrix key (`folder_asset` → `portable_asset`), the staging directory, and the prose across `README.md`, `SECURITY.md`, `ANTIVIRUS-NOTICE.md`, `docs/antivirus-transparency.md`, and **both GitHub Pages files** (`docs/index.html`, `docs/falsepositives.html`) — those document the download by name, so missing them would leave the published site pointing at filenames that no longer exist.

**"Folder" is kept where it means an actual directory**: games folder, temporary folder, folder browsing, the repo-layout table, and "run `PS2Servers.exe` from inside the folder". Only the download name changed.

## Worth knowing before merging

This changes **published download filenames**. Links posted elsewhere (forum threads, PSX-Place, etc.) pointing at the old names will 404 against future releases. Existing releases keep their existing assets, so nothing already published breaks — but it is a user-visible rename, so it's your call whether the clarity is worth it.

## Note on actionlint

actionlint still reports the pre-existing `matrix.macos_target_arch` typo in `release-on-main.yml`. That line is **deliberately untouched here** — #127 already corrects it, and fixing it in both branches would conflict on merge.

## Verification

- All four workflows parse; release compliance passes
- Zero `-folder.zip` / `-folder.tar.gz` references remain anywhere in the repo
- Real-directory uses of the word "folder" confirmed preserved

Separate from #128 (the packaging hotfix) so that fix can merge immediately without carrying a cosmetic rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Releases now include standalone portable packages for Windows and Linux.
  - Portable ZIP and TAR downloads are available alongside existing single-file builds.
  - Release checksums, attestations, and download listings now cover portable artifacts.

- **Documentation**
  - Updated Windows and Linux download guidance to recommend portable builds.
  - Clarified portable builds avoid self-extracting startup behavior and may reduce antivirus warnings.
  - Updated verification, security, and build instructions with portable artifact names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->