### PR TITLE
fix(ci): correct GOOS in Edge archive metadata, harden checkout

### DIFF
--- a/.github/workflows/edge-build.yml
+++ b/.github/workflows/edge-build.yml
@@ -219,6 +219,12 @@ jobs:
               reports x86_64.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # This job holds contents/id-token/attestations write. Leaving the
+          # default credential helper configured would keep that token
+          # available to everything that follows, including `go build`
+          # fetching modules. edge.yml's test job already does this.
+          persist-credentials: false
       - uses: actions/setup-go@v6.4.0
         with:
           go-version-file: native/ps2servers-edge/go.mod
@@ -245,11 +251,15 @@ jobs:
           GOMIPS: ${{ matrix.gomips }}
           GOMIPS64: ${{ matrix.gomips64 }}
           SOURCE_DATE_EPOCH: ${{ steps.version.outputs.source_date_epoch }}
+          # Through env, not inline ${{ }}: on a tag push this is GITHUB_REF_NAME
+          # verbatim, and git permits characters in a tag name that would be
+          # interpreted by the shell if pasted into the script body.
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
           mkdir -p "$GITHUB_WORKSPACE/out/stage"
           go build -trimpath -buildvcs=true \
-            -ldflags="-s -w -buildid= -X main.version=${{ steps.version.outputs.version }}" \
+            -ldflags="-s -w -buildid= -X main.version=${VERSION}" \
             -o "$GITHUB_WORKSPACE/out/stage/ps2servers-edge${{ matrix.ext }}" ./cmd/ps2servers-edge
       - name: Inspect and package artifact
         shell: bash
@@ -265,6 +275,7 @@ jobs:
           GOMIPS_V: ${{ matrix.gomips }}
           GOMIPS64_V: ${{ matrix.gomips64 }}
           VERSION: ${{ steps.version.outputs.version }}
+          EPOCH: ${{ steps.version.outputs.source_date_epoch }}
           EXT: ${{ matrix.ext }}
           ARCHIVE: ${{ matrix.archive }}
           GOOS_V: ${{ matrix.goos }}
@@ -302,7 +313,7 @@ jobs:
             printf 'error". Nothing is damaged; just try another one.\n\n'
             printf -- '-------------------------------------\n\n'
             printf 'WHAT THIS BUILD IS\n\n'
-            printf '  Go target      : GOOS=linux GOARCH=%s' "${GOARCH_V}"
+            printf '  Go target      : GOOS=%s GOARCH=%s' "${GOOS_V}" "${GOARCH_V}"
             [ -n "${GOARM_V}" ]     && printf ' GOARM=%s' "${GOARM_V}"
             [ -n "${GOMIPS_V}" ]    && printf ' GOMIPS=%s' "${GOMIPS_V}"
             [ -n "${GOMIPS64_V}" ]  && printf ' GOMIPS64=%s' "${GOMIPS64_V}"
@@ -340,7 +351,7 @@ jobs:
             # SOURCE_DATE_EPOCH. zip(1) stores real mtimes, which would make
             # two builds of the same commit differ and undermine the
             # attestation the next step produces.
-            SOURCE_DATE_EPOCH="${{ steps.version.outputs.source_date_epoch }}" \
+            SOURCE_DATE_EPOCH="${EPOCH}" \
             PKG="${package}" python3 - <<'PYZIP'
           import os, time, zipfile
           pkg = os.environ["PKG"]
@@ -368,7 +379,7 @@ jobs:
             sha256sum "out/${package}.zip" > "out/${package}.zip.sha256"
           else
             tar --sort=name --owner=0 --group=0 --numeric-owner \
-              --mtime="@${{ steps.version.outputs.source_date_epoch }}" \
+              --mtime="@${EPOCH}" \
               -czf "out/${package}.tar.gz" -C out "${package}"
             sha256sum "out/${package}.tar.gz" > "out/${package}.tar.gz.sha256"
           fi

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -16,6 +16,11 @@ on:
       - "docs/THIRD-PARTY.md"
       - "THIRD_PARTY_NOTICES.md"
       - ".github/workflows/edge.yml"
+      # The reusable workflow holds the entire build matrix and the packaging
+      # script, so a change there affects every target. Without this path a PR
+      # editing only edge-build.yml runs no Edge builds at all -- which is
+      # exactly what happened on the PR that added this line.
+      - ".github/workflows/edge-build.yml"
   push:
     branches: [main]
     tags: ["v*"]


### PR DESCRIPTION
Follow-up to #127, which is already merged. Three verified review findings — one is a real bug currently on `main`.

## 1. Every Windows and macOS Edge archive claims to be a Linux build 🐛

`WHICH-DEVICE.txt` hardcoded `GOOS=linux`:

```
printf '  Go target      : GOOS=linux GOARCH=%s' "${GOARCH_V}"
```

`GOOS_V` was already in the step env and already used for the quick-start line — the target line just never used it. So `PS2ServersEdge-<ver>-windows-64bit.zip` shipped metadata saying it was a Linux binary, which is exactly the kind of thing someone checks when a download won't run.

Fixed and confirmed by regenerating the file:

```
  Go target      : GOOS=windows GOARCH=amd64
  Internal name  : windows-amd64
    ps2servers-edge.exe udpfs --root D:\PS2Games
```

## 2. Checkout kept credentials available to the whole build job

The reusable build job holds `contents: write`, `id-token: write` and `attestations: write`, but left `actions/checkout` at the default `persist-credentials: true`. That leaves a git credential helper configured for everything after it — including `go build` fetching modules.

`edge.yml`'s own `test` job already sets `persist-credentials: false`; the job extracted into `edge-build.yml` didn't inherit it. Now matches.

## 3. Version values were pasted into shell bodies

`VERSION` and `source_date_epoch` were interpolated inline with `${{ }}` — while the very next step carries a comment explaining why matrix values go through `env` instead. On a tag push `VERSION` is `GITHUB_REF_NAME` verbatim, and git permits characters in a tag name that the shell would interpret. Both now route through `env`.

## Not taken: enforcing the declared WRITE_REQ size

CodeRabbit flagged that the client-declared `size` is only used as buffer capacity, so a client can announce 10 bytes and assemble up to the 8 MiB cap. Mechanically correct, but I'm not applying it:

- **The hardware-validated Python reference behaves identically** — `_handle_write_req` stores `size` and never rechecks it. Enforcing a bound the reference treats as advisory risks refusing writes from a real console that under-declares, and I have no hardware to A/B that.
- **The security property already holds.** `maxWriteBytes` is the real boundary; per-peer memory is capped at 8 MiB regardless, and an oversized declaration is already rejected up front with `EFBIG`.

Reasoning posted on the thread rather than silently dropped. Worth revisiting if a console is ever observed sending an accurate size — that would let the bound shrink from 8 MiB to the announced value.

## Verification

- actionlint clean
- A script check confirms **every `${VAR}` in every `run:` body is declared in that step's `env`** — I introduced and then caught exactly that bug mid-edit (referencing `${EPOCH}` before declaring it), which under `set -u` would have aborted the build
- Windows packaging re-simulated end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build reproducibility with deterministic timestamps in packaged artifacts.
  * Enhanced portability by accurately recording the operating system and architecture for each build.
  * Reduced credential exposure during the build process.
  * Improved version handling in generated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->