### PR TITLE
feat(edge): implement UDPBD so Edge is not a downgrade

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -109,6 +109,63 @@ jobs:
             --host 127.0.0.1 --port "$port" --root "$root" --path probe.iso
         working-directory: native/ps2servers-edge
 
+      # Same idea for the block-device protocol. The probe is server-agnostic
+      # and is run against the Python UDPBD server too, so a divergence between
+      # the two implementations shows up as a CI failure rather than as a
+      # console that will not boot.
+      - name: UDPBD conformance probe against Edge and Core
+        shell: bash
+        run: |
+          set -euo pipefail
+          port=48573
+          work="$(mktemp -d)"
+          # 4 MiB / 8192 sectors: large enough that a 512-sector read exercises
+          # the 32-byte block regime and spans many RDMA packets.
+          python - "$work/edge.img" <<'PYIMG'
+          import random, sys
+          random.seed(1234)
+          with open(sys.argv[1], "wb") as f:
+              f.write(bytes(random.getrandbits(8) for _ in range(4 * 1024 * 1024)))
+          PYIMG
+          cp "$work/edge.img" "$work/core.img"
+
+          go build -o "$RUNNER_TEMP/ps2servers-edge" ./cmd/ps2servers-edge
+
+          run_probe() {
+            local label="$1" image="$2"
+            for _ in $(seq 1 50); do
+              if ss -lun 2>/dev/null | grep -q ":${port}\b"; then break; fi
+              sleep 0.2
+            done
+            python "$GITHUB_WORKSPACE/conformance/integration/udpbd_probe.py" \
+              --host 127.0.0.1 --port "$port" --image "$image"
+            echo "  ^ $label"
+          }
+
+          "$RUNNER_TEMP/ps2servers-edge" udpbd --image "$work/edge.img" --bind 127.0.0.1 --port "$port" &
+          edge_pid=$!
+          trap 'kill "$edge_pid" 2>/dev/null || true' EXIT
+          run_probe "PS2 Servers Edge (Go)" "$work/edge.img"
+          kill "$edge_pid" 2>/dev/null || true
+          wait "$edge_pid" 2>/dev/null || true
+
+          # Control: the same probe against the hardware-validated Python
+          # server. If this ever fails, the probe is wrong rather than Edge.
+          python "$GITHUB_WORKSPACE/udpbd_server/udpbd_server.py" "$work/core.img" &
+          core_pid=$!
+          trap 'kill "$core_pid" 2>/dev/null || true' EXIT
+          run_probe "Python Core (control)" "$work/core.img"
+          kill "$core_pid" 2>/dev/null || true
+
+          # Both servers began from identical images and received identical
+          # writes, so the images must still match byte for byte.
+          if ! cmp -s "$work/edge.img" "$work/core.img"; then
+            echo "::error::Edge and Core produced different images from the same writes"
+            exit 1
+          fi
+          echo "Edge and Core wrote byte-identical images"
+        working-directory: native/ps2servers-edge
+
   build:
     name: Build Edge
     needs: test

--- a/conformance/integration/udpbd_probe.py
+++ b/conformance/integration/udpbd_probe.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Socket-level UDPBD probe for the Python UDPBD server or PS2 Servers Edge.
+
+Speaks the UDPBD v2 wire protocol against a already-running server and checks
+the externally observable behaviour both implementations must share: the INFO
+reply, RDMA reads reassembling to exactly the image bytes across every
+block-size regime, writes landing in the image, and the three abuse cases that
+must not corrupt anything (fuzz, truncated RDMA, unsolicited RDMA).
+
+Deliberately defines its own packing rather than importing udpbd_server: a probe
+that shares its encoder with one implementation cannot catch that
+implementation's encoding bugs.
+
+The block-size optimizer and the simulated-write-error path stay in
+udpbd_server/selftest.py, because both need in-process access to the Python
+server and neither is observable from the wire.
+
+    python udpbd_probe.py --image /path/to/test.img [--host H] [--port P]
+"""
+import argparse
+import socket
+import struct
+import sys
+from pathlib import Path
+
+CMD_INFO, CMD_INFO_REPLY = 0x00, 0x01
+CMD_READ, CMD_READ_RDMA = 0x02, 0x03
+CMD_WRITE, CMD_WRITE_RDMA, CMD_WRITE_DONE = 0x04, 0x05, 0x06
+SECTOR_SIZE = 512
+
+
+def pack_header(cmd, cmdid, cmdpkt):
+    return struct.pack("<H", (cmd & 0x1F) | ((cmdid & 0x07) << 5) | ((cmdpkt & 0xFF) << 8))
+
+
+def unpack_header(datagram):
+    value = struct.unpack_from("<H", datagram, 0)[0]
+    return value & 0x1F, (value >> 5) & 0x07, (value >> 8) & 0xFF
+
+
+def pack_block_type(block_shift, block_count):
+    return struct.pack("<I", (block_shift & 0x0F) | ((block_count & 0x1FF) << 4))
+
+
+def unpack_block_type(datagram, offset=2):
+    value = struct.unpack_from("<I", datagram, offset)[0]
+    return value & 0x0F, (value >> 4) & 0x1FF
+
+
+class Probe:
+    def __init__(self, host, port, timeout=5.0):
+        self.srv = (host, port)
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.settimeout(timeout)
+
+    def close(self):
+        self.sock.close()
+
+    def send(self, payload):
+        self.sock.sendto(payload, self.srv)
+
+    def info(self, expected_sectors):
+        self.send(pack_header(CMD_INFO, 0, 0) + b"\0" * 6)
+        data, _ = self.sock.recvfrom(2048)
+        cmd, _, _ = unpack_header(data)
+        if cmd != CMD_INFO_REPLY:
+            raise AssertionError(f"INFO replied cmd 0x{cmd:02x}, expected INFO_REPLY")
+        sector_size, sector_count = struct.unpack_from("<II", data, 2)
+        if sector_size != SECTOR_SIZE:
+            raise AssertionError(f"INFO sector_size={sector_size}, expected {SECTOR_SIZE}")
+        if sector_count != expected_sectors:
+            raise AssertionError(
+                f"INFO sector_count={sector_count}, expected {expected_sectors}")
+
+    def read(self, image, start, count, cmdid=1):
+        """Read sectors and require the reassembled RDMA stream to equal the image."""
+        self.send(pack_header(CMD_READ, cmdid, 0) + struct.pack("<IH", start, count))
+        want = count * SECTOR_SIZE
+        got = bytearray()
+        while len(got) < want:
+            data, _ = self.sock.recvfrom(2048)
+            cmd, rid, _ = unpack_header(data)
+            if cmd != CMD_READ_RDMA:
+                raise AssertionError(f"expected READ_RDMA, got 0x{cmd:02x}")
+            if rid != cmdid:
+                raise AssertionError(f"READ_RDMA cmdid={rid}, expected {cmdid}")
+            shift, blocks = unpack_block_type(data)
+            size = blocks * (1 << (shift + 2))
+            if len(data) < 6 + size:
+                raise AssertionError("READ_RDMA payload shorter than its block_type")
+            got += data[6:6 + size]
+        expect = image[start * SECTOR_SIZE:(start + count) * SECTOR_SIZE]
+        if bytes(got[:want]) != expect:
+            raise AssertionError(
+                f"READ sectors {start}+{count} did not match the image")
+
+    def write(self, path, start, count, cmdid=2):
+        """Write a recognisable pattern and require it to land in the file."""
+        payload = bytes(((start + i) & 0xFF) for i in range(count * SECTOR_SIZE))
+        self.send(pack_header(CMD_WRITE, cmdid, 0) + struct.pack("<IH", start, count))
+        # 512-byte blocks (shift 7); two sectors per RDMA keeps packets legal.
+        per = 2
+        offset = 0
+        while offset < len(payload):
+            chunk = payload[offset:offset + per * SECTOR_SIZE]
+            blocks = len(chunk) // 512
+            self.send(pack_header(CMD_WRITE_RDMA, cmdid, 0)
+                      + pack_block_type(7, blocks) + chunk)
+            offset += len(chunk)
+        data, _ = self.sock.recvfrom(2048)
+        cmd, _, _ = unpack_header(data)
+        result = struct.unpack_from("<i", data, 2)[0]
+        if cmd != CMD_WRITE_DONE:
+            raise AssertionError(f"expected WRITE_DONE, got 0x{cmd:02x}")
+        if result != 0:
+            raise AssertionError(f"WRITE_DONE result={result}, expected 0")
+        on_disk = Path(path).read_bytes()
+        landed = on_disk[start * SECTOR_SIZE:(start + count) * SECTOR_SIZE]
+        if landed != payload:
+            raise AssertionError(f"write to sectors {start}+{count} did not land")
+        return payload
+
+    def fuzz(self, expected_sectors):
+        """Malformed and short datagrams must not take the server down."""
+        for junk in (b"", b"\x00", b"\xff" * 3, b"\x02" + b"\x00" * 3,
+                     pack_header(CMD_READ, 0, 0) + b"\x01",
+                     pack_header(0x1F, 7, 255) + b"\xAA" * 32):
+            self.send(junk)
+        self.info(expected_sectors)  # still answering -> it survived
+
+    def truncated_rdma(self, image, start):
+        """An RDMA shorter than its block_type must be dropped, not written."""
+        self.send(pack_header(CMD_WRITE, 5, 0) + struct.pack("<IH", start, 1))
+        self.send(pack_header(CMD_WRITE_RDMA, 5, 0) + pack_block_type(7, 1) + b"\xEE" * 100)
+        self.read(image, start, 1, cmdid=5)  # region unchanged
+
+    def unsolicited_rdma(self, image, start):
+        """An RDMA with no CMD_WRITE in front of it must be ignored."""
+        self.send(pack_header(CMD_WRITE_RDMA, 6, 0) + pack_block_type(7, 1) + b"\xCD" * 512)
+        self.read(image, start, 2, cmdid=6)  # region unchanged
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=0xBDBD)
+    ap.add_argument("--image", required=True,
+                    help="the same image file the server was pointed at")
+    args = ap.parse_args()
+
+    path = Path(args.image).resolve()
+    image = path.read_bytes()
+    sectors = len(image) // SECTOR_SIZE
+    if sectors < 2048:
+        raise SystemExit("image must be at least 1 MiB so every block regime is covered")
+
+    p = Probe(args.host, args.port)
+    try:
+        p.info(sectors)
+        # Each count lands in a different block-size regime of the optimizer.
+        p.read(image, 0, 1)      # 512-byte blocks
+        p.read(image, 100, 8)    # 128-byte blocks
+        p.read(image, 1000, 512) # 32-byte blocks, many packets
+        p.read(image, 777, 17)   # odd offset and count
+        p.unsolicited_rdma(image, 600)
+        p.truncated_rdma(image, 400)
+        p.write(str(path), 200, 5)
+        image = path.read_bytes()  # re-read: the write changed it
+        p.read(image, 200, 5)      # written region reads back as the new data
+        p.fuzz(sectors)
+    except Exception as exc:
+        print(f"UDPBD conformance FAILED: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        p.close()
+    print("UDPBD open/read/write byte conformance passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/EDGE.md
+++ b/docs/EDGE.md
@@ -101,12 +101,39 @@ should use an explicit build tag, supported host/target combinations, separate
 artifact names, dependency documentation, and CHD integration fixtures. The
 CGO-free router binaries remain independent of that path.
 
-## UDPBD status
+## UDPBD
 
-Native UDPBD is not advertised in this version. The CLI architecture reserves a
-peer subcommand boundary, but verified native UDPBD requires protocol fixtures
-and integration tests that demonstrate real sector reads and correct responses.
-Desktop/Core UDPBD is unchanged.
+Edge serves a disk image as a network block device as well as serving folders
+over UDPFS, so picking Edge does not cost you a server the Desktop build has:
+
+```sh
+ps2servers-edge udpbd --image /mnt/ps2.img          # read/write
+ps2servers-edge udpbd --image /mnt/ps2.img --read-only
+```
+
+It is a separate protocol on its own fixed port (`0xBDBD`), so it is a separate
+subcommand: one invocation serves either a folder of files or one image as a raw
+drive, never both. In OPL, choose UDPBD — there is no IP or port to enter, the
+console finds the server by broadcast.
+
+**UDPFS versus UDPBD.** UDPFS is a network file share: the console asks for a
+named file and a byte range, and the server understands files. UDPBD is a
+network hard drive: the console asks for numbered 512-byte sectors, and the
+server has no idea what is in them, because the filesystem lives inside the
+image and only the PS2 interprets it.
+
+Implemented: `INFO`, `READ` with RDMA streaming and the upstream block-size
+optimizer, and `WRITE` with its RDMA handshake. Requests that run past the end
+of the image are refused rather than answered with unbounded zero padding.
+Truncated and unsolicited RDMA packets are dropped rather than written at an
+arbitrary offset. A read-only image reports `-1` rather than faking a successful
+save.
+
+The wire format was ported from this repository's hardware-validated Python
+UDPBD server, and `conformance/integration/udpbd_probe.py` runs against **both**
+implementations in CI, finishing by asserting that the two produce byte-identical
+images from identical writes. A divergence surfaces as a CI failure rather than
+as a console that will not boot.
 
 ## Writes
 
@@ -149,7 +176,10 @@ they held is released. Normal logs do not print full requested host paths.
 
 - unit tested: yes
 - loopback integration tested: yes
-- shared conformance probe (`conformance/integration/udpfs_probe.py`): yes, run
+- shared UDPBD conformance probe (`conformance/integration/udpbd_probe.py`): yes,
+  run against Edge AND the Python server in CI, asserting both produce
+  byte-identical images from identical writes
+- shared UDPFS conformance probe (`conformance/integration/udpfs_probe.py`): yes, run
   against a live Edge process in CI — standard plus three Modulo-shaped clients
   concurrently, covering the 4095 → 0 sequence wrap
 - parser fuzz seeds: yes

--- a/native/ps2servers-edge/README.md
+++ b/native/ps2servers-edge/README.md
@@ -53,12 +53,31 @@ Guarantees:
   silently concatenating it into the wrong place
 - completed writes are flushed with `fsync` before `WRITE_DONE` is sent
 
+## UDPBD
+
+Edge also serves a single disk image as a network block device, so choosing
+Edge no longer means giving up a server the Desktop build has:
+
+```sh
+./ps2servers-edge udpbd --image /mnt/ps2.img          # read/write
+./ps2servers-edge udpbd --image /mnt/ps2.img --read-only
+```
+
+UDPBD is a different level of abstraction from UDPFS. UDPFS is a network file
+share: the console asks for a named file and a byte range. UDPBD is a network
+hard drive: the console asks for numbered 512-byte sectors, and the filesystem
+lives inside the image where only the PS2 interprets it. In OPL, pick UDPBD; no
+IP or port is entered, the console finds the server by broadcast.
+
+Implemented: INFO, READ with RDMA streaming and the upstream block-size
+optimizer, and WRITE with the RDMA handshake. Out-of-range, truncated and
+unsolicited RDMA packets are refused rather than written. A read-only image
+reports failure rather than faking a successful save.
+
 ## Not claimed
 
 - CHD in generic static builds
-- native UDPBD
-- block-device writes (`BWRITE`); file writes only
-- emulator or physical-console verification of the write path
+- emulator or physical-console verification of the write paths
 
 See `docs/EDGE.md`, `docs/PROTOCOL-COMPATIBILITY.md`, and
 `docs/EDGE-ARCHITECTURE.md` for installation, compatibility, security, and

--- a/native/ps2servers-edge/cmd/ps2servers-edge/main.go
+++ b/native/ps2servers-edge/cmd/ps2servers-edge/main.go
@@ -14,13 +14,19 @@ import (
 
 	edgelog "github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/session"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/udpbd"
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/udpfs"
 )
 
 var version = "dev"
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "PS2 Servers Edge %s\n\nUsage:\n  ps2servers-edge udpfs --root /games [options]\n  ps2servers-edge --version\n\n", version)
+	fmt.Fprintf(os.Stderr, "PS2 Servers Edge %s\n\nUsage:\n"+
+		"  ps2servers-edge udpfs --root /games [options]\n"+
+		"  ps2servers-edge udpbd --image /path/ps2.img [options]\n"+
+		"  ps2servers-edge --version\n\n"+
+		"  udpfs serves a folder as a network file share.\n"+
+		"  udpbd serves one disk image as a network hard drive.\n\n", version)
 }
 func duration(v string) (time.Duration, error) {
 	if v == "" {
@@ -38,6 +44,10 @@ func duration(v string) (time.Duration, error) {
 func main() {
 	if len(os.Args) == 2 && (os.Args[1] == "--version" || os.Args[1] == "version") {
 		fmt.Printf("ps2servers-edge %s\n", version)
+		return
+	}
+	if len(os.Args) >= 2 && os.Args[1] == "udpbd" {
+		runUDPBD()
 		return
 	}
 	if len(os.Args) < 2 || os.Args[1] != "udpfs" {
@@ -161,4 +171,52 @@ func envFloat(name string, def float64) float64 {
 		return def
 	}
 	return n
+}
+
+// runUDPBD serves one disk image as a network block device.
+//
+// UDPBD is a separate protocol from UDPFS on its own fixed port, so it gets its
+// own subcommand rather than a flag: a server serves either a folder of files
+// or one image as a raw drive, never both from the same invocation.
+func runUDPBD() {
+	fs := flag.NewFlagSet("udpbd", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	image := fs.String("image", env("BDPATH", ""), "disk image to serve as a block device")
+	bind := fs.String("bind", env("BIND", "0.0.0.0"), "IPv4 bind address")
+	port := fs.Int("port", envInt("UDPBD_PORT", udpbd.Port), "UDP port (default 0xBDBD)")
+	readOnly := fs.Bool("read-only", envBool("RO", false), "serve the image read-only")
+	logFormat := fs.String("log-format", env("LOG_FORMAT", "text"), "text or json")
+	verbose := fs.Bool("verbose", envBool("VERBOSE", false), "verbose protocol logging")
+	quiet := fs.Bool("quiet", false, "suppress informational logs")
+	if err := fs.Parse(os.Args[2:]); err != nil {
+		os.Exit(2)
+	}
+	// Accept a bare positional image too, matching how the Python UDPBD server
+	// is invoked (`udpbd_server.py <image>`).
+	if *image == "" && fs.NArg() > 0 {
+		*image = fs.Arg(0)
+	}
+	if *image == "" {
+		fmt.Fprintln(os.Stderr, "error: --image is required")
+		os.Exit(2)
+	}
+	if *logFormat != "text" && *logFormat != "json" {
+		fmt.Fprintln(os.Stderr, "error: --log-format must be text or json")
+		os.Exit(2)
+	}
+	logger := edgelog.New(os.Stdout, *logFormat, *quiet, *verbose)
+	server, err := udpbd.New(udpbd.Config{
+		Image: *image, Bind: *bind, Port: *port, ReadOnly: *readOnly, Log: logger,
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+	defer server.Close()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err = server.Serve(ctx); err != nil {
+		logger.Error("server stopped", map[string]any{"error": err})
+		os.Exit(1)
+	}
 }

--- a/native/ps2servers-edge/internal/udpbd/protocol.go
+++ b/native/ps2servers-edge/internal/udpbd/protocol.go
@@ -1,0 +1,104 @@
+// Package udpbd implements the UDPBD v2 block-device protocol for PS2 Servers
+// Edge, so Edge is not a downgrade from the Desktop/Core server for people who
+// serve a disk image rather than a folder.
+//
+// UDPBD is a different level of abstraction from UDPFS. UDPFS is a network file
+// share -- the console asks for a named file and a byte range. UDPBD is a
+// network hard drive: the console asks for numbered 512-byte sectors and the
+// server has no idea what is inside them, because the filesystem lives in the
+// image and only the PS2 interprets it.
+//
+// The wire format here is ported from this repository's hardware-validated
+// Python implementation (udpbd_server/udpbd_server.py), which is itself an
+// independent reimplementation of Rick Gaiser's published protocol. No upstream
+// source is copied; only the wire format is reproduced so PS2 clients
+// interoperate. The bit packing and the RDMA block-size table below have to
+// match the Python server byte for byte -- udpbd_server/selftest.py asserts the
+// optimizer against the same table.
+package udpbd
+
+import "encoding/binary"
+
+const (
+	// Port is fixed: the PS2 broadcasts here to find a server.
+	Port = 0xBDBD
+
+	CmdInfo      = 0x00 // client -> server
+	CmdInfoReply = 0x01 // server -> client
+	CmdRead      = 0x02 // client -> server
+	CmdReadRDMA  = 0x03 // server -> client
+	CmdWrite     = 0x04 // client -> server
+	CmdWriteRDMA = 0x05 // client -> server
+	CmdWriteDone = 0x06 // server -> client
+
+	SectorSize = 512
+	RecvBufLen = 2048
+
+	// Header (2 bytes) + block_type (4 bytes) = 6 bytes of RDMA overhead.
+	rdmaMaxPayload = 1472 - 2 - 4 // 1466
+)
+
+// packHeader builds the 16-bit little-endian header bitfield:
+// cmd:5, cmdid:3, cmdpkt:8.
+func packHeader(cmd, cmdid, cmdpkt uint8) []byte {
+	v := uint16(cmd&0x1F) | uint16(cmdid&0x07)<<5 | uint16(cmdpkt)<<8
+	b := make([]byte, 2)
+	binary.LittleEndian.PutUint16(b, v)
+	return b
+}
+
+// headerCmd reads just the command nibble, for dispatch.
+func headerCmd(p []byte) uint8 { return p[0] & 0x1F }
+
+// unpackHeader returns cmd, cmdid, cmdpkt.
+func unpackHeader(p []byte) (cmd, cmdid, cmdpkt uint8) {
+	v := binary.LittleEndian.Uint16(p)
+	return uint8(v & 0x1F), uint8((v >> 5) & 0x07), uint8(v >> 8)
+}
+
+// packBlockType builds the 32-bit little-endian block descriptor:
+// block_shift:4, block_count:9.
+func packBlockType(blockShift uint8, blockCount uint16) []byte {
+	v := uint32(blockShift&0x0F) | uint32(blockCount&0x1FF)<<4
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, v)
+	return b
+}
+
+// unpackBlockType reads the block descriptor at the given offset.
+func unpackBlockType(p []byte, offset int) (blockShift uint8, blockCount uint16) {
+	v := binary.LittleEndian.Uint32(p[offset:])
+	return uint8(v & 0x0F), uint16((v >> 4) & 0x1FF)
+}
+
+// ceilDiv is integer ceiling division for non-negative values.
+func ceilDiv(a, b int64) int64 { return (a + b - 1) / b }
+
+// blockShiftForSectors picks the largest block size that still yields the
+// minimum packet count: fewest packets is least overhead, and larger blocks are
+// faster for the PS2 to consume.
+//
+// The 1440 / 1024 / 1280 / 1408 thresholds and the 7 / 6 / 5 / 3 shifts are not
+// arbitrary -- they reproduce upstream's table exactly, and selftest.py pins
+// them. Changing one without the other silently degrades throughput on real
+// hardware rather than failing visibly.
+func blockShiftForSectors(sectors int64) uint8 {
+	size := sectors * SectorSize
+	packetsMin := ceilDiv(size, 1440)
+	switch {
+	case ceilDiv(size, 1024) == packetsMin:
+		return 7 // 512-byte blocks
+	case ceilDiv(size, 1280) == packetsMin:
+		return 6 // 256-byte blocks
+	case ceilDiv(size, 1408) == packetsMin:
+		return 5 // 128-byte blocks
+	default:
+		return 3 // 32-byte blocks
+	}
+}
+
+// blockGeometry derives the sizes that follow from a shift.
+func blockGeometry(shift uint8) (blockSize, blocksPerPacket, blocksPerSector int) {
+	blockSize = 1 << (shift + 2)
+	return blockSize, rdmaMaxPayload / blockSize, SectorSize / blockSize
+}

--- a/native/ps2servers-edge/internal/udpbd/server.go
+++ b/native/ps2servers-edge/internal/udpbd/server.go
@@ -1,0 +1,432 @@
+package udpbd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+
+	edgelog "github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
+)
+
+// Config describes one UDPBD service.
+type Config struct {
+	Image    string
+	Bind     string
+	Port     int
+	ReadOnly bool
+	Log      *edgelog.Logger
+}
+
+// device is an image file addressed as fixed-size sectors.
+type device struct {
+	path     string
+	file     *os.File
+	size     int64
+	readOnly bool
+}
+
+func openDevice(path string, readOnly bool) (*device, error) {
+	flag := os.O_RDWR
+	if readOnly {
+		flag = os.O_RDONLY
+	}
+	f, err := os.OpenFile(path, flag, 0o644)
+	if err != nil && !readOnly {
+		// Fall back to read-only rather than refusing to serve: an image on a
+		// read-only mount is still perfectly useful for loading games, and this
+		// mirrors the Python server's behaviour.
+		f, err = os.OpenFile(path, os.O_RDONLY, 0o644)
+		readOnly = true
+	}
+	if err != nil {
+		return nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	return &device{path: path, file: f, size: info.Size(), readOnly: readOnly}, nil
+}
+
+func (d *device) sectorCount() int64 { return d.size / SectorSize }
+
+// readAtOffset reads size bytes at an absolute byte offset, zero-padding a
+// short read so RDMA packet sizing stays correct rather than truncating.
+//
+// Positional reads are used throughout rather than a shared file cursor, so two
+// consoles reading concurrently cannot pull each other's data out from under
+// one another.
+func (d *device) readAtOffset(offset int64, size int) ([]byte, error) {
+	buf := make([]byte, size)
+	n, err := d.file.ReadAt(buf, offset)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	for i := n; i < size; i++ {
+		buf[i] = 0
+	}
+	return buf, nil
+}
+
+func (d *device) writeAt(offset int64, data []byte) error {
+	if d.readOnly {
+		return nil
+	}
+	_, err := d.file.WriteAt(data, offset)
+	return err
+}
+
+func (d *device) close() { _ = d.file.Close() }
+
+// writeState tracks one in-flight CMD_WRITE handshake.
+//
+// UDPBD serves a single image through a single file, so a write sequence is
+// inherently one-client-at-a-time; the reference server keeps exactly one such
+// state. The peer is recorded as well so a stray RDMA from a *different*
+// console cannot land in the middle of another one's write.
+type writeState struct {
+	peer   string
+	offset int64
+	left   int64
+}
+
+// Server serves one disk image over UDPBD.
+type Server struct {
+	cfg  Config
+	dev  *device
+	conn *net.UDPConn
+
+	mu    sync.Mutex
+	write writeState
+	seen  map[string]bool // peers already announced, to keep the log quiet
+
+	totalRead  int64
+	totalWrite int64
+}
+
+func New(cfg Config) (*Server, error) {
+	if cfg.Image == "" {
+		return nil, fmt.Errorf("a disk image is required")
+	}
+	if cfg.Port == 0 {
+		cfg.Port = Port
+	}
+	if cfg.Port < 1 || cfg.Port > 65535 {
+		return nil, fmt.Errorf("port out of range")
+	}
+	if cfg.Log == nil {
+		cfg.Log = edgelog.New(os.Stdout, "text", false, false)
+	}
+	dev, err := openDevice(cfg.Image, cfg.ReadOnly)
+	if err != nil {
+		return nil, err
+	}
+	if dev.size < SectorSize {
+		dev.close()
+		return nil, fmt.Errorf("image is smaller than one %d-byte sector", SectorSize)
+	}
+	return &Server{cfg: cfg, dev: dev, seen: make(map[string]bool)}, nil
+}
+
+// Listen binds the UDPBD port.
+func (s *Server) Listen() error {
+	ip := net.ParseIP(s.cfg.Bind)
+	if s.cfg.Bind != "" && ip == nil {
+		return fmt.Errorf("invalid bind address %q", s.cfg.Bind)
+	}
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: ip, Port: s.cfg.Port})
+	if err != nil {
+		return err
+	}
+	s.conn = conn
+	return nil
+}
+
+// Addr reports the bound address, for tests.
+func (s *Server) Addr() *net.UDPAddr {
+	if s.conn == nil {
+		return nil
+	}
+	return s.conn.LocalAddr().(*net.UDPAddr)
+}
+
+func (s *Server) Close() error {
+	if s.conn != nil {
+		err := s.conn.Close()
+		s.dev.close()
+		return err
+	}
+	s.dev.close()
+	return nil
+}
+
+// Serve runs until ctx is cancelled or the socket closes.
+func (s *Server) Serve(ctx context.Context) error {
+	if s.conn == nil {
+		if err := s.Listen(); err != nil {
+			return err
+		}
+	}
+	mode := "read/write"
+	if s.dev.readOnly {
+		mode = "read-only"
+	}
+	s.cfg.Log.Info("UDPBD listening", map[string]any{
+		"image":   s.dev.path,
+		"mode":    mode,
+		"sectors": s.dev.sectorCount(),
+		"size_mb": s.dev.size / (1024 * 1024),
+		"listen":  s.Addr().String(),
+	})
+
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = s.conn.Close()
+		case <-done:
+		}
+	}()
+	defer close(done)
+
+	buf := make([]byte, RecvBufLen)
+	for {
+		n, peer, err := s.conn.ReadFromUDP(buf)
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+				return nil // socket closed
+			}
+		}
+		if n < 2 {
+			continue
+		}
+		s.dispatch(append([]byte(nil), buf[:n]...), peer)
+	}
+}
+
+func (s *Server) dispatch(p []byte, peer *net.UDPAddr) {
+	switch headerCmd(p) {
+	case CmdInfo:
+		s.handleInfo(p, peer)
+	case CmdRead:
+		if len(p) >= 8 {
+			s.handleRead(p, peer)
+		}
+	case CmdWrite:
+		if len(p) >= 8 {
+			s.handleWrite(p, peer)
+		}
+	case CmdWriteRDMA:
+		if len(p) >= 6 {
+			s.handleWriteRDMA(p, peer)
+		}
+	default:
+		s.cfg.Log.Debug("ignoring unknown UDPBD command",
+			map[string]any{"peer": peer.String(), "cmd": headerCmd(p)})
+	}
+}
+
+// sectorRequest reads the (sector_nr, sector_count) pair shared by CMD_READ and
+// CMD_WRITE. Layout is header:uint16, sector_nr:uint32, sector_count:uint16.
+func sectorRequest(p []byte) (sectorNr int64, sectorCount int64) {
+	nr := int64(uint32(p[2]) | uint32(p[3])<<8 | uint32(p[4])<<16 | uint32(p[5])<<24)
+	count := int64(uint16(p[6]) | uint16(p[7])<<8)
+	return nr, count
+}
+
+func (s *Server) handleInfo(p []byte, peer *net.UDPAddr) {
+	_, cmdid, _ := unpackHeader(p)
+
+	// First contact names the console's address, which is what tells a wrong
+	// subnet or firewall apart from a server that never heard anything.
+	s.mu.Lock()
+	first := !s.seen[peer.String()]
+	s.seen[peer.String()] = true
+	readTotal, writeTotal := s.totalRead, s.totalWrite
+	s.mu.Unlock()
+	if first {
+		s.cfg.Log.Info("UDPBD INFO received, console found this server",
+			map[string]any{"peer": peer.String()})
+	} else {
+		s.cfg.Log.Debug("UDPBD INFO", map[string]any{
+			"peer": peer.String(), "read_kib": readTotal / 1024, "write_kib": writeTotal / 1024})
+	}
+
+	reply := packHeader(CmdInfoReply, cmdid, 1)
+	reply = append(reply, le32(SectorSize)...)
+	reply = append(reply, le32(uint32(s.dev.sectorCount()))...)
+	s.send(reply, peer)
+}
+
+func (s *Server) handleRead(p []byte, peer *net.UDPAddr) {
+	_, cmdid, _ := unpackHeader(p)
+	sectorNr, sectorCount := sectorRequest(p)
+	if sectorCount <= 0 {
+		return
+	}
+	// Refuse a request that runs past the image rather than streaming zero
+	// padding for an arbitrary length: a bad or hostile count would otherwise
+	// make the server emit unbounded traffic.
+	if sectorNr < 0 || sectorNr+sectorCount > s.dev.sectorCount() {
+		s.cfg.Log.Warn("UDPBD READ out of range", map[string]any{
+			"peer": peer.String(), "sector": sectorNr, "count": sectorCount,
+			"sectors": s.dev.sectorCount()})
+		return
+	}
+
+	shift := blockShiftForSectors(sectorCount)
+	blockSize, blocksPerPacket, blocksPerSector := blockGeometry(shift)
+	blocksLeft := sectorCount * int64(blocksPerSector)
+
+	s.mu.Lock()
+	s.totalRead += blocksLeft * int64(blockSize)
+	s.mu.Unlock()
+
+	s.cfg.Log.Debug("UDPBD READ", map[string]any{
+		"peer": peer.String(), "sector": sectorNr, "count": sectorCount,
+		"block_size": blockSize})
+
+	offsetSector := sectorNr
+	consumed := int64(0)
+	cmdpkt := uint8(1)
+	for blocksLeft > 0 {
+		blockCount := blocksLeft
+		if blockCount > int64(blocksPerPacket) {
+			blockCount = int64(blocksPerPacket)
+		}
+		blocksLeft -= blockCount
+		size := int(blockCount) * blockSize
+
+		// Read at an absolute byte offset rather than relying on a shared file
+		// cursor, so two consoles reading at once cannot pull each other's data.
+		data, err := s.dev.readAtOffset(offsetSector*SectorSize+consumed, size)
+		if err != nil {
+			s.cfg.Log.Warn("UDPBD read failed",
+				map[string]any{"peer": peer.String(), "error": err.Error()})
+			return
+		}
+		consumed += int64(size)
+
+		packet := packHeader(CmdReadRDMA, cmdid, cmdpkt)
+		packet = append(packet, packBlockType(shift, uint16(blockCount))...)
+		packet = append(packet, data...)
+		s.send(packet, peer)
+		cmdpkt = (cmdpkt + 1) & 0xFF
+	}
+}
+
+func (s *Server) handleWrite(p []byte, peer *net.UDPAddr) {
+	_, _, _ = unpackHeader(p)
+	sectorNr, sectorCount := sectorRequest(p)
+	if sectorCount <= 0 {
+		return
+	}
+	if sectorNr < 0 || sectorNr+sectorCount > s.dev.sectorCount() {
+		s.cfg.Log.Warn("UDPBD WRITE out of range", map[string]any{
+			"peer": peer.String(), "sector": sectorNr, "count": sectorCount})
+		return
+	}
+	if s.dev.readOnly {
+		s.cfg.Log.Warn("UDPBD WRITE on a read-only image, ignoring",
+			map[string]any{"peer": peer.String()})
+	}
+	s.cfg.Log.Debug("UDPBD WRITE", map[string]any{
+		"peer": peer.String(), "sector": sectorNr, "count": sectorCount})
+
+	s.mu.Lock()
+	s.write = writeState{
+		peer:   peer.String(),
+		offset: sectorNr * SectorSize,
+		left:   sectorCount * SectorSize,
+	}
+	s.totalWrite += sectorCount * SectorSize
+	s.mu.Unlock()
+}
+
+func (s *Server) handleWriteRDMA(p []byte, peer *net.UDPAddr) {
+	_, cmdid, _ := unpackHeader(p)
+
+	s.mu.Lock()
+	st := s.write
+	if st.left <= 0 || st.peer != peer.String() {
+		s.mu.Unlock()
+		// No CMD_WRITE handshake in progress for this peer. Writing here would
+		// land data at whatever offset happened to be current -- an arbitrary
+		// sector -- so drop it.
+		s.cfg.Log.Debug("dropping unsolicited UDPBD WRITE_RDMA",
+			map[string]any{"peer": peer.String()})
+		return
+	}
+	s.mu.Unlock()
+
+	blockShift, blockCount := unpackBlockType(p, 2)
+	size := int(blockCount) * (1 << (blockShift + 2))
+	if len(p) < 6+size {
+		// Truncated payload: writing it short would misalign every following
+		// block in the sequence, so drop the packet rather than corrupt.
+		s.cfg.Log.Debug("dropping truncated UDPBD WRITE_RDMA",
+			map[string]any{"peer": peer.String()})
+		return
+	}
+	if int64(size) > st.left {
+		size = int(st.left) // never write past the requested region
+	}
+
+	if err := s.dev.writeAt(st.offset, p[6:6+size]); err != nil {
+		s.cfg.Log.Warn("UDPBD write failed",
+			map[string]any{"peer": peer.String(), "error": err.Error()})
+		s.mu.Lock()
+		s.write = writeState{}
+		s.mu.Unlock()
+		s.sendWriteDone(cmdid, -1, peer)
+		return
+	}
+
+	s.mu.Lock()
+	s.write.offset += int64(size)
+	s.write.left -= int64(size)
+	finished := s.write.left <= 0
+	if finished {
+		s.write = writeState{}
+	}
+	s.mu.Unlock()
+
+	if finished {
+		// Report failure on a read-only image rather than faking success, so the
+		// console does not believe a save committed when nothing was written.
+		result := int32(0)
+		if s.dev.readOnly {
+			result = -1
+		} else if err := s.dev.file.Sync(); err != nil {
+			s.cfg.Log.Warn("UDPBD sync failed",
+				map[string]any{"peer": peer.String(), "error": err.Error()})
+			result = -1
+		}
+		s.sendWriteDone(cmdid, result, peer)
+	}
+}
+
+func (s *Server) sendWriteDone(cmdid uint8, result int32, peer *net.UDPAddr) {
+	reply := packHeader(CmdWriteDone, cmdid, (cmdid+1)&0xFF)
+	reply = append(reply, le32(uint32(result))...)
+	s.send(reply, peer)
+}
+
+func (s *Server) send(p []byte, peer *net.UDPAddr) {
+	if _, err := s.conn.WriteToUDP(p, peer); err != nil {
+		s.cfg.Log.Debug("UDPBD send failed",
+			map[string]any{"peer": peer.String(), "error": err.Error()})
+	}
+}
+
+func le32(v uint32) []byte {
+	return []byte{byte(v), byte(v >> 8), byte(v >> 16), byte(v >> 24)}
+}

--- a/native/ps2servers-edge/internal/udpbd/udpbd_test.go
+++ b/native/ps2servers-edge/internal/udpbd/udpbd_test.go
@@ -1,0 +1,384 @@
+package udpbd
+
+import (
+	"context"
+	"encoding/binary"
+	"math/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	edgelog "github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
+)
+
+// TestBlockShiftMatchesReferenceTable pins the RDMA block-size optimizer against
+// values computed from the hardware-validated Python server
+// (udpbd_server/udpbd_server.py `_set_block_shift_for_sectors`, which
+// udpbd_server/selftest.py asserts in turn).
+//
+// A mismatch here does not fail loudly on a console -- it silently picks a worse
+// packet size, so transfers get slower rather than broken. That is exactly the
+// kind of regression a table test has to catch, because nothing else would.
+func TestBlockShiftMatchesReferenceTable(t *testing.T) {
+	cases := []struct {
+		sectors int64
+		want    uint8
+	}{
+		{sectors: 1, want: 7}, {sectors: 2, want: 7}, {sectors: 3, want: 7},
+		{sectors: 4, want: 7}, {sectors: 5, want: 6}, {sectors: 6, want: 7},
+		{sectors: 7, want: 6}, {sectors: 8, want: 5}, {sectors: 9, want: 6},
+		{sectors: 16, want: 5}, {sectors: 17, want: 6}, {sectors: 32, want: 5},
+		{sectors: 33, want: 5}, {sectors: 64, want: 3}, {sectors: 100, want: 3},
+		{sectors: 128, want: 3}, {sectors: 255, want: 3}, {sectors: 256, want: 3},
+		{sectors: 512, want: 3}, {sectors: 1000, want: 3}, {sectors: 1024, want: 3},
+		{sectors: 2048, want: 3},
+	}
+	for _, c := range cases {
+		if got := blockShiftForSectors(c.sectors); got != c.want {
+			t.Errorf("blockShiftForSectors(%d) = %d, reference says %d",
+				c.sectors, got, c.want)
+		}
+	}
+}
+
+// TestBlockGeometryIsConsistent guards the derived sizes. blocks_per_sector in
+// particular must divide evenly, or a sector would straddle a block boundary
+// and every read after the first would be misaligned.
+func TestBlockGeometryIsConsistent(t *testing.T) {
+	for _, shift := range []uint8{3, 5, 6, 7} {
+		size, perPacket, perSector := blockGeometry(shift)
+		if size != 1<<(shift+2) {
+			t.Errorf("shift %d: block size %d", shift, size)
+		}
+		if perSector*size != SectorSize {
+			t.Errorf("shift %d: %d blocks x %d != one %d-byte sector",
+				shift, perSector, size, SectorSize)
+		}
+		if perPacket*size > rdmaMaxPayload {
+			t.Errorf("shift %d: %d blocks x %d exceeds the %d-byte RDMA payload",
+				shift, perPacket, size, rdmaMaxPayload)
+		}
+	}
+}
+
+func TestHeaderAndBlockTypeRoundTrip(t *testing.T) {
+	for _, c := range []struct{ cmd, cmdid, cmdpkt uint8 }{
+		{CmdInfo, 0, 0}, {CmdReadRDMA, 7, 255}, {CmdWriteDone, 3, 128},
+	} {
+		cmd, cmdid, cmdpkt := unpackHeader(packHeader(c.cmd, c.cmdid, c.cmdpkt))
+		if cmd != c.cmd || cmdid != c.cmdid || cmdpkt != c.cmdpkt {
+			t.Errorf("header round trip: got (%d,%d,%d) want (%d,%d,%d)",
+				cmd, cmdid, cmdpkt, c.cmd, c.cmdid, c.cmdpkt)
+		}
+	}
+	for _, c := range []struct {
+		shift uint8
+		count uint16
+	}{{7, 1}, {3, 45}, {5, 511}} {
+		shift, count := unpackBlockType(packBlockType(c.shift, c.count), 0)
+		if shift != c.shift || count != c.count {
+			t.Errorf("block_type round trip: got (%d,%d) want (%d,%d)",
+				shift, count, c.shift, c.count)
+		}
+	}
+}
+
+// --- integration over real sockets ---------------------------------------- //
+
+func startServer(t *testing.T, readOnly bool) (*net.UDPAddr, string, []byte) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.img")
+	img := make([]byte, 1<<20) // 2048 sectors
+	rand.New(rand.NewSource(1234)).Read(img)
+	if err := os.WriteFile(path, img, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Port 0 lets the OS choose, so tests never collide with a real server.
+	srv, err := New(Config{
+		Image: path, Bind: "127.0.0.1", Port: freePort(t), ReadOnly: readOnly,
+		Log: edgelog.New(discard{}, "text", true, false),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.Listen(); err != nil {
+		t.Fatal(err)
+	}
+	addr := srv.Addr()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("server did not stop")
+		}
+		srv.Close()
+	})
+	return addr, path, img
+}
+
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	c, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	return c.LocalAddr().(*net.UDPAddr).Port
+}
+
+func dialServer(t *testing.T, addr *net.UDPAddr) *net.UDPConn {
+	t.Helper()
+	c, err := net.DialUDP("udp4", nil, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { c.Close() })
+	_ = c.SetDeadline(time.Now().Add(5 * time.Second))
+	return c
+}
+
+func sectorReq(cmd, cmdid uint8, sector uint32, count uint16) []byte {
+	b := packHeader(cmd, cmdid, 0)
+	b = append(b, byte(sector), byte(sector>>8), byte(sector>>16), byte(sector>>24))
+	return append(b, byte(count), byte(count>>8))
+}
+
+func TestInfoReportsSectorGeometry(t *testing.T) {
+	addr, _, img := startServer(t, false)
+	c := dialServer(t, addr)
+
+	if _, err := c.Write(append(packHeader(CmdInfo, 0, 0), make([]byte, 6)...)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 2048)
+	n, err := c.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd, _, _ := unpackHeader(buf[:n])
+	if cmd != CmdInfoReply {
+		t.Fatalf("got cmd 0x%02x, want INFO_REPLY", cmd)
+	}
+	size := binary.LittleEndian.Uint32(buf[2:])
+	count := binary.LittleEndian.Uint32(buf[6:])
+	if size != SectorSize || int64(count) != int64(len(img)/SectorSize) {
+		t.Fatalf("INFO reported %d-byte sectors x %d, want %d x %d",
+			size, count, SectorSize, len(img)/SectorSize)
+	}
+}
+
+// readSectors reassembles an RDMA stream, the way a console does.
+func readSectors(t *testing.T, c *net.UDPConn, cmdid uint8, sector uint32, count uint16) []byte {
+	t.Helper()
+	if _, err := c.Write(sectorReq(CmdRead, cmdid, sector, count)); err != nil {
+		t.Fatal(err)
+	}
+	want := int(count) * SectorSize
+	out := make([]byte, 0, want)
+	buf := make([]byte, 2048)
+	for len(out) < want {
+		n, err := c.Read(buf)
+		if err != nil {
+			t.Fatalf("read sectors %d+%d: %v (got %d/%d bytes)", sector, count, err, len(out), want)
+		}
+		cmd, gotID, _ := unpackHeader(buf[:n])
+		if cmd != CmdReadRDMA || gotID != cmdid {
+			t.Fatalf("unexpected reply cmd=0x%02x cmdid=%d", cmd, gotID)
+		}
+		shift, blocks := unpackBlockType(buf[:n], 2)
+		size := int(blocks) * (1 << (shift + 2))
+		if n < 6+size {
+			t.Fatalf("RDMA payload %d shorter than its block_type %d", n-6, size)
+		}
+		out = append(out, buf[6:6+size]...)
+	}
+	return out[:want]
+}
+
+// TestReadsMatchTheImageAcrossBlockRegimes covers each branch of the optimizer,
+// because packet sizing changes with the request size and an off-by-one in the
+// loop would only show up in one regime.
+func TestReadsMatchTheImageAcrossBlockRegimes(t *testing.T) {
+	addr, _, img := startServer(t, false)
+	c := dialServer(t, addr)
+
+	for i, tc := range []struct {
+		sector uint32
+		count  uint16
+	}{{0, 1}, {100, 8}, {777, 17}, {1000, 512}} {
+		got := readSectors(t, c, uint8(i%8), tc.sector, tc.count)
+		want := img[int(tc.sector)*SectorSize : (int(tc.sector)+int(tc.count))*SectorSize]
+		if string(got) != string(want) {
+			t.Fatalf("sectors %d+%d did not match the image", tc.sector, tc.count)
+		}
+	}
+}
+
+func TestWriteLandsInTheImage(t *testing.T) {
+	addr, path, _ := startServer(t, false)
+	c := dialServer(t, addr)
+
+	const sector, count = 200, 2
+	payload := make([]byte, count*SectorSize)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+	if _, err := c.Write(sectorReq(CmdWrite, 2, sector, count)); err != nil {
+		t.Fatal(err)
+	}
+	pkt := packHeader(CmdWriteRDMA, 2, 0)
+	pkt = append(pkt, packBlockType(7, count)...) // 512-byte blocks
+	pkt = append(pkt, payload...)
+	if _, err := c.Write(pkt); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 2048)
+	n, err := c.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd, _, _ := unpackHeader(buf[:n])
+	result := int32(binary.LittleEndian.Uint32(buf[2:]))
+	if cmd != CmdWriteDone || result != 0 {
+		t.Fatalf("WRITE_DONE cmd=0x%02x result=%d, want (0x%02x, 0)", cmd, result, CmdWriteDone)
+	}
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(onDisk[sector*SectorSize:(sector+count)*SectorSize]) != string(payload) {
+		t.Fatal("write did not land in the image")
+	}
+}
+
+// TestUnsolicitedWriteRDMAIsIgnored: without a CMD_WRITE in front of it, an RDMA
+// has no offset of its own. Honouring it would write at whatever offset happened
+// to be current -- an arbitrary sector -- which is silent corruption.
+func TestUnsolicitedWriteRDMAIsIgnored(t *testing.T) {
+	addr, _, img := startServer(t, false)
+	c := dialServer(t, addr)
+
+	pkt := packHeader(CmdWriteRDMA, 6, 0)
+	pkt = append(pkt, packBlockType(7, 1)...)
+	pkt = append(pkt, make([]byte, SectorSize)...)
+	for i := range pkt[6:] {
+		pkt[6+i] = 0xCD
+	}
+	if _, err := c.Write(pkt); err != nil {
+		t.Fatal(err)
+	}
+	got := readSectors(t, c, 6, 600, 2)
+	if string(got) != string(img[600*SectorSize:602*SectorSize]) {
+		t.Fatal("an unsolicited WRITE_RDMA corrupted the image")
+	}
+}
+
+// TestTruncatedWriteRDMAIsIgnored: a payload shorter than its own block_type
+// would, if written, misalign every following block in the sequence.
+func TestTruncatedWriteRDMAIsIgnored(t *testing.T) {
+	addr, _, img := startServer(t, false)
+	c := dialServer(t, addr)
+
+	if _, err := c.Write(sectorReq(CmdWrite, 5, 400, 1)); err != nil {
+		t.Fatal(err)
+	}
+	pkt := packHeader(CmdWriteRDMA, 5, 0)
+	pkt = append(pkt, packBlockType(7, 1)...) // claims 512 bytes
+	pkt = append(pkt, make([]byte, 100)...)   // supplies 100
+	if _, err := c.Write(pkt); err != nil {
+		t.Fatal(err)
+	}
+	got := readSectors(t, c, 5, 400, 1)
+	if string(got) != string(img[400*SectorSize:401*SectorSize]) {
+		t.Fatal("a truncated WRITE_RDMA corrupted the image")
+	}
+}
+
+// TestReadOnlyImageReportsFailure: reporting success would let the console
+// believe a save committed when nothing was written.
+func TestReadOnlyImageReportsWriteFailure(t *testing.T) {
+	addr, path, img := startServer(t, true)
+	c := dialServer(t, addr)
+
+	if _, err := c.Write(sectorReq(CmdWrite, 3, 10, 1)); err != nil {
+		t.Fatal(err)
+	}
+	pkt := packHeader(CmdWriteRDMA, 3, 0)
+	pkt = append(pkt, packBlockType(7, 1)...)
+	pkt = append(pkt, make([]byte, SectorSize)...)
+	if _, err := c.Write(pkt); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 2048)
+	n, err := c.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result := int32(binary.LittleEndian.Uint32(buf[2:n])); result != -1 {
+		t.Fatalf("read-only write reported %d, want -1", result)
+	}
+	onDisk, _ := os.ReadFile(path)
+	if string(onDisk[10*SectorSize:11*SectorSize]) != string(img[10*SectorSize:11*SectorSize]) {
+		t.Fatal("a read-only image was modified")
+	}
+}
+
+// TestOutOfRangeRequestsAreRefused: a count running past the image would make
+// the server stream unbounded zero padding on request.
+func TestOutOfRangeRequestsAreRefused(t *testing.T) {
+	addr, _, img := startServer(t, false)
+	c := dialServer(t, addr)
+	sectors := uint32(len(img) / SectorSize)
+
+	if _, err := c.Write(sectorReq(CmdRead, 1, sectors-1, 64)); err != nil {
+		t.Fatal(err)
+	}
+	_ = c.SetReadDeadline(time.Now().Add(400 * time.Millisecond))
+	buf := make([]byte, 2048)
+	if _, err := c.Read(buf); err == nil {
+		t.Fatal("an out-of-range READ was answered instead of refused")
+	}
+
+	// The server must still be alive and answering afterwards.
+	_ = c.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if _, err := c.Write(append(packHeader(CmdInfo, 0, 0), make([]byte, 6)...)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Read(buf); err != nil {
+		t.Fatalf("server stopped answering after an out-of-range request: %v", err)
+	}
+}
+
+// TestMalformedDatagramsDoNotKillTheServer mirrors the Python selftest's fuzz
+// pass: a port scan or a broken client must not take the server down.
+func TestMalformedDatagramsDoNotKillTheServer(t *testing.T) {
+	addr, _, _ := startServer(t, false)
+	c := dialServer(t, addr)
+
+	for _, junk := range [][]byte{
+		{}, {0x00}, {0xff, 0xff, 0xff},
+		append(packHeader(CmdRead, 0, 0), 0x01),
+		append(packHeader(0x1F, 7, 255), make([]byte, 32)...),
+		append(packHeader(CmdWriteRDMA, 0, 0), 0x00, 0x00),
+	} {
+		_, _ = c.Write(junk)
+	}
+	buf := make([]byte, 2048)
+	if _, err := c.Write(append(packHeader(CmdInfo, 0, 0), make([]byte, 6)...)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Read(buf); err != nil {
+		t.Fatalf("server died on malformed input: %v", err)
+	}
+}


### PR DESCRIPTION
You pushed back on this and you were right. My answer — "we set a validation bar and didn't clear it" — was process-speak, not a reason. If someone picks Edge for their router, they shouldn't silently lose a server.

## What I was actually defending

- The whole protocol is **7 commands in 326 lines** of Python.
- `udpbd_server/selftest.py` **already drove it over real UDP sockets**.

So the "protocol fixtures and integration tests" `docs/EDGE.md` called missing **substantially existed**. I repeated a doc's justification without checking whether it was still true.

## What this adds

`ps2servers-edge udpbd --image /mnt/ps2.img [--read-only]`

`INFO`, `READ` with RDMA streaming and the upstream block-size optimizer, `WRITE` with its RDMA handshake. It's a subcommand rather than a flag because UDPBD is a separate protocol on its own fixed port — one invocation serves either a folder of files or one image as a raw drive, never both.

## The part that needed care

The bit packing (`cmd:5/cmdid:3/cmdpkt:8`, `block_shift:4/block_count:9`) and the `1440/1024/1280/1408` optimizer thresholds must match the reference **byte for byte**. A wrong threshold doesn't fail visibly — it silently picks worse packet sizes and slows real transfers. So the Go table test pins values **computed from the Python implementation** rather than from my reading of it.

## Hardened where it cost nothing

- Reads and writes are **positional**, never a shared file cursor, so two consoles can't pull each other's data
- An in-flight write **records its peer**, so a stray RDMA from a different console can't land inside another's sequence
- Requests past the end of the image are **refused**, not answered with unbounded zero padding
- Completed writes are **fsync'd** before `WRITE_DONE`

## Verification — differential, not just unit

`conformance/integration/udpbd_probe.py` deliberately **defines its own packing** instead of importing `udpbd_server`: a probe sharing an encoder with the implementation cannot catch that implementation's encoding bugs.

Locally:

| Check | Result |
|---|---|
| Probe vs **Python** server (control) | pass |
| Probe vs **Go** Edge | pass |
| Both images after identical writes | **byte-identical** (`c640543f28446435`) |
| Go tests under `-race` | 11 pass |
| `go vet` | clean |
| All 16 cross-compile targets | build |
| Python UDPBD selftest, UDPFS selftests, compliance | unaffected |

CI now runs the probe against **both** implementations from identical images and asserts the images still match afterwards — so a divergence is a CI failure rather than a console that won't boot.

## Still not claimed

**No console or emulator has exercised the Go UDPBD path.** The validation status records that. This is wire-level agreement with a hardware-validated implementation, which is the strongest evidence available without hardware — not a substitute for it.

Docs updated: the stale "native UDPBD — not claimed" entries are gone, and `docs/EDGE.md` now explains the UDPFS-vs-UDPBD distinction in plain terms, since "block device" isn't obvious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UDPBD support for serving a disk image as a network block device.
  * Added a new `udpbd` command with options for image selection, binding, logging, and read-only mode.
  * Supports block-device information, reads, writes, RDMA transfers, and safe handling of invalid requests.
* **Documentation**
  * Added usage guidance and clarified UDPBD versus UDPFS behavior.
* **Tests**
  * Added comprehensive protocol, read/write, read-only, malformed-request, and conformance coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->