### PR TITLE
ci: bump + SHA-pin actions, and make the release page pickable at a glance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/edge-build.yml
+++ b/.github/workflows/edge-build.yml
@@ -218,14 +218,14 @@ jobs:
               launcher ships separately as PS2Servers-macos-x64.zip. uname -m
               reports x86_64.
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # This job holds contents/id-token/attestations write. Leaving the
           # default credential helper configured would keep that token
           # available to everything that follows, including `go build`
           # fetching modules. edge.yml's test job already does this.
           persist-credentials: false
-      - uses: actions/setup-go@v6.4.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: native/ps2servers-edge/go.mod
           cache: false

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -36,14 +36,14 @@ jobs:
     name: Edge and Core tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6.4.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: native/ps2servers-edge/go.mod
           cache-dependency-path: native/ps2servers-edge/go.mod
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Test and vet Edge
@@ -125,7 +125,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Validate package files
         run: |
           set -euo pipefail

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -334,16 +334,39 @@ jobs:
 
             ## Downloads
 
-            **On 64-bit Windows, download the portable build**
-            (`PS2Servers-windows-x64-portable.zip`) and run `PS2Servers.exe` from
-            inside the folder — it is the same app without the self-extracting
-            wrapper that trips antivirus heuristics, so it comes up clean. A
-            single-file `PS2Servers-windows-x64.zip` is also published for
-            convenience. **On 32-bit Windows** (older / low-end PCs), download
-            `PS2Servers-windows-x86-portable.zip` (or the single-file
-            `PS2Servers-windows-x86.zip`) instead — the x64 build will not run
-            there. Linux: `PS2Servers-linux-x64` (or the `-portable.tar.gz` build if
-            `/tmp` is `noexec`). macOS ships as a `.app`.
+            There are a lot of files below. **You need exactly one.** Find your
+            computer in this table and ignore everything else:
+
+            | Your computer | Download this |
+            |---|---|
+            | Windows, normal (64-bit) | **`PS2Servers-windows-x64-portable.zip`** |
+            | Windows, older 32-bit PC | **`PS2Servers-windows-x86-portable.zip`** |
+            | Linux | **`PS2Servers-linux-x64`** |
+            | Mac, Apple Silicon (M1–M4) | **`PS2Servers-macos-arm64.zip`** |
+            | Mac, Intel | **`PS2Servers-macos-x64.zip`** |
+
+            On Windows: unzip it, open the folder, run `PS2Servers.exe`. That's it.
+
+            <details>
+            <summary>Why "portable", and what are the other files?</summary>
+
+            The **portable** build is the same app laid out as a plain folder,
+            with no self-extracting wrapper. The wrapper is what makes some
+            antivirus flag the single-file build, so the portable one usually
+            comes up clean — that is why it is the recommendation rather than the
+            single-file `PS2Servers-windows-x64.zip`, which is published for
+            convenience.
+
+            On Linux, `PS2Servers-linux-x64` is a single executable; take
+            `PS2Servers-linux-x64-portable.tar.gz` instead if `/tmp` is mounted
+            `noexec`. macOS ships as a `.app` inside the zip.
+
+            `PS2Servers-source.zip` is the source, for running from Python
+            directly or for inspection.
+
+            Everything beginning **`PS2ServersEdge-`** is a different program —
+            see the section below. You do not need it on a normal computer.
+            </details>
 
             ### PS2 Servers Edge (routers, NAS, Raspberry Pi)
 

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -42,11 +42,11 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         if: matrix.macos_arch != 'x86_64' && matrix.win_arch != 'x86'
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
 
@@ -54,7 +54,7 @@ jobs:
       # and pip pulls the win32 wheels (lz4, zstandard).
       - name: Set up Python (Windows x86)
         if: matrix.win_arch == 'x86'
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
           architecture: 'x86'
@@ -223,7 +223,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Create portable source zip
         shell: bash
@@ -266,7 +266,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download release asset artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,12 +43,12 @@ jobs:
             asset: PS2Servers-macos-x64.zip
             macos_arch: x86_64
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Most jobs use setup-python. The macOS x86_64 cross-build instead needs a
       # universal2 interpreter (with universal Tcl/Tk) and must execute Python as
       # x86_64 so compiled dependencies like lz4 match the Intel artifact.
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         if: matrix.macos_arch != 'x86_64' && matrix.win_arch != 'x86'
         with:
           python-version: "3.12"
@@ -58,7 +58,7 @@ jobs:
       # zstandard). setup-python provides an official 32-bit CPython.
       - name: Set up Python (Windows x86)
         if: matrix.win_arch == 'x86'
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           architecture: "x86"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,6 +299,14 @@ jobs:
 
           Compression note: ZSO/LZ4 support is bundled. CHD support is backed by a libchdr native library built from source during release packaging.
 
+          ### PS2 Servers Edge — routers, NAS, Raspberry Pi
+
+          **If you are on a normal computer, stop here — the table above is what you want.** Everything named \`PS2ServersEdge-*\` is a different program: a small headless server with no GUI and no Python, for devices where the launcher does not fit.
+
+          Each Edge file is named for the device family it serves, for example \`armv5-pogoplug-sheevaplug-dockstar\`, \`edgerouter-octeon-mips64\`, or \`router-mips-little-endian-mt7621\`. Run \`uname -m\` on the device and match it in [EDGE-WHICH-BUILD.md](https://github.com/NathanNeurotic/PS2-Servers/blob/main/docs/EDGE-WHICH-BUILD.md); every archive also contains a \`WHICH-DEVICE.txt\` confirming what it is for. Picking the wrong one is harmless — it simply will not start.
+
+          Edge serves CSO/ZSO but **not CHD**, and allows the console to write saves by default (\`--read-only\` to prevent that). For OpenWrt, build the source package for your exact target instead — see [OPENWRT.md](https://github.com/NathanNeurotic/PS2-Servers/blob/main/docs/OPENWRT.md).
+
           One launcher for all three OPL servers (SMBv1, UDPFS, UDPBD): pick a folder, hit Start. On Windows it runs from the system tray (close/minimize → tray; right-click → Open/Quit).
 
           ## Security transparency


### PR DESCRIPTION
The two optional items from the wrap-up. Two independent commits, readable separately.

---

## 1. `10b431c` — action bumps, done properly

**Supersedes dependabot #121, #122, #123.** Merging those as-is would have preserved a supply-chain gap.

`actions/setup-go` was the **only** action pinned to a movable version tag (`@v6.4.0`); every other action in the repo is SHA-pinned. A version tag can be repointed by its publisher, so that one entry didn't get the guarantee the others do.

```
checkout      9c091bb (v7.0.0) -> 3d3c42e (v7.0.1)
setup-go      @v6.4.0           -> b7ad1da (v7.0.0)   ← now SHA-pinned
setup-python  ece7cb0 (v6.3.0)  -> 5fda3b9 (v7.0.0)
```

Every SHA was **resolved from the upstream tag through the GitHub API**, not copied out of the dependabot PR bodies, with annotated tags dereferenced to their commit. 16 references across all five workflows; no floating version tag remains anywhere.

## 2. `2639ccf` — release page guidance

A rolling release now carries **26 assets**, and a tagged one will carry about as many, because Edge ships 16 device-named archives next to the launcher builds. The download guidance was a paragraph of prose — hard to scan against a file list that long.

**`release-on-main.yml`**: prose replaced with a five-row table — *find your computer, take that one file* — with the "why portable", Linux `noexec`, source-zip and Edge explanations folded into a collapsed `<details>`. The page now opens with the single decision a user actually has to make.

**`release.yml`** — the more important one: the **tagged**-release notes never mentioned Edge at all, even though `edge.yml` attaches all 16 archives on `refs/tags/`. A v0.5.0 page would have shown sixteen unexplained files next to the app. Now there's a section that opens by telling normal-computer users to stop reading, then covers the device-family naming, `EDGE-WHICH-BUILD.md`, `WHICH-DEVICE.txt`, that a wrong pick is harmless, and that Edge has no CHD and allows writes by default.

## Verification

- **Every asset filename named in the notes is checked against the published `files:` list** — 8 named, 0 missing. Notes can't advertise a download that isn't there.
- actionlint clean; all five workflows parse
- Release compliance passes
- UTF-8 verified intact in the new table (the en-dash is a real `–`, not mojibake)

Branches were left alone as you asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)