### PR TITLE
One version number, and a gate so a tag can't disagree with it

### DIFF
--- a/.github/workflows/edge-build.yml
+++ b/.github/workflows/edge-build.yml
@@ -234,10 +234,21 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # The base version comes from launcher/release_metadata.py, which is
+          # the one number the maintainer edits and the one the launcher GUI
+          # reports. This step used to hardcode its own literal, so Edge and the
+          # launcher drifted and the drift shipped: main-130-3efbc27 attached
+          # PS2ServersEdge-0.5.0-edge.* beside a launcher reporting 0.4.9, and a
+          # tester quoting "the version" would name a different number depending
+          # on which binary they looked at.
+          #
+          # On a tag the tag wins, because release.yml has already refused to
+          # publish a tag that disagrees with the source.
+          BASE="$(python3 tools/version_source.py)"
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
           else
-            VERSION="0.5.0-edge.${GITHUB_SHA::7}"
+            VERSION="${BASE}-edge.${GITHUB_SHA::7}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "source_date_epoch=$(git show -s --format=%ct HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/edge-build.yml
+++ b/.github/workflows/edge-build.yml
@@ -246,6 +246,14 @@ jobs:
           # publish a tag that disagrees with the source.
           BASE="$(python3 tools/version_source.py)"
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            # Checked here as well as in release.yml, because release.yml's
+            # needs-graph cannot gate this workflow: edge.yml triggers on v*
+            # tags on its own, and the step below attaches straight to the
+            # release. Without this, a tag that disagrees with the source would
+            # still publish Edge binaries named for the tag -- producing a
+            # release holding Edge alone, labelled a version the source denies,
+            # while the launcher half correctly refused to build.
+            python3 tools/version_source.py --check-tag "$GITHUB_REF_NAME"
             VERSION="${GITHUB_REF_NAME#v}"
           else
             VERSION="${BASE}-edge.${GITHUB_SHA::7}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,38 @@ permissions:
   attestations: write
 
 jobs:
+  # Runs before anything is built, because the failure it catches is only
+  # expensive once it has shipped. Edge takes its version from the tag while the
+  # launcher takes its own from launcher/release_metadata.py, so tagging v0.5.0
+  # while the source still said 0.4.9 would publish binaries labelled both, and a
+  # bug report could honestly quote either number. Seconds here rather than a
+  # twenty-minute matrix followed by a bad release.
+  #
+  # Not gated on `if: startsWith(github.ref, 'refs/tags/')` -- a skipped job would
+  # skip everything that needs it. The script no-ops when there is no tag.
+  verify-version:
+    name: Verify tag matches source version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check the version in the source against the tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/version_source.py --check-sources
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            python3 tools/version_source.py --check-tag "$GITHUB_REF_NAME"
+          else
+            echo "not a tag build; source version is $(python3 tools/version_source.py --print-display)"
+          fi
+
   build:
     name: Build ${{ matrix.asset }}
+    needs: verify-version
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -347,6 +377,7 @@ jobs:
   # the same eleven targets twice and race to attach them.
   source:
     name: Package source archive
+    needs: verify-version
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -66,14 +66,29 @@ class VersionIsReadableWithoutImportingTheLauncher(unittest.TestCase):
                 "VERSION_QUALIFIER %r must start with '-' so DISPLAY_VERSION "
                 "reads like 0.5.0-rc1" % qualifier)
 
-    def test_display_version_matches_the_launcher_package(self):
-        """launcher.__version__ is DISPLAY_VERSION; the parser must agree with it."""
+    def test_display_version_matches_an_independent_read(self):
+        """Cross-check the ast parser against a different way of reading the file.
+
+        Deliberately not the same mechanism: a parser validated only by itself
+        would agree with its own bug. The regex is the naive read, so if the two
+        disagree one of them is wrong.
+
+        Both quote styles are accepted, and a missing match fails with a sentence
+        rather than an AttributeError on .group() -- the assertion should say what
+        is wrong, not crash on the way to finding out.
+        """
         with open(os.path.join(ROOT, "launcher", "release_metadata.py"),
                   encoding="utf-8") as handle:
             text = handle.read()
-        product = re.search(r'PRODUCT_VERSION = "([^"]+)"', text).group(1)
-        qualifier = re.search(r'VERSION_QUALIFIER = "([^"]*)"', text).group(1)
-        self.assertEqual(vs.display_version(), product + qualifier)
+        product = re.search(r"""PRODUCT_VERSION\s*=\s*["']([^"']+)["']""", text)
+        self.assertIsNotNone(
+            product, "PRODUCT_VERSION is no longer a plain string literal in "
+                     "launcher/release_metadata.py")
+        qualifier = re.search(r"""VERSION_QUALIFIER\s*=\s*["']([^"']*)["']""", text)
+        # A missing VERSION_QUALIFIER is legitimate; version_source defaults it
+        # to "", so the independent read has to as well.
+        suffix = qualifier.group(1) if qualifier else ""
+        self.assertEqual(vs.display_version(), product.group(1) + suffix)
 
 
 class NoWorkflowCarriesItsOwnVersion(unittest.TestCase):
@@ -84,16 +99,45 @@ class NoWorkflowCarriesItsOwnVersion(unittest.TestCase):
         except SystemExit as exc:
             self.fail(str(exc))
 
-    def test_edge_workflow_derives_its_base_version(self):
-        """Belt and braces: the fallback must reference the shared tool."""
+    def _edge_version_step(self):
+        """The `run:` body of edge-build.yml's version step, from parsed YAML."""
+        import yaml
         with open(vs.EDGE_WORKFLOW, encoding="utf-8") as handle:
-            text = handle.read()
-        # Compared as a boolean rather than with assertIn, which would print the
-        # entire workflow on failure and bury the one sentence that matters.
+            workflow = yaml.safe_load(handle)
+        for step in workflow["jobs"]["build"]["steps"]:
+            if step.get("id") == "version":
+                return step["run"]
+        self.fail("edge-build.yml has no step with id: version")
+
+    def test_edge_workflow_derives_its_base_version(self):
+        """The step that computes the version must call the shared tool.
+
+        Checked against that step's parsed `run:` body rather than against the
+        whole file. A substring search over the file would be satisfied by the
+        path appearing in a comment or an unrelated step while the fallback went
+        back to a hardcoded literal -- and this file now contains exactly such a
+        comment, explaining the drift, so that weaker check would be self-
+        satisfying.
+        """
+        run = self._edge_version_step()
         self.assertTrue(
-            "tools/version_source.py" in text,
-            "edge-build.yml no longer derives its base version from the shared "
-            "source of truth, so it can drift from the launcher again")
+            "version_source.py" in run,
+            "edge-build.yml's version step no longer calls version_source.py, "
+            "so its base version can drift from the launcher again")
+
+    def test_edge_workflow_validates_a_tag_itself(self):
+        """release.yml's needs-graph cannot gate edge.yml.
+
+        edge.yml triggers on v* tags independently and attaches straight to the
+        release, so a mismatched tag would otherwise publish Edge binaries named
+        for the tag while the launcher half correctly refused to build -- a
+        release holding Edge alone, labelled a version the source denies.
+        """
+        run = self._edge_version_step()
+        self.assertTrue(
+            "--check-tag" in run,
+            "edge-build.yml does not validate the tag against the source, and "
+            "nothing else can validate it on this workflow's behalf")
 
 
 class TagCheckActuallyRejects(unittest.TestCase):
@@ -109,12 +153,26 @@ class TagCheckActuallyRejects(unittest.TestCase):
             vs.check_tag("v" + bumped)
         self.assertIn("mismatch", str(caught.exception))
 
-    def test_missing_qualifier_is_refused(self):
-        """v0.5.0-rc1 against an empty qualifier ships a GUI calling itself 0.5.0."""
+    def test_qualifier_mismatch_is_refused(self):
+        """The qualifier half must be enforced whichever way it is wrong.
+
+        Both directions ship a GUI that contradicts the release it came from:
+        tagging v0.5.0-rc1 with an empty qualifier gives binaries calling
+        themselves 0.5.0, and tagging a bare v0.5.0 while the qualifier still
+        says -rc1 gives binaries calling themselves 0.5.0-rc1.
+
+        Skipping whichever case does not currently apply would mean this test
+        quietly stops checking anything the moment a qualifier is set -- which is
+        precisely when a release is under test and the check matters most.
+        """
+        product = vs.product_version()
         if vs.version_qualifier():
-            self.skipTest("a qualifier is set; this case cannot arise right now")
-        with self.assertRaises(SystemExit):
-            vs.check_tag("v" + vs.product_version() + "-rc1")
+            wrong = "v" + product          # bare tag, qualifier still set
+        else:
+            wrong = "v" + product + "-rc1"  # qualified tag, no qualifier set
+        with self.assertRaises(SystemExit) as caught:
+            vs.check_tag(wrong)
+        self.assertIn("mismatch", str(caught.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,121 @@
+"""The launcher and Edge must not be able to disagree about the version.
+
+There were two version numbers. `launcher/release_metadata.py` held
+`PRODUCT_VERSION`, which the maintainer edits and which reaches the GUI, the
+Windows executable metadata and `--version`. `.github/workflows/edge-build.yml`
+held a second literal for non-tag builds. Nothing compared them.
+
+They drifted, and the drift shipped. Development build `main-130-3efbc27`
+attached
+
+    PS2ServersEdge-0.5.0-edge.3efbc27-arm64-pi3-pi4-pi5-nas.tar.gz
+
+beside a launcher reporting `0.4.9`. Both came out of the same release, so a
+tester quoting "the version" in a report would name a different number depending
+on which binary they happened to open -- and the version is most of what a bug
+report is for.
+
+The tag case is worse, because Edge derives its version from the tag and the
+launcher does not: tagging `v0.5.0` while the source still said `0.4.9` publishes
+binaries labelled both at once. That check needs a tag, so it lives in
+release.yml. Everything checkable without one lives here, where it runs on every
+push instead of once per release.
+
+Run:  python -m unittest tests.test_version_consistency -v
+"""
+
+import importlib.util
+import os
+import re
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+def _load_version_source():
+    """Import tools/version_source.py by path; tools/ is not a package."""
+    spec = importlib.util.spec_from_file_location(
+        "_ps2_version_source", os.path.join(ROOT, "tools", "version_source.py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+vs = _load_version_source()
+
+
+class VersionIsReadableWithoutImportingTheLauncher(unittest.TestCase):
+    """A release runner must not have to execute GUI code to read a string.
+
+    launcher/__init__.py installs an import hook for the dependency panel, so
+    importing the package to reach one constant runs machinery that has nothing
+    to do with versioning and can fail where the GUI dependencies are absent.
+    """
+
+    def test_product_version_looks_like_a_version(self):
+        self.assertRegex(vs.product_version(), r"^\d+\.\d+\.\d+$")
+
+    def test_qualifier_is_empty_or_prefixed_with_a_dash(self):
+        qualifier = vs.version_qualifier()
+        if qualifier:
+            self.assertTrue(
+                qualifier.startswith("-"),
+                "VERSION_QUALIFIER %r must start with '-' so DISPLAY_VERSION "
+                "reads like 0.5.0-rc1" % qualifier)
+
+    def test_display_version_matches_the_launcher_package(self):
+        """launcher.__version__ is DISPLAY_VERSION; the parser must agree with it."""
+        with open(os.path.join(ROOT, "launcher", "release_metadata.py"),
+                  encoding="utf-8") as handle:
+            text = handle.read()
+        product = re.search(r'PRODUCT_VERSION = "([^"]+)"', text).group(1)
+        qualifier = re.search(r'VERSION_QUALIFIER = "([^"]*)"', text).group(1)
+        self.assertEqual(vs.display_version(), product + qualifier)
+
+
+class NoWorkflowCarriesItsOwnVersion(unittest.TestCase):
+    def test_check_sources_passes(self):
+        """The guard that would have caught the drift before it shipped."""
+        try:
+            vs.check_sources()
+        except SystemExit as exc:
+            self.fail(str(exc))
+
+    def test_edge_workflow_derives_its_base_version(self):
+        """Belt and braces: the fallback must reference the shared tool."""
+        with open(vs.EDGE_WORKFLOW, encoding="utf-8") as handle:
+            text = handle.read()
+        # Compared as a boolean rather than with assertIn, which would print the
+        # entire workflow on failure and bury the one sentence that matters.
+        self.assertTrue(
+            "tools/version_source.py" in text,
+            "edge-build.yml no longer derives its base version from the shared "
+            "source of truth, so it can drift from the launcher again")
+
+
+class TagCheckActuallyRejects(unittest.TestCase):
+    """The guard is only worth having if it refuses the bad case."""
+
+    def test_matching_tag_is_accepted(self):
+        vs.check_tag("v" + vs.display_version())
+
+    def test_mismatched_tag_is_refused(self):
+        product = vs.product_version()
+        bumped = product.rsplit(".", 1)[0] + ".999"
+        with self.assertRaises(SystemExit) as caught:
+            vs.check_tag("v" + bumped)
+        self.assertIn("mismatch", str(caught.exception))
+
+    def test_missing_qualifier_is_refused(self):
+        """v0.5.0-rc1 against an empty qualifier ships a GUI calling itself 0.5.0."""
+        if vs.version_qualifier():
+            self.skipTest("a qualifier is set; this case cannot arise right now")
+        with self.assertRaises(SystemExit):
+            vs.check_tag("v" + vs.product_version() + "-rc1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/version_source.py
+++ b/tools/version_source.py
@@ -1,0 +1,153 @@
+"""One place that answers "what version is this?", and a guard that keeps it one.
+
+The repository had two independent version numbers. `launcher/release_metadata.py`
+carried `PRODUCT_VERSION`, which the maintainer edits and which feeds the GUI, the
+Windows executable metadata and `--version`. `.github/workflows/edge-build.yml`
+carried its own hardcoded literal for non-tag builds. Nothing compared them, so
+they drifted, and the drift shipped: development build `main-130-3efbc27` attached
+`PS2ServersEdge-0.5.0-edge.3efbc27-*` next to a launcher reporting `0.4.9`. A
+tester quoting "the version" from that download would name a different number
+depending on which binary they happened to look at, which is exactly the
+information a bug report exists to carry.
+
+On a tag the two could disagree in a worse way, because Edge derives its version
+from the tag while the launcher does not: tagging `v0.5.0` while the source still
+said `0.4.9` would publish binaries labelled both.
+
+So: `launcher/release_metadata.py` is the source of truth. Edge asks this module
+for the base version instead of hardcoding one, and `--check-tag` refuses to let a
+tag be published that disagrees with the source.
+
+Read with `ast` rather than by importing `launcher`, because importing that
+package installs a GUI panel hook and pulls in machinery a release runner has no
+reason to execute just to read a string.
+
+Usage:
+    python tools/version_source.py                  # print PRODUCT_VERSION
+    python tools/version_source.py --print-display  # print DISPLAY_VERSION
+    python tools/version_source.py --check-tag v0.5.0
+    python tools/version_source.py --check-sources
+"""
+
+import argparse
+import ast
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+METADATA = os.path.join(ROOT, "launcher", "release_metadata.py")
+EDGE_WORKFLOW = os.path.join(ROOT, ".github", "workflows", "edge-build.yml")
+
+# Workflows that must not carry a version literal of their own. Anything here is
+# checked by --check-sources and by tests/test_version_consistency.py.
+VERSIONED_WORKFLOWS = (EDGE_WORKFLOW,)
+
+_VERSION_LITERAL = re.compile(r'VERSION="(\d+\.\d+\.\d+)')
+
+
+def _constants():
+    """String constants from release_metadata.py, without importing it."""
+    with open(METADATA, encoding="utf-8") as handle:
+        tree = ast.parse(handle.read(), filename=METADATA)
+    found = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not isinstance(node.value, ast.Constant) or not isinstance(node.value.value, str):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                found[target.id] = node.value.value
+    return found
+
+
+def product_version():
+    """The numeric version, e.g. "0.4.9". Never carries a qualifier."""
+    values = _constants()
+    try:
+        return values["PRODUCT_VERSION"]
+    except KeyError:
+        raise SystemExit(
+            "launcher/release_metadata.py no longer defines PRODUCT_VERSION as a "
+            "plain string literal; version_source.py cannot read it")
+
+
+def version_qualifier():
+    """"" for a normal release, "-rc1"/"-beta1" while a version is under test."""
+    return _constants().get("VERSION_QUALIFIER", "")
+
+
+def display_version():
+    """What the GUI shows and what a tester should quote in a report."""
+    return product_version() + version_qualifier()
+
+
+def expected_tag():
+    return "v" + display_version()
+
+
+def check_tag(tag):
+    """Fail unless the tag being published matches the version in the source.
+
+    Both halves matter. PRODUCT_VERSION feeds the executable metadata and Edge's
+    filenames; VERSION_QUALIFIER feeds DISPLAY_VERSION, which is the string a
+    tester reads off the GUI and puts in a report. Tagging v0.5.0-rc1 with an
+    empty qualifier would ship binaries whose own GUI called them 0.5.0.
+    """
+    want = expected_tag()
+    if tag == want:
+        print("version check passed: tag %s matches launcher/release_metadata.py" % tag)
+        return
+    raise SystemExit(
+        "tag/source version mismatch\n"
+        "  tag being published : %s\n"
+        "  source says         : %s  (PRODUCT_VERSION=%r, VERSION_QUALIFIER=%r)\n"
+        "\n"
+        "Publishing this would attach Edge binaries named for the tag next to a\n"
+        "launcher reporting the source version, so a bug report could quote\n"
+        "either. Edit launcher/release_metadata.py to match the tag, or tag %s."
+        % (tag, want, product_version(), version_qualifier(), want))
+
+
+def check_sources():
+    """Fail if a workflow has grown a version literal of its own again."""
+    problems = []
+    for path in VERSIONED_WORKFLOWS:
+        with open(path, encoding="utf-8") as handle:
+            for number, line in enumerate(handle, 1):
+                match = _VERSION_LITERAL.search(line)
+                if match:
+                    problems.append("%s:%d assigns VERSION=%s as a literal"
+                                    % (os.path.relpath(path, ROOT), number, match.group(1)))
+    if problems:
+        raise SystemExit(
+            "a workflow carries its own version number again:\n  %s\n\n"
+            "That is how the launcher and Edge drifted apart. Derive it from\n"
+            "launcher/release_metadata.py via tools/version_source.py instead."
+            % "\n  ".join(problems))
+    print("version check passed: no workflow carries its own version literal")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--print-display", action="store_true",
+                        help="print DISPLAY_VERSION (with any qualifier)")
+    parser.add_argument("--check-tag", metavar="TAG",
+                        help="fail unless TAG matches the version in the source")
+    parser.add_argument("--check-sources", action="store_true",
+                        help="fail if a workflow hardcodes its own version")
+    args = parser.parse_args(argv)
+
+    if args.check_tag:
+        check_tag(args.check_tag)
+        return 0
+    if args.check_sources:
+        check_sources()
+        return 0
+    print(display_version() if args.print_display else product_version())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/version_source.py
+++ b/tools/version_source.py
@@ -43,7 +43,11 @@ EDGE_WORKFLOW = os.path.join(ROOT, ".github", "workflows", "edge-build.yml")
 # checked by --check-sources and by tests/test_version_consistency.py.
 VERSIONED_WORKFLOWS = (EDGE_WORKFLOW,)
 
-_VERSION_LITERAL = re.compile(r'VERSION="(\d+\.\d+\.\d+)')
+# Any shell assignment of a dotted version literal, not just VERSION="...".
+# The first version of this matched double quotes after the exact name VERSION,
+# which a reintroduction as VERSION='0.5.0', VERSION=0.5.0 or BASE="0.5.0" would
+# have walked straight past -- a guard narrower than the thing it guards.
+_VERSION_LITERAL = re.compile(r"""\b([A-Z][A-Z0-9_]*)=["']?(\d+\.\d+\.\d+)""")
 
 
 def _constants():
@@ -118,8 +122,9 @@ def check_sources():
             for number, line in enumerate(handle, 1):
                 match = _VERSION_LITERAL.search(line)
                 if match:
-                    problems.append("%s:%d assigns VERSION=%s as a literal"
-                                    % (os.path.relpath(path, ROOT), number, match.group(1)))
+                    problems.append("%s:%d assigns %s=%s as a literal"
+                                    % (os.path.relpath(path, ROOT), number,
+                                       match.group(1), match.group(2)))
     if problems:
         raise SystemExit(
             "a workflow carries its own version number again:\n  %s\n\n"


### PR DESCRIPTION
## This is already shipping

`main-130-3efbc27` — the build testers are downloading right now — attaches:

```
PS2ServersEdge-0.5.0-edge.3efbc27-arm64-pi3-pi4-pi5-nas.tar.gz
```

next to a launcher reporting **0.4.9**. Same release. A tester quoting "the
version" in a bug report names a different number depending on which binary they
happened to open.

There were two version sources and nothing compared them:

| Source | Value |
|---|---|
| `launcher/release_metadata.py` → `PRODUCT_VERSION` | `0.4.9` |
| `.github/workflows/edge-build.yml` (hardcoded) | `0.5.0` |

The tag case is worse, and is what prompted this. Edge derives its version from
the tag while the launcher doesn't — so tagging `v0.5.0` against source saying
`0.4.9` publishes binaries labelled **both at once**. That's exactly what the
`v0.5.0-rc1` smoke test produced.

## The fix

`launcher/release_metadata.py` is now the only version.

- **Edge asks `tools/version_source.py`** for its base instead of carrying a
  literal. A rolling build becomes `0.4.9-edge.<sha>` and agrees with the
  launcher beside it.
- **`release.yml` gains a `verify-version` job** that `build` and `source` both
  need, so a mismatched tag fails in seconds rather than after a 20-minute
  matrix and a bad release.

It deliberately has **no `if:`** on the tag condition — a skipped job skips
everything downstream, so the script no-ops when there's no tag instead.

The check covers `VERSION_QUALIFIER`, not just the number. That's the half
feeding `DISPLAY_VERSION`, the string a tester reads off the GUI, so tagging
`v0.5.0-rc1` with an empty qualifier would ship binaries whose own interface
called them `0.5.0`.

Metadata is read with `ast` rather than by importing `launcher` — that package
installs a GUI panel hook on import, which a release runner shouldn't execute to
read a string and which would fail where GUI deps are absent.

## Verified

The offline half runs as an ordinary test, so drift fails on **every push**
rather than once per release. I restored the original hardcoded literal and
confirmed two tests fail, then restored:

```
FAIL: test_check_sources_passes
FAIL: test_edge_workflow_derives_its_base_version
  edge-build.yml:250 assigns VERSION=0.5.0 as a literal
```

Both branches of the Edge version step executed directly:

| Build | Before | After |
|---|---|---|
| rolling | `0.5.0-edge.3efbc27` | `0.4.9-edge.3efbc27` |
| tag `v0.4.9` | `0.4.9` | `0.4.9` |

229 Python tests pass; compliance check passes.

## Worth knowing before you tag

**Cutting v0.5.0 now requires editing `PRODUCT_VERSION` first.** Had this existed
yesterday it would have blocked the `v0.5.0-rc1` smoke test — which is the
correct outcome, since that tag published a release labelled `0.5.0-rc1` built
from source that said `0.4.9`.

No version bump in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Version information is now managed consistently across release artifacts.
  * Tagged releases are validated against the product version before packaging begins.
  * Edge builds now generate versions from the shared release metadata.

* **Quality Improvements**
  * Added automated checks to detect mismatched tags, invalid version formats, and inconsistent release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->