### PR TITLE
fix(edge): offer the Modulo fallback after a sequence-zero discovery

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -62,6 +62,53 @@ jobs:
           python udpfs_server/pathguard_selftest.py
           python udpfs_server/compression_selftest.py
 
+      # Drives the shared conformance probe against a real Edge process over
+      # real UDP sockets: standards client plus three Modulo-shaped ones,
+      # concurrently, covering the 4095 -> 0 sequence wrap and comparing
+      # returned bytes against the source file. Go unit tests exercise Edge's
+      # own helpers; this checks the bytes it actually puts on the wire, which
+      # is the part that has to match a console.
+      #
+      # This earns the "integration tested" label in conformance/README.md.
+      # It is NOT a hardware claim -- see docs/EDGE.md validation status.
+      - name: UDPFS conformance probe against Edge
+        shell: bash
+        run: |
+          set -euo pipefail
+          port=62966
+          root="$(mktemp -d)"
+          # Deterministic fixture so a failure is reproducible. Keep it inside
+          # one UDPRDMA payload (MaxPayload is 1408): the probe compares the
+          # bytes from a single READ reply and does not reassemble a fragmented
+          # transfer, so a larger fixture reports a false "READ mismatch"
+          # against a perfectly healthy server -- verified by reproducing that
+          # against the Python core as well as Edge.
+          python - "$root/probe.iso" <<'PYFIX'
+          import sys
+          with open(sys.argv[1], "wb") as f:
+              f.write(bytes([(i * 7) & 0xFF for i in range(1024)]))
+          PYFIX
+
+          go build -o "$RUNNER_TEMP/ps2servers-edge" ./cmd/ps2servers-edge
+          "$RUNNER_TEMP/ps2servers-edge" udpfs --root "$root" --bind 127.0.0.1 --port "$port" &
+          edge_pid=$!
+          trap 'kill "$edge_pid" 2>/dev/null || true' EXIT
+
+          # Wait for the discovery socket to be bound. A UDP connect() always
+          # succeeds, so poll the listening table instead of probing blindly.
+          for _ in $(seq 1 50); do
+            if ss -lun 2>/dev/null | grep -q ":${port}\b"; then break; fi
+            sleep 0.2
+          done
+          if ! kill -0 "$edge_pid" 2>/dev/null; then
+            echo "::error::Edge exited before the probe could run"
+            exit 1
+          fi
+
+          python "$GITHUB_WORKSPACE/conformance/integration/udpfs_probe.py" \
+            --host 127.0.0.1 --port "$port" --root "$root" --path probe.iso
+        working-directory: native/ps2servers-edge
+
   build:
     name: Build Edge
     needs: test

--- a/docs/EDGE.md
+++ b/docs/EDGE.md
@@ -145,11 +145,26 @@ they held is released. Normal logs do not print full requested host paths.
 
 - unit tested: yes
 - loopback integration tested: yes
+- shared conformance probe (`conformance/integration/udpfs_probe.py`): yes, run
+  against a live Edge process in CI — standard plus three Modulo-shaped clients
+  concurrently, covering the 4095 → 0 sequence wrap
 - parser fuzz seeds: yes
 - `go vet`: passed in the implementation environment
-- eight Linux target builds: compiled and inspected
+- sixteen target builds (eleven Linux, three Windows, two macOS): compiled and
+  inspected
 - emulator tested: no
 - physical PS2 hardware tested: no
+- **file writes: not verified on hardware or an emulator.** The write path is
+  implemented against the Python server's wire behaviour and covered by unit
+  and loopback tests only. No console has been observed writing through Edge.
+  Writes are off by default for this reason.
 
 Hardware validation must be recorded separately before making a hardware-success
 claim.
+
+The conformance probe is worth its place: it caught a real defect the Go unit
+tests could not see. `classify()` returned `Modulo` correctly for the
+`modulo-fresh` case (discovery 0, first data 1), but `handleDiscovery` committed
+a sequence-zero discovery straight to `Standard` and never scheduled the
+compatibility INFORM, so a fresh Modulo client waited forever. The classifier
+was right; the path that reaches it was not.

--- a/native/ps2servers-edge/internal/udpfs/negotiation.go
+++ b/native/ps2servers-edge/internal/udpfs/negotiation.go
@@ -67,14 +67,24 @@ func (s *Server) handleDiscovery(in inbound, h protocol.Header) {
 		st.Profile = session.Modulo
 		s.sendModuloInform(st)
 	case session.Pending:
-		if h.Sequence == 0 {
-			st.Profile = session.Standard
-			s.sendStandardInform(st)
-		} else {
-			st.Profile = session.Pending
-			s.sendStandardInform(st)
-			s.scheduleFallback(st)
-		}
+		// A sequence-zero discovery used to commit straight to Standard and
+		// skip the fallback. That silently broke the shared conformance case
+		// "modulo-fresh" (discovery 0, first data 1): a fresh Modulo client
+		// waits for the compatibility INFORM before sending anything, so it
+		// never got one, and because Profile was already Standard rather than
+		// Pending the classify() path in handleData never ran either -- the
+		// session stayed misclassified for its whole life. classify() itself
+		// was correct, which is why the unit tests passed while a real client
+		// timed out.
+		//
+		// Staying Pending is safe for standard clients: scheduleFallback bails
+		// when the generation moved on, when Streaming, or when the first DATA
+		// has already resolved Profile away from Pending -- which is exactly
+		// what a standard client does. Re-broadcast during a live transfer is
+		// handled by the Streaming guard above, before this switch.
+		st.Profile = session.Pending
+		s.sendStandardInform(st)
+		s.scheduleFallback(st)
 	}
 }
 

--- a/native/ps2servers-edge/internal/udpfs/negotiation_seq0_test.go
+++ b/native/ps2servers-edge/internal/udpfs/negotiation_seq0_test.go
@@ -1,6 +1,7 @@
 package udpfs
 
 import (
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -112,7 +113,13 @@ func TestStandardClientDoesNotReceiveModuloFallback(t *testing.T) {
 	for {
 		n, from, err := client.ReadFromUDP(buf)
 		if err != nil {
-			return // timed out with no stray INFORM, which is the pass condition
+			// Only the deadline elapsing proves nothing arrived. Treating any
+			// error as success would let a broken socket pass this silently.
+			var nerr net.Error
+			if errors.As(err, &nerr) && nerr.Timeout() {
+				return
+			}
+			t.Fatalf("unexpected socket error while watching for a stray INFORM: %v", err)
 		}
 		fh, perr := protocol.ParseHeader(buf[:n])
 		if perr == nil && fh.Type == protocol.Inform && from.Port == disc.Port {

--- a/native/ps2servers-edge/internal/udpfs/negotiation_seq0_test.go
+++ b/native/ps2servers-edge/internal/udpfs/negotiation_seq0_test.go
@@ -1,0 +1,122 @@
+package udpfs
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/protocol"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/session"
+)
+
+// A fresh Modulo client opens with discovery sequence 0 and waits for the
+// compatibility INFORM before sending anything. handleDiscovery used to treat
+// sequence 0 as proof of a standard client: it committed Profile to Standard
+// and skipped scheduleFallback, so that INFORM never arrived and the client sat
+// there until it timed out. Because Profile was already Standard rather than
+// Pending, the classify() path in handleData never ran either, so the session
+// stayed misclassified for its whole life.
+//
+// classify(0, 1) returns Modulo correctly, which is why the unit tests passed
+// while the shared conformance probe timed out against a real Edge process on
+// exactly the fixture named "modulo-fresh" in
+// conformance/fixtures/handshake_cases.json.
+//
+// This test drives the discovery handshake over real sockets, because the bug
+// lived in the path between discovery and the first DATA packet -- the part a
+// classifier unit test cannot see.
+func TestSequenceZeroDiscoveryStillOffersModuloFallback(t *testing.T) {
+	_, disc, _ := startTestServer(t, session.Pending)
+	client, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	if _, err := client.WriteToUDP(discoveryPacket(0), disc); err != nil {
+		t.Fatal(err)
+	}
+
+	canonical, canonicalFrom := recvPacket(t, client)
+	h, err := protocol.ParseHeader(canonical)
+	if err != nil || h.Type != protocol.Inform {
+		t.Fatalf("first reply was not an INFORM: %v %+v", err, h)
+	}
+	if canonicalFrom.Port == disc.Port {
+		t.Fatalf("canonical INFORM came from the discovery port %d; expected the data port", disc.Port)
+	}
+
+	// The fallback is what a fresh Modulo client is waiting on. It must arrive
+	// without the client sending any DATA first, and on the discovery port.
+	if err := client.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 64*1024)
+	for {
+		n, from, err := client.ReadFromUDP(buf)
+		if err != nil {
+			t.Fatalf("no Modulo fallback INFORM after a sequence-zero discovery: %v "+
+				"(a fresh Modulo client would hang here)", err)
+		}
+		fh, err := protocol.ParseHeader(buf[:n])
+		if err != nil || fh.Type != protocol.Inform {
+			continue
+		}
+		if from.Port != disc.Port {
+			// Another canonical INFORM; keep waiting for the discovery-port one.
+			continue
+		}
+		return // fallback delivered on the discovery port
+	}
+}
+
+// The companion case: a standard client that answers promptly must not be sent
+// the compatibility INFORM. scheduleFallback bails once the first DATA has
+// moved Profile off Pending, and this pins that behaviour so widening the
+// sequence-zero path did not start spraying Modulo INFORMs at standard clients.
+func TestStandardClientDoesNotReceiveModuloFallback(t *testing.T) {
+	_, disc, _ := startTestServer(t, session.Pending)
+	client, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	if _, err := client.WriteToUDP(discoveryPacket(0), disc); err != nil {
+		t.Fatal(err)
+	}
+	canonical, dataAddr := recvPacket(t, client)
+	if h, err := protocol.ParseHeader(canonical); err != nil || h.Type != protocol.Inform {
+		t.Fatalf("expected canonical INFORM: %v", err)
+	}
+
+	// Standard shape: first DATA sequence equals the discovery sequence.
+	open := make([]byte, 8)
+	open[0] = byte(protocol.OpenRequest)
+	open = append(open, []byte("game.iso\x00")...)
+	if _, err := client.WriteToUDP(dataPacket(0, open), dataAddr); err != nil {
+		t.Fatal(err)
+	}
+	respHeader, payload, respAddr := recvDataPayload(t, client)
+	if protocol.MessageType(payload[0]) != protocol.OpenReply {
+		t.Fatalf("expected OPEN reply, got opcode 0x%02x", payload[0])
+	}
+	_, _ = client.WriteToUDP(ackPacket(respHeader.Sequence), respAddr)
+
+	// Past the fallback delay, nothing further should arrive from the
+	// discovery port.
+	if err := client.SetReadDeadline(time.Now().Add(400 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 64*1024)
+	for {
+		n, from, err := client.ReadFromUDP(buf)
+		if err != nil {
+			return // timed out with no stray INFORM, which is the pass condition
+		}
+		fh, perr := protocol.ParseHeader(buf[:n])
+		if perr == nil && fh.Type == protocol.Inform && from.Port == disc.Port {
+			t.Fatal("standard client received a Modulo fallback INFORM it never needed")
+		}
+	}
+}


### PR DESCRIPTION
**Found a real Edge defect** by running the shared conformance probe against a live Edge process for the first time. Fixes it, guards it, and wires the probe into CI.

## The bug

Same fixture, same probe, deterministic across three runs:

| Case | Python core | Edge (before) |
| --- | --- | --- |
| `(0, 0)` standard | pass | pass |
| **`(0, 1)` modulo** — `modulo-fresh` | **pass** | **TIMEOUT** |
| `(7, 8)` modulo | pass | pass |
| `(4095, 0)` modulo | pass | pass |

`handleDiscovery` treated a sequence-zero discovery as proof of a standard client:

```go
if h.Sequence == 0 {
    st.Profile = session.Standard
    s.sendStandardInform(st)      // no scheduleFallback
} else {
    s.sendStandardInform(st)
    s.scheduleFallback(st)
}
```

A **fresh Modulo client waits for the compatibility INFORM before sending anything**, so it never got one and hung. And because `Profile` was already `Standard` rather than `Pending`, the `classify()` call in `handleData` never ran either — the session stayed misclassified for its whole life.

`conformance/fixtures/handshake_cases.json` has specified the correct behaviour all along:

```json
{ "name": "modulo-fresh", "discovery": 0, "first_data": 1, "profile": "modulo" }
```

**Why the unit tests missed it:** they exercise `classify()` directly, and `classify(0, 1)` correctly returns `Modulo`. The classifier was right; the path that reaches it was not. That gap is the whole argument for the probe.

## The fix

Sequence zero now stays `Pending` and schedules the fallback like any other sequence.

Safe for standard clients — `scheduleFallback` already bails when the generation moved on, when `Streaming`, or when the first DATA resolved `Profile` away from `Pending`, which is exactly what a standard client does. Re-broadcast during a live transfer is handled by the `Streaming` guard **above** the switch and is untouched.

## Guards

Both drive real sockets, because the defect lived between discovery and the first DATA packet:

- `TestSequenceZeroDiscoveryStillOffersModuloFallback` — **fails against the previous code** with `no Modulo fallback INFORM after a sequence-zero discovery (a fresh Modulo client would hang here)`
- `TestStandardClientDoesNotReceiveModuloFallback` — pins that widening the path didn't start spraying Modulo INFORMs at standard clients

Plus the probe itself now runs in `edge.yml` against a live Edge process.

## A false alarm worth recording

My first probe run "failed" against Edge with a byte mismatch. It was my fixture: 64 KB exceeds what the probe collects, because it compares a single READ reply and doesn't reassemble a fragmented transfer. Running the **same fixture against the Python core reproduced the identical failure**, which proved it was the harness, not Edge — and stopped a phantom bug being filed. The CI step now pins the fixture inside one UDPRDMA payload with a comment explaining why.

## Docs

`docs/EDGE.md` validation status: adds the probe, corrects the stale **"eight Linux target builds"** to sixteen across three OSes, and states plainly that **the write path has no hardware or emulator verification** — it's implemented against the Python server's wire behaviour and covered by unit and loopback tests only. Writes stay off by default for that reason.

## Verification

- Probe passes 3/3 against patched Edge; fails deterministically against the previous build
- `go test -race ./...` and `go vet` clean
- actionlint clean; heredoc dedent verified so the terminator lands at column 0

Answers the question that prompted this: **no, Edge's correctness cannot be inferred from udpfsd.** Edge is an independent implementation and it diverged from the hardware-validated reference on a case the repo's own fixtures define.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated UDPFS discovery handling for sequence-zero clients to consistently follow the pending flow and schedule the Modulo fallback.
  * Ensured standard clients don’t receive unnecessary fallback INFORMs.
* **Tests**
  * Added integration tests covering sequence-zero discovery handshake behavior and timing.
  * Expanded CI with a UDPFS conformance probe running against a live Edge process and validating deterministic ISO fixture bytes.
* **Documentation**
  * Updated EDGE validation status to reflect broader CI conformance coverage and clarified write-path verification limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->