### PR TITLE
feat: Edge metrics, override-drift guard, and honest release notes

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -275,6 +275,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate SHA256 checksums
+        id: sums
         shell: bash
         run: |
           cd release-assets
@@ -308,6 +309,31 @@ jobs:
           sha256sum "${present[@]}" > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
+          # Build the "which file do I download" table from what is actually
+          # here. The portable build is best-effort (continue-on-error above),
+          # so a static table could recommend a download that failed to build
+          # and is not attached -- pointing a non-technical user at a 404 on the
+          # exact row the notes tell them to use. When a portable asset is
+          # missing the row falls back to that OS's single-file build and says
+          # why, and if neither exists the row is omitted entirely rather than
+          # listed as broken.
+          row() { # row <label> <preferred> <fallback>
+            if [ -n "$2" ] && [ -f "$2" ]; then
+              printf '| %s | **`%s`** |\n' "$1" "$2"
+            elif [ -n "$3" ] && [ -f "$3" ]; then
+              printf '| %s | **`%s`** — portable build unavailable in this release |\n' "$1" "$3"
+            fi
+          }
+          {
+            echo "downloads_table<<PS2SERVERS_EOF"
+            row "Windows, normal (64-bit)"   PS2Servers-windows-x64-portable.zip   PS2Servers-windows-x64.zip
+            row "Windows, older 32-bit PC"   PS2Servers-windows-x86-portable.zip   PS2Servers-windows-x86.zip
+            row "Linux"                      PS2Servers-linux-x64                  PS2Servers-linux-x64-portable.tar.gz
+            row "Mac, Apple Silicon (M1–M4)" PS2Servers-macos-arm64.zip            ""
+            row "Mac, Intel"                 PS2Servers-macos-x64.zip              ""
+            echo "PS2SERVERS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create release tag
         id: tag
         run: |
@@ -339,11 +365,7 @@ jobs:
 
             | Your computer | Download this |
             |---|---|
-            | Windows, normal (64-bit) | **`PS2Servers-windows-x64-portable.zip`** |
-            | Windows, older 32-bit PC | **`PS2Servers-windows-x86-portable.zip`** |
-            | Linux | **`PS2Servers-linux-x64`** |
-            | Mac, Apple Silicon (M1–M4) | **`PS2Servers-macos-arm64.zip`** |
-            | Mac, Intel | **`PS2Servers-macos-x64.zip`** |
+            ${{ steps.sums.outputs.downloads_table }}
 
             On Windows: unzip it, open the folder, run `PS2Servers.exe`. That's it.
 

--- a/native/ps2servers-edge/cmd/ps2servers-edge/main.go
+++ b/native/ps2servers-edge/cmd/ps2servers-edge/main.go
@@ -75,6 +75,10 @@ func main() {
 	// because a router share is often an entire attached disk. See
 	// packaging/openwrt/files/ps2servers-edge.config.
 	readOnly := fs.Bool("read-only", envBool("RO", false), "serve files read-only; omit to allow the console to write saves")
+	// Names match the Desktop/Core server so a command line or compose file
+	// written for one works on the other.
+	metrics := fs.Bool("metrics", envBool("METRICS", false), "log periodic transfer statistics")
+	metricsPeriod := fs.String("metrics-period", env("METRICS_PERIOD", "1m"), "how often to log statistics")
 	logFormat := fs.String("log-format", env("LOG_FORMAT", "text"), "text or json")
 	verbose := fs.Bool("verbose", envBool("VERBOSE", false), "verbose protocol logging")
 	quiet := fs.Bool("quiet", false, "suppress informational logs")
@@ -124,8 +128,16 @@ func main() {
 	if *txDelayMs > 0 {
 		txDelay = time.Duration(*txDelayMs * float64(time.Millisecond))
 	}
+	var metricsEvery time.Duration
+	if *metrics {
+		metricsEvery, err = duration(*metricsPeriod)
+		if err != nil || metricsEvery < time.Second || metricsEvery > 24*time.Hour {
+			fmt.Fprintln(os.Stderr, "error: --metrics-period must be between 1s and 24h")
+			os.Exit(2)
+		}
+	}
 	logger := edgelog.New(os.Stdout, *logFormat, *quiet, *verbose)
-	server, err := udpfs.New(udpfs.Config{Root: *root, Bind: *bind, Port: *port, DataPort: *dataPort, SinglePort: *singlePort, ProtocolMode: profile, PeerTimeout: timeout, TxDelay: txDelay, ReadOnly: *readOnly, Log: logger, ServerName: "PS2 Servers Edge"})
+	server, err := udpfs.New(udpfs.Config{Root: *root, Bind: *bind, Port: *port, DataPort: *dataPort, SinglePort: *singlePort, ProtocolMode: profile, PeerTimeout: timeout, TxDelay: txDelay, ReadOnly: *readOnly, MetricsPeriod: metricsEvery, Log: logger, ServerName: "PS2 Servers Edge"})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)

--- a/native/ps2servers-edge/internal/udpfs/metrics.go
+++ b/native/ps2servers-edge/internal/udpfs/metrics.go
@@ -1,0 +1,79 @@
+package udpfs
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// metrics counts protocol operations and bytes moved.
+//
+// Edge is headless and usually lives on a router or NAS with no screen, so
+// "is it actually transferring anything?" is otherwise unanswerable without a
+// packet capture. The Desktop/Core server has emitted these counters behind
+// --metrics for a long time; Edge not having them was an omission rather than a
+// decision, and it is the last real capability gap against udpfsd.
+//
+// Counters are atomic rather than mutex-guarded: they are written on every
+// operation from per-peer worker goroutines, and a lock there would put
+// contention on the transfer path purely for bookkeeping.
+type metrics struct {
+	discovery atomic.Int64
+	open      atomic.Int64
+	read      atomic.Int64
+	write     atomic.Int64
+	closeOp   atomic.Int64
+	dread     atomic.Int64
+	getstat   atomic.Int64
+	lseek     atomic.Int64
+
+	bytesRead    atomic.Int64
+	bytesWritten atomic.Int64
+
+	started time.Time
+}
+
+// snapshot renders the counters for one log line. The names match the Python
+// server's stats keys so the two are comparable when diagnosing a transfer that
+// behaves differently on one of them.
+func (m *metrics) snapshot() map[string]any {
+	elapsed := time.Since(m.started)
+	readBytes := m.bytesRead.Load()
+	fields := map[string]any{
+		"uptime":        elapsed.Truncate(time.Second).String(),
+		"discovery":     m.discovery.Load(),
+		"open":          m.open.Load(),
+		"read":          m.read.Load(),
+		"write":         m.write.Load(),
+		"close":         m.closeOp.Load(),
+		"dread":         m.dread.Load(),
+		"getstat":       m.getstat.Load(),
+		"lseek":         m.lseek.Load(),
+		"bytes_read":    readBytes,
+		"bytes_written": m.bytesWritten.Load(),
+	}
+	// A rate is what actually tells a slow transfer from a stalled one, which
+	// is the question someone enables metrics to answer.
+	if secs := elapsed.Seconds(); secs >= 1 {
+		fields["read_bytes_per_sec"] = int64(float64(readBytes) / secs)
+	}
+	return fields
+}
+
+// emitMetrics logs a counter snapshot on an interval until ctx-driven shutdown
+// closes the done channel.
+func (s *Server) emitMetrics(period time.Duration, done <-chan struct{}) {
+	defer s.wg.Done()
+	tick := time.NewTicker(period)
+	defer tick.Stop()
+	for {
+		select {
+		case <-done:
+			// One final line on the way out, so a short-lived run still reports
+			// what it moved rather than nothing at all.
+			s.cfg.Log.Info("UDPFS metrics", s.stats.snapshot())
+			return
+		case <-tick.C:
+			s.cfg.Log.Info("UDPFS metrics", s.stats.snapshot())
+		}
+	}
+}

--- a/native/ps2servers-edge/internal/udpfs/negotiation.go
+++ b/native/ps2servers-edge/internal/udpfs/negotiation.go
@@ -42,6 +42,8 @@ func (s *Server) handleDiscovery(in inbound, h protocol.Header) {
 	// Only the first discovery per peer is announced at Info: both client
 	// families keep broadcasting discovery for the life of a transfer, so
 	// logging every one would bury the transfer log. --verbose shows them all.
+	s.stats.discovery.Add(1)
+
 	s.sessionsMu.Lock()
 	_, known := s.sessions[in.peer.String()]
 	s.sessionsMu.Unlock()

--- a/native/ps2servers-edge/internal/udpfs/operations.go
+++ b/native/ps2servers-edge/internal/udpfs/operations.go
@@ -17,22 +17,33 @@ import (
 )
 
 func (s *Server) handleMessage(st *session.State, p []byte) {
+	// Counters are incremented at dispatch so one request counts once,
+	// regardless of how a handler exits. WriteData is not counted separately:
+	// a write is one operation however many chunks carry it, which is how the
+	// Desktop server counts it too.
 	switch protocol.MessageType(p[0]) {
 	case protocol.OpenRequest:
+		s.stats.open.Add(1)
 		s.handleOpen(st, p)
 	case protocol.CloseRequest:
+		s.stats.closeOp.Add(1)
 		s.handleClose(st, p)
 	case protocol.ReadRequest:
+		s.stats.read.Add(1)
 		s.handleRead(st, p)
 	case protocol.WriteRequest:
+		s.stats.write.Add(1)
 		s.handleWriteRequest(st, p)
 	case protocol.WriteData:
 		s.handleWriteData(st, p)
 	case protocol.SeekRequest:
+		s.stats.lseek.Add(1)
 		s.handleSeek(st, p)
 	case protocol.DReadRequest:
+		s.stats.dread.Add(1)
 		s.handleDRead(st, p)
 	case protocol.GetStatRequest:
+		s.stats.getstat.Add(1)
 		s.handleGetStat(st, p)
 	default:
 		s.cfg.Log.Debug("unknown UDPFS opcode", map[string]any{"peer": st.Peer, "opcode": p[0]})
@@ -242,6 +253,7 @@ func (s *Server) handleRead(st *session.State, p []byte) {
 		s.sendTransfer(st, result8(protocol.ResultReply, errno(err)), nil)
 		return
 	}
+	s.stats.bytesRead.Add(int64(n))
 	s.sendTransfer(st, result8(protocol.ResultReply, int32(n)), buf[:n])
 }
 // maxWriteBytes caps one assembled write. The WRITE_REQ size field is 32-bit,
@@ -362,6 +374,7 @@ func (s *Server) completeWrite(st *session.State) {
 			return
 		}
 	}
+	s.stats.bytesWritten.Add(int64(n))
 	s.cfg.Log.Debug("WRITE ok", map[string]any{"peer": st.Peer, "handle": id, "bytes": n})
 	s.sendWriteDone(st, int32(n))
 }

--- a/native/ps2servers-edge/internal/udpfs/server.go
+++ b/native/ps2servers-edge/internal/udpfs/server.go
@@ -34,6 +34,9 @@ type Config struct {
 	PeerTimeout   time.Duration
 	TxDelay       time.Duration
 	ReadOnly      bool
+	// MetricsPeriod logs a periodic counter snapshot when > 0, matching the
+	// Desktop server's --metrics / --metrics-period.
+	MetricsPeriod time.Duration
 	Log           *edgelog.Logger
 	ServerName    string
 	FallbackDelay time.Duration
@@ -67,6 +70,8 @@ type Server struct {
 	closed     chan struct{}
 	closeOnce  sync.Once
 	wg         sync.WaitGroup
+
+	stats metrics
 
 	// writers reserves each file that some peer currently holds open for
 	// writing, mapping resolved path to a reference count. Two consoles
@@ -135,6 +140,7 @@ func New(cfg Config) (*Server, error) {
 		return nil, err
 	}
 	s := &Server{cfg: cfg, root: root, sessions: make(map[string]*peerWorker), incoming: make(chan inbound, 256), closed: make(chan struct{})}
+	s.stats.started = time.Now()
 	return s, nil
 }
 
@@ -187,6 +193,10 @@ func (s *Server) Serve(ctx context.Context) error {
 	}
 	s.wg.Add(1)
 	go s.reaper()
+	if s.cfg.MetricsPeriod > 0 {
+		s.wg.Add(1)
+		go s.emitMetrics(s.cfg.MetricsPeriod, s.closed)
+	}
 	for {
 		select {
 		case <-ctx.Done():

--- a/tests/test_server_override_contract.py
+++ b/tests/test_server_override_contract.py
@@ -1,0 +1,100 @@
+"""Pin which UdpfsServer methods ps2servers_core replaces.
+
+There are two UDPFS server classes in this repository and only one of them runs:
+
+* ``udpfs_server.UdpfsServer`` -- redistributed from Rick Gaiser's Neutrino host
+  tools (see NOTICE.md) and still a documented standalone entry point in the
+  README, so it stays as it is.
+* ``ps2servers_core.AutoUdpfsServer`` -- subclasses it, replaces the global
+  Modulo switch with per-session negotiation, and is what the launcher registry
+  actually points at.
+
+Editing an overridden method in the base class alone therefore changes nothing
+on the shipped path. That is not hypothetical: a discovery log line was added to
+``udpfs_server.py`` first, the server ran, the tests passed, and the line never
+appeared, because ``AutoUdpfsServer._handle_discovery`` shadows it.
+
+These tests do not forbid overriding. They make the set of overrides an explicit,
+reviewed list, so adding a seventh is a deliberate act rather than something a
+future reader discovers the hard way.
+
+Run:  python -m unittest tests.test_server_override_contract -v
+"""
+
+import os
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_UDPFS_DIR = os.path.join(ROOT, "udpfs_server")
+for path in (ROOT, _UDPFS_DIR):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+import ps2servers_core  # noqa: E402
+import udpfs_server  # noqa: E402
+
+from launcher.servers import REGISTRY  # noqa: E402
+
+
+# Every method AutoUdpfsServer replaces. Changing this set is a real decision:
+# whatever is listed here must be edited in ps2servers_core.py, because editing
+# the udpfs_server.py copy will not affect the launcher, the packaged app, or
+# anything a user runs through the GUI.
+EXPECTED_OVERRIDES = {
+    "__init__",
+    "_get_or_create_session",
+    "_handle_data",
+    "_handle_discovery",
+    "_sendto",
+    "run",
+}
+
+
+def _own_methods(cls):
+    """Methods defined directly on cls, ignoring anything inherited."""
+    return {
+        name for name, value in vars(cls).items()
+        if callable(value) and not isinstance(value, (staticmethod, classmethod))
+    }
+
+
+class OverrideContractTests(unittest.TestCase):
+    def test_override_set_is_exactly_what_is_documented(self):
+        base = _own_methods(udpfs_server.UdpfsServer)
+        core = _own_methods(ps2servers_core.AutoUdpfsServer)
+        actual = base & core
+
+        unexpected = actual - EXPECTED_OVERRIDES
+        self.assertFalse(unexpected, (
+            "ps2servers_core.AutoUdpfsServer now also overrides {}. That is fine, "
+            "but add it to EXPECTED_OVERRIDES here so the next person editing "
+            "udpfs_server.{} knows their change will not reach the launcher."
+        ).format(sorted(unexpected), sorted(unexpected)[0] if unexpected else ""))
+
+        missing = EXPECTED_OVERRIDES - actual
+        self.assertFalse(missing, (
+            "{} is no longer overridden in ps2servers_core. If that is "
+            "intentional the base implementation is now live on the shipped "
+            "path -- confirm it is the behaviour you want, then remove it here."
+        ).format(sorted(missing)))
+
+    def test_the_launcher_runs_the_core_entry_point(self):
+        # The whole hazard rests on this: the registry decides which file is
+        # loaded, and it is the core, not the base module.
+        udpfs = REGISTRY["udpfs"]
+        self.assertEqual(
+            os.path.basename(udpfs.module_file), "ps2servers_core.py",
+            "the UDPFS registry entry no longer points at ps2servers_core.py; "
+            "the override contract in this file assumes it does")
+
+    def test_core_subclasses_the_base_rather_than_reimplementing_it(self):
+        # If this ever stops being true the two servers have genuinely forked
+        # and this contract cannot express the relationship any more.
+        self.assertTrue(
+            issubclass(ps2servers_core.AutoUdpfsServer, udpfs_server.UdpfsServer),
+            "AutoUdpfsServer no longer subclasses UdpfsServer")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/udpfs_server/ps2servers_core.py
+++ b/udpfs_server/ps2servers_core.py
@@ -72,7 +72,21 @@ def classify_profile(discovery_sequence: int, first_data_sequence: int) -> str:
 
 
 class AutoUdpfsServer(UdpfsServer):
-    """Existing Python UDPFS implementation with per-session compatibility."""
+    """Existing Python UDPFS implementation with per-session compatibility.
+
+    This is the class the launcher actually runs: the registry in
+    launcher/servers.py points at this file, not at udpfs_server.py. Six
+    UdpfsServer methods are overridden below -- __init__, run, _sendto,
+    _get_or_create_session, _handle_data and _handle_discovery -- so behaviour
+    changes to any of those belong here. Editing only the udpfs_server.py copy
+    produces code that never executes on the shipped path, which has already
+    happened once.
+
+    udpfs_server.py stays as it is on purpose: it is redistributed upstream code
+    (NOTICE.md) and a standalone entry point the README documents.
+    tests/test_server_override_contract.py pins the override set so adding a
+    seventh is a deliberate, reviewed act.
+    """
 
     def __init__(self, *args, protocol_mode: str = "auto",
                  fallback_interval: float = DEFAULT_FALLBACK_SECONDS, **kwargs):

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -1096,7 +1096,19 @@ class UdpfsServer:
     # --- UDPRDMA packet handling ---
 
     def _handle_discovery(self, data: bytes, addr: Tuple[str, int]):
-        """Handle DISCOVERY packet"""
+        """Handle DISCOVERY packet.
+
+        NOT the implementation the launcher runs. ps2servers_core.
+        AutoUdpfsServer overrides this method, and the launcher registry points
+        at ps2servers_core.py, so editing this copy alone changes nothing for
+        the GUI, the packaged app, or `python -m launcher --serve udpfs`. It is
+        live only for `python udpfs_server/udpfs_server.py`, the standalone
+        entry point the README documents.
+
+        Six methods are overridden this way; tests/test_server_override_contract
+        .py pins the list. Change behaviour in ps2servers_core.py, and mirror it
+        here only if the standalone server needs it too.
+        """
         if len(data) < 6:
             return
 


### PR DESCRIPTION
Items 1–3 from the remaining-work list. **Item 1 changed shape once I checked it, and item 4 turned out to be a non-issue** — details below, because both are corrections to things I told you.

---

## 2. Metrics in Edge ✅

The last real capability gap against udpfsd, and an omission rather than a decision. Edge is headless and usually lives on a router with no screen, so *"is it actually transferring?"* was unanswerable without a packet capture.

`--metrics` / `--metrics-period`, names matching the Desktop server so a command line written for one works on the other. Same counter set (`discovery/open/read/write/close/dread/getstat/lseek` + bytes), plus a read rate — which is what separates a slow transfer from a stalled one.

Counters are atomic rather than mutex-guarded: they're written from every per-peer worker, and a lock there would put contention on the transfer path purely for bookkeeping.

**Verified against a live server**, not just wiring — the conformance probe's four clients produced exactly:

```
discovery=4 open=4 read=4 bytes_read=4096 read_bytes_per_sec=292
```

## 1. Override drift — *not* the fix I proposed ⚠️

I said "collapse the duplicate discovery handlers." **Checking first showed that's the wrong fix.**

`udpfs_server.py` is **redistributed upstream code** (NOTICE.md — Rick Gaiser's Neutrino, AFL-3.0) **and** a standalone entry point the README documents twice, including the Raspberry Pi / NAS instructions. The two handlers aren't accidental duplication — they're two generations of the design: upstream's global `modulo_compat` switch, and our per-session negotiation layered on by subclassing. Collapsing them would mean rewriting redistributed code or deleting a documented command.

**The hazard is real though, and bigger than I thought — six methods are overridden, not one:**

```
__init__  run  _sendto  _get_or_create_session  _handle_data  _handle_discovery
```

Editing any of those in the base file alone is dead code on the shipped path. That already cost a debug line that never appeared.

So instead: `tests/test_server_override_contract.py` pins the set, and both files now cross-reference each other **at the point an editor would be standing**. Adding a seventh override becomes a reviewed act instead of a trap.

## 3. Release notes can't advertise a missing download ✅

The portable build is best-effort (`continue-on-error`), so a static table could recommend a download that failed to build and was never attached — pointing a non-technical user at a 404 on the exact row telling them what to use.

The table is now generated from the assets actually present. All three cases exercised:

| Case | Result |
|---|---|
| Everything built | normal table |
| Portable build failed | falls back to single-file, **says why** |
| Build absent entirely | row dropped, not listed broken |

## 4. I was wrong — nothing to fix

You agreed with my claim that Edge filenames embed the commit on tagged releases. They don't. `VERSION="${GITHUB_REF_NAME#v}"` means a `v0.5.0` tag already produces `PS2ServersEdge-0.5.0-pc-64bit-amd64.tar.gz`. The `-edge.<sha>` suffix applies only to rolling builds, which is correct. I hadn't checked before recommending it.

## Verification

- `go build`, `go vet`, `go test -race` clean
- 9 Python test modules, 3 selftests, release compliance
- actionlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)