### PR TITLE
feat(edge): allow writes by default, and make the OpenWrt option real

### DIFF
--- a/docs/EDGE-WHICH-BUILD.md
+++ b/docs/EDGE-WHICH-BUILD.md
@@ -150,11 +150,11 @@ System Settings → Privacy & Security.
 
 ## Letting the console write (saves)
 
-Every build is **read-only by default**. To let the PS2 write — memory-card
-saves, for instance — add `--read-only=false`:
+Every build **allows writes by default**, so memory-card saves work with no
+extra flags. To serve read-only instead, add `--read-only`:
 
 ```sh
-./ps2servers-edge udpfs --root /path/to/games --read-only=false
+./ps2servers-edge udpfs --root /path/to/games --read-only
 ```
 
 Only one console may hold a given file open for writing at a time; a second one

--- a/docs/EDGE.md
+++ b/docs/EDGE.md
@@ -14,12 +14,12 @@ ps2servers-edge udpfs \
   --protocol-mode auto \
   --data-port 0 \
   --peer-timeout 1h \
-  --read-only \
   --log-format text
 ```
 
 Important options:
 
+- `--read-only` — serve read-only; writes are allowed by default
 - `--protocol-mode auto|standard|modulo`
 - `--modulo-mode` — deprecated alias for strict Modulo mode
 - `--single-port`
@@ -110,14 +110,18 @@ Desktop/Core UDPBD is unchanged.
 
 ## Writes
 
-Edge supports file writes, so a console can save. They are **off by default**;
-pass `--read-only=false` (or `RO=false`) to enable them.
+Edge supports file writes, so a console can save. They are **on by default**,
+matching the Desktop/Core server and udpfsd. UDPFS is a two-way protocol in
+practice — a console that loads a game off the share usually wants to write its
+saves back to the same place — so a read-only default would make Edge quietly
+less capable than its siblings for the ordinary case.
 
-The default differs from the Desktop server and from udpfsd, both of which
-default to writable. Edge normally runs unauthenticated on a router or NAS
-where the share may be an entire disk, and it shipped read-only, so enabling
-writes is a deliberate act rather than something an upgrade does silently. The
-OpenWrt package ships `option read_only '1'` regardless.
+Pass `--read-only` (or `RO=1`) to serve read-only instead.
+
+**The OpenWrt package still starts read-only** unless the operator opts in, via
+`option read_only '1'` in `/etc/config/ps2servers-edge`. A router share is
+frequently an entire attached disk, and the service is unauthenticated on the
+LAN, so writes are opt-in on that platform regardless of the binary default.
 
 With writes enabled:
 
@@ -137,7 +141,7 @@ Block-device writes (`BWRITE`) are not implemented; file writes only.
 Edge enforces a configured filesystem root. It rejects `..`, absolute and
 drive-qualified paths, unsafe symbolic links, oversized paths, oversized reads
 and writes, malformed packet lengths, unknown packet types, and excessive open
-handles. It is read-only unless explicitly started with `--read-only=false`.
+handles. It serves writes unless started with `--read-only`.
 Idle sessions are removed, their files are closed, and any write reservation
 they held is released. Normal logs do not print full requested host paths.
 
@@ -157,7 +161,7 @@ they held is released. Normal logs do not print full requested host paths.
 - **file writes: not verified on hardware or an emulator.** The write path is
   implemented against the Python server's wire behaviour and covered by unit
   and loopback tests only. No console has been observed writing through Edge.
-  Writes are off by default for this reason.
+  Treat the write path as the least-proven part of Edge.
 
 Hardware validation must be recorded separately before making a hardware-success
 claim.

--- a/native/ps2servers-edge/README.md
+++ b/native/ps2servers-edge/README.md
@@ -8,8 +8,8 @@ single binary for people who want no Python runtime.
 go build ./cmd/ps2servers-edge
 ./ps2servers-edge udpfs --root /mnt/games --protocol-mode auto
 
-# Allow the console to write (memory-card saves). Off by default.
-./ps2servers-edge udpfs --root /mnt/games --read-only=false
+# Serve read-only. Writes are allowed by default, so saves work without this.
+./ps2servers-edge udpfs --root /mnt/games --read-only
 ```
 
 Edge is one edition of PS2 Servers; it does not replace the desktop launcher.
@@ -26,18 +26,21 @@ both can transfer concurrently.
   O_TRUNC and O_APPEND, one writer per file at a time
 - retransmission, NACK handling, send windows, sequence wraparound
 - multiple clients and idle cleanup
-- safe rooted filesystem, read-only unless `--read-only=false`
+- safe rooted filesystem; writes allowed unless `--read-only` is passed
 - ISO, CSO/CISO, ZSO/ZISO
 - text and JSON logs
 - graceful SIGINT/SIGTERM shutdown
 
 ## Writes
 
-Off by default: Edge normally runs unauthenticated on a LAN, and it shipped
-read-only, so enabling writes is a deliberate choice rather than something an
-upgrade does silently. Pass `--read-only=false` (or `RO=false`) to allow them.
+On by default, matching the Desktop/Core server and udpfsd. UDPFS is a two-way
+protocol in practice: a console loading a game off the share usually wants to
+write its saves back to it. Pass `--read-only` (or `RO=1`) to serve read-only.
 
-When enabled:
+The OpenWrt package still starts read-only unless the operator sets
+`option read_only '0'` — a router share is often an entire attached disk.
+
+Guarantees:
 
 - a second peer opening the same file for writing gets `EBUSY`, since two
   consoles interleaving into one file would corrupt it

--- a/native/ps2servers-edge/cmd/ps2servers-edge/main.go
+++ b/native/ps2servers-edge/cmd/ps2servers-edge/main.go
@@ -55,11 +55,16 @@ func main() {
 	singlePort := fs.Bool("single-port", envBool("SINGLE_PORT", false), "use discovery port for all traffic")
 	timeoutText := fs.String("peer-timeout", env("PEER_TIMEOUT", "1h"), "idle session timeout")
 	txDelayMs := fs.Float64("tx-delay-ms", envFloat("TX_DELAY_MS", 0.0), "inter-packet transmit delay in milliseconds")
-	// Defaults to read-only, unlike the Desktop server and udpfsd which
-	// default to writable. Edge runs unauthenticated on routers and NAS boxes
-	// where the game share is often the whole disk, and it shipped read-only,
-	// so writes are opt-in rather than a silent posture change on upgrade.
-	readOnly := fs.Bool("read-only", envBool("RO", true), "serve files read-only; pass --read-only=false to allow writes")
+	// Writable by default, matching the Desktop/Core server and udpfsd. UDPFS
+	// is a two-way protocol in practice -- a console that loads a game off the
+	// share usually wants to write its saves back to it -- so a read-only
+	// default makes Edge quietly less capable than its siblings for the normal
+	// case. Pass --read-only (or RO=1) to serve read-only.
+	//
+	// The OpenWrt package still starts read-only unless the operator opts in,
+	// because a router share is often an entire attached disk. See
+	// packaging/openwrt/files/ps2servers-edge.config.
+	readOnly := fs.Bool("read-only", envBool("RO", false), "serve files read-only; omit to allow the console to write saves")
 	logFormat := fs.String("log-format", env("LOG_FORMAT", "text"), "text or json")
 	verbose := fs.Bool("verbose", envBool("VERBOSE", false), "verbose protocol logging")
 	quiet := fs.Bool("quiet", false, "suppress informational logs")

--- a/packaging/openwrt/files/ps2servers-edge.init
+++ b/packaging/openwrt/files/ps2servers-edge.init
@@ -33,8 +33,14 @@ start_service() {
                 --data-port "$data_port" \
                 --protocol-mode "$protocol" \
                 --peer-timeout "$peer_timeout" \
-                --log-format "$log_format" \
-                --read-only
+                --log-format "$log_format"
+        # --read-only used to be hardcoded here, which made the read_only UCI
+        # option decorative: setting it to 0 changed nothing. It is honoured
+        # now, and still defaults to 1 -- a router share is frequently an
+        # entire attached disk, so writes stay opt-in on this platform even
+        # though the binary itself defaults to writable.
+        config_get_bool read_only main read_only 1
+        [ "$read_only" -eq 1 ] && procd_append_param command --read-only
         append_bool_flag main single_port --single-port
         append_bool_flag main verbose --verbose
         procd_set_param user ps2edge


### PR DESCRIPTION
You were right, and my reasoning for read-only was weaker than I presented it.

UDPFS is a two-way protocol in practice — a console loading a game off the share usually wants to write its saves back to the same place. Defaulting Edge to read-only made it quietly less capable than its own siblings for the ordinary case. The Desktop/Core server and udpfsd both default to writable; Edge now matches. `--read-only` (or `RO=1`) restores the old behaviour.

## Both of my objections fell over on inspection

**"Silent posture change on upgrade"** — barely applies. Edge has no tagged release yet, only rolling builds. There's essentially no installed base to surprise.

**"Routers would become writable"** — doesn't follow. The OpenWrt init passes `--read-only`, so those installs stay read-only regardless of the binary default.

## A bug found while checking that second point 🐛

The init **hardcoded** `--read-only` and never read the `read_only` UCI option:

```sh
procd_set_param command "$PROG" udpfs \
        ... \
        --read-only          # unconditional
```

So `option read_only '0'` in `/etc/config/ps2servers-edge` did **nothing**. The config line was decorative — an operator who deliberately enabled writes got a read-only server with no indication why.

It's honoured now, and still defaults to `1`. A router share is frequently an entire attached disk and the service is unauthenticated on the LAN, so writes stay opt-in on that platform even though the binary allows them. That split feels right: the binary matches its family, the constrained deployment stays conservative, and the setting that claims to control it actually does.

## Docs

Updated across `EDGE.md`, `EDGE-WHICH-BUILD.md` and the Edge README — including removing `--read-only` from the canonical run example, where it now contradicts the default it sits next to.

**Unchanged:** the validation status still records that the write path has **no hardware or emulator verification**. Enabling it by default doesn't make it more proven, and that line stands until a console is actually observed writing through Edge. This raises the value of that test, it doesn't substitute for it.

## Verification

- `go vet` and `go test -race ./...` clean
- All five `openwrt-source-check` assertions still hold
- No stale `--read-only=false` wording left anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)