### PR TITLE
feat: log the source address on first discovery from a console

### DIFF
--- a/native/ps2servers-edge/internal/udpfs/negotiation.go
+++ b/native/ps2servers-edge/internal/udpfs/negotiation.go
@@ -33,10 +33,30 @@ func (s *Server) handleDiscovery(in inbound, h protocol.Header) {
 	if err != nil || dh.ServiceID != protocol.ServiceUDPFS {
 		return
 	}
+	// First contact from a console is the most useful line this server emits.
+	// It proves packets are arriving and names the address they came from,
+	// which separates "the PS2 never reached us" -- wrong subnet, firewall,
+	// wrong interface -- from "it reached us but the reply went astray".
+	// Without it a misconfigured setup is silent on both sides.
+	//
+	// Only the first discovery per peer is announced at Info: both client
+	// families keep broadcasting discovery for the life of a transfer, so
+	// logging every one would bury the transfer log. --verbose shows them all.
+	s.sessionsMu.Lock()
+	_, known := s.sessions[in.peer.String()]
+	s.sessionsMu.Unlock()
+
 	w := s.getWorker(in.peer)
 	if w == nil {
 		return
 	}
+	if !known {
+		s.cfg.Log.Info("DISCOVERY received, console found this server",
+			map[string]any{"peer": in.peer.String()})
+	} else {
+		s.cfg.Log.Debug("DISCOVERY", map[string]any{"peer": in.peer.String(), "seq": h.Sequence})
+	}
+
 	st := w.state
 	st.Mu.Lock()
 	defer st.Mu.Unlock()

--- a/udpfs_server/ps2servers_core.py
+++ b/udpfs_server/ps2servers_core.py
@@ -207,7 +207,27 @@ class AutoUdpfsServer(UdpfsServer):
             quiet = (time.monotonic() - existing.last_activity
                      if existing is not None else float("inf"))
         self.stats["discovery"] += 1
+
+        # First contact from a console is the most useful line this server can
+        # print. It proves packets are arriving and names the address they came
+        # from, which is what separates "the PS2 never reached us" -- wrong
+        # subnet, firewall, wrong interface -- from "it reached us but the reply
+        # went astray". Without it a misconfigured setup is silent on both ends
+        # and there is nothing to debug from. Asked for by a tester who could not
+        # tell those two cases apart.
+        #
+        # Only first contact is announced: both client families keep
+        # broadcasting discovery for the life of a transfer, so logging every one
+        # would bury the transfer log. --verbose shows them all.
+        first_contact = existing is None
+
         sess = self._get_or_create_session(addr)
+
+        if first_contact:
+            self._print_event(
+                f"[{addr[0]}:{addr[1]}] DISCOVERY received -- console found this server")
+        elif self.verbose:
+            self._print_event(f"[{addr[0]}:{addr[1]}] DISCOVERY seq={hdr.seq_nr}")
         with sess.compat_lock:
             # Active clients can keep sequence-zero discovery traffic running in
             # parallel with reads. Reply to it, but never reset that live stream.

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -1159,7 +1159,13 @@ class UdpfsServer:
             # Assigned on the session, not through the _session_prop proxies: we are
             # on the demux thread, where _local.session is unset.
             sess.rx_seq_nr_expected = (hdr.seq_nr + 1) & 0xFFF
-        self._print_event(f"[{addr[0]}:{addr[1]}] DISCOVERY -> INFORM")
+        # Verbose-only: this fires for every broadcast, and both client families
+        # keep discovery running for the life of a transfer, so at default
+        # verbosity it buries the transfer log. The first-contact line above
+        # already gives the default visibility that matters -- proof a console
+        # reached us, and from which address.
+        if self.verbose:
+            self._print_event(f"[{addr[0]}:{addr[1]}] DISCOVERY -> INFORM")
         self._send_inform(addr, sess)
 
     def _handle_data(self, data: bytes, addr: Tuple[str, int]):

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -1111,8 +1111,29 @@ class UdpfsServer:
 
         self.stats['discovery'] += 1
 
+        # First contact from a console is the most useful line this server can
+        # print. It proves packets are arriving and names the address they came
+        # from, which is what separates "the PS2 never reached us" (wrong subnet,
+        # firewall, wrong interface) from "it reached us but the reply went
+        # astray". Without it a misconfigured setup is silent on both sides and
+        # there is nothing to debug from. Reported by a tester who could not tell
+        # the two cases apart.
+        #
+        # Only the first discovery per peer is announced: both client families
+        # keep broadcasting discovery for the life of a transfer, so logging
+        # every one would bury the transfer log. --verbose shows them all.
+        with self.sessions_lock:
+            first_contact = addr not in self.sessions
+
         # Ensure a per-client session (and its worker thread) exists for this peer.
         sess = self._get_or_create_session(addr)
+
+        if first_contact:
+            self._print_event(
+                f"[{addr[0]}:{addr[1]}] DISCOVERY received -- console found this server")
+        elif self.verbose:
+            self._print_event(
+                f"[{addr[0]}:{addr[1]}] DISCOVERY seq={hdr.seq_nr}")
         if self.modulo_compat and (not sess.rx_streaming or hdr.seq_nr != 0):
             # Modulo's client keeps one monotonic sequence for its whole life -- it
             # never restarts at 0, not even across a server restart -- so the


### PR DESCRIPTION
Tester feedback from GhostTown:

> *"this 'discovery request received' is a useful debug to have — your ps2 servers didnt show unless im blind — because it shows the ip which sent the broadcast on, easy to debug ip issues"*

**He wasn't blind.** Neither server logged discovery at all — Python's `_handle_discovery` had no print, Edge's had no `Log` call.

So a console broadcasting at the server produced **zero output**. That makes these two indistinguishable:

- the PS2 never reached us — wrong subnet, firewall, server bound to the wrong adapter
- it reached us fine, but the reply went astray

That's the most common setup problem there is, and the log said nothing either way.

## Now

```
[192.168.1.50:51851] DISCOVERY received -- console found this server
[192.168.1.50:51851] protocol=standard response_socket=data
[192.168.1.50:51851] OPEN 'game.iso' -> handle=1, size=...
```

First contact per peer only. Both client families keep broadcasting discovery for the life of a transfer, so logging every one would bury the transfer log — `--verbose` still shows them all.

## A trap worth knowing about

The Python change had to go in **`ps2servers_core.py`, not `udpfs_server.py`**. The core defines its **own** `_handle_discovery` that overrides the base one, and the launcher registry points at the core — so my first edit, to `udpfs_server.py`, was silently dead code. The server ran, the probe passed, and the log line simply never appeared.

Only caught by running a real server and watching the output. Unit tests would not have noticed, because the handler they reach isn't the handler that runs.

Both copies are updated so they stay consistent, but **two independent discovery handlers is a standing hazard** — a protocol fix made in one won't reach the other. Same shape as the `DATA_FILES` drift in #128 and the `classify()`-vs-`handleDiscovery` split in #131. Worth a follow-up to collapse them.

## Verification

Against **live servers**, not just tests — appropriate, since this is a diagnostic feature and the bug was that the diagnostic didn't appear:

- Conformance probe drives 4 clients at Edge and 4 at the Python core; both logs show one line per client with its source address, then the negotiated profile, no flood
- Full Python suite (8 modules), 3 UDPFS selftests, release compliance
- `go vet` and `go test -race` clean

## Not addressed here

The rest of that conversation is **Simple-Media-System**, a different repo — the IP config not being settable, the freeze-on-failure needing a hard reboot, and udptty. Nothing in this PR touches those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced repetitive discovery notifications during ongoing transfers.
  * Discovery events now appear only when a peer connects for the first time.
  * Added optional verbose logging for subsequent discovery messages, including sequence details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->