### PR TITLE
Protocol mode back on the UDPFS card: Auto / Proper / Modulo

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -318,6 +318,15 @@ class ServerCard(ttk.LabelFrame):
             var = tk.StringVar(value=default_val)
             ttk.Entry(parent, textvariable=var, width=12).grid(
                 row=row, column=1, sticky="w", padx=6, pady=2)
+        elif f.kind == "choice":
+            # readonly, so the box can be opened and read but not typed into:
+            # an editable combobox would let a typo reach the server as an
+            # unknown value, and the server exits rather than guessing.
+            labels = [label for label, _ in f.choices]
+            var = tk.StringVar(value=str(f.default or (labels[0] if labels else "")))
+            ttk.Combobox(parent, textvariable=var, values=labels,
+                         state="readonly", width=18).grid(
+                row=row, column=1, sticky="w", padx=6, pady=2)
         elif f.kind in ("folder", "file"):
             var = tk.StringVar(value="")
             ttk.Entry(parent, textvariable=var).grid(

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -29,7 +29,7 @@ def _direct_link_experimental():
     """Non-Windows: the setup path is real but unverified on hardware."""
     return platform.system() in ("Linux", "Darwin")
 
-from . import config, directlink, elevate, netinfo, posix_firewall, theme, tray, windows_setup
+from . import config, directlink, elevate, netinfo, posix_firewall, servers, theme, tray, windows_setup
 from .process import ServerProcess
 from .release_metadata import DISPLAY_VERSION
 from .servers import REGISTRY, REPO_ROOT, frozen_self_exe, is_frozen, serve_command
@@ -378,6 +378,12 @@ class ServerCard(ttk.LabelFrame):
         return out
 
     def set_values(self, saved):
+        # Migrate first. This loop only restores keys that have a widget, so a
+        # setting whose control was retired is dropped here and can never come
+        # back on save either -- values() walks the same dict. Honouring a
+        # retired key further downstream cannot help, because nothing upstream
+        # can still deliver it.
+        saved = servers.migrate_saved(self.server.key, saved)
         for key, var in self.vars.items():
             if key in saved:
                 var.set(saved[key])

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -156,6 +156,36 @@ for _label, _value in PROTOCOL_MODE_CHOICES:
     _PROTOCOL_MODE_BY_NAME[_value.lower()] = _value
 
 
+def migrate_saved(server_key, saved):
+    """Translate retired settings keys into the controls that replaced them.
+
+    Applied when a saved configuration is loaded into a card, because the card
+    restores and collects values by walking its widgets: a key with no widget is
+    dropped on load and can never appear again on save. So honouring a retired
+    key inside build_argv is not enough on its own -- the GUI cannot put it
+    there. It has to become a key that does have a widget, before the widgets are
+    filled in.
+
+    Translating rather than merely preserving is also the better outcome for the
+    person upgrading. Their console keeps working AND the reason is now visible
+    in the interface, where they can see they are on Modulo and change it, rather
+    than being held in a key nothing displays.
+    """
+    if not saved:
+        return saved
+    if server_key != "udpfs":
+        return saved
+    if not saved.get("modulo_mode"):
+        return saved
+    migrated = dict(saved)
+    # Only fills an empty selection. Someone who has since made an explicit
+    # choice in the new control means it.
+    if not protocol_mode_value(migrated.get("protocol_mode")):
+        migrated["protocol_mode"] = "Modulo"
+    migrated.pop("modulo_mode", None)
+    return migrated
+
+
 def protocol_mode_value(raw):
     """Map whatever is stored for protocol_mode to a value the servers accept.
 

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -46,6 +46,10 @@ class Field:
     help: str = ""
     advanced: bool = False
     windows_only: bool = False
+    # For kind="choice": the ordered options as (label shown, value sent). The
+    # two differ so the interface can say something a user understands while the
+    # wire keeps the word the servers actually accept.
+    choices: tuple = ()
 
 
 @dataclass
@@ -129,6 +133,41 @@ def _smbv1_argv(v):
     return args
 
 
+# How the protocol mode is offered, and what each choice puts on the wire.
+#
+# "Proper" rather than "Standard" because the choice a user is making is between
+# the protocol as specified and a client that counts sequences differently --
+# "standard" reads like a recommendation, and the recommended setting is Auto.
+# The wire value stays "standard": it is what both the Python server and Edge
+# accept, and renaming it would break every saved configuration and command line.
+PROTOCOL_MODE_CHOICES = (
+    ("Auto", "auto"),
+    ("Proper", "standard"),
+    ("Modulo", "modulo"),
+)
+
+# Accepts the label, the wire value, or any casing of either. A saved settings
+# file predating the dropdown holds "standard"; a new one holds "Proper"; and a
+# user editing the file by hand may write either. All three should work rather
+# than silently falling back to auto.
+_PROTOCOL_MODE_BY_NAME = {}
+for _label, _value in PROTOCOL_MODE_CHOICES:
+    _PROTOCOL_MODE_BY_NAME[_label.lower()] = _value
+    _PROTOCOL_MODE_BY_NAME[_value.lower()] = _value
+
+
+def protocol_mode_value(raw):
+    """Map whatever is stored for protocol_mode to a value the servers accept.
+
+    Returns None for anything unrecognised, which the caller treats as "say
+    nothing and let the server default to auto" -- a bad string must not become
+    a command-line argument the server exits on.
+    """
+    if raw is None:
+        return None
+    return _PROTOCOL_MODE_BY_NAME.get(str(raw).strip().lower())
+
+
 def _udpfs_argv(v):
     if not v.get("root_dir") and not v.get("block_device"):
         raise ValueError("UDPFS needs a Games folder and/or a Disk image.")
@@ -157,12 +196,23 @@ def _udpfs_argv(v):
         args.append("--read-only")
     if not v.get("enable_compression", True):
         args.append("--no-compression")
-    # Existing saved launcher state may still contain modulo_mode. Preserve it as
-    # a strict diagnostic selection, but new GUI sessions use automatic mode and
-    # no longer expose the misleading global checkbox.
-    protocol_mode = v.get("protocol_mode")
+    # The old global "Modulo mode" checkbox was removed because it applied one
+    # client's quirk to every client at once. Auto classifies each session on its
+    # own, so a Proper client and several Modulo clients transfer side by side.
+    #
+    # The selector is back as a visible three-way choice, not because Auto is
+    # unreliable, but because when it does misjudge a client there has to be a
+    # way to say so from the interface rather than by hand-editing a settings
+    # file. Auto stays the default.
+    #
+    # modulo_mode is still read: a settings file written before the dropdown
+    # existed carries it, and losing that on upgrade would silently move someone
+    # off the setting that made their console work.
+    protocol_mode = protocol_mode_value(v.get("protocol_mode"))
     if v.get("modulo_mode"):
         protocol_mode = "modulo"
+    # "auto" is deliberately not passed. It is the server default, so omitting it
+    # keeps the logged command line honest about what was actually chosen.
     if protocol_mode in ("standard", "modulo"):
         args += ["--protocol-mode", protocol_mode]
     if v.get("verbose"):
@@ -223,6 +273,14 @@ UDPFS = ServerDef(
               help="A single disk image to serve as a block device."),
         Field("enable_compression", "Decompress CHD/CSO/ZSO", "bool", default=True,
               help="On by default. Formats without their optional library remain unadvertised."),
+        # Visible rather than advanced. It is the first thing to reach for when a
+        # console will not connect, and a setting you have to know exists is no
+        # use to the person who needs it.
+        Field("protocol_mode", "Protocol mode", "choice", default="Auto",
+              choices=PROTOCOL_MODE_CHOICES,
+              help="Auto handles Proper and Modulo clients at the same time and "
+                   "suits almost everyone. Pick one explicitly only if a console "
+                   "will not connect on Auto."),
         Field("read_only", "Read-only", "bool", default=False, advanced=True),
         Field("port", "Port", "port", default=0xF5F6, advanced=True,
               help="UDP discovery port (default 0xF5F6)."),

--- a/tests/test_protocol_mode_selector.py
+++ b/tests/test_protocol_mode_selector.py
@@ -23,7 +23,7 @@ if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
 from launcher.servers import (  # noqa: E402
-    PROTOCOL_MODE_CHOICES, REGISTRY, protocol_mode_value)
+    PROTOCOL_MODE_CHOICES, REGISTRY, migrate_saved, protocol_mode_value)
 
 UDPFS = REGISTRY["udpfs"]
 # The three words both servers accept; anything else makes them exit.
@@ -126,6 +126,82 @@ class ArgvContract(unittest.TestCase):
                 mode = _mode_in(_argv(protocol_mode=raw))
                 if mode is not None:
                     self.assertIn(mode, ACCEPTED_ON_THE_WIRE)
+
+
+class LegacyKeySurvivesTheRealLoadPath(unittest.TestCase):
+    """The argv test above is not enough, and was passing for the wrong reason.
+
+    ServerCard.set_values() restores only keys that have a widget, and values()
+    collects only keys that have a widget. modulo_mode has had no widget since
+    the checkbox was retired, so the GUI can neither restore it nor emit it: the
+    dict that reaches build_argv cannot contain it. Handing build_argv that key
+    directly, as the ArgvContract test does, exercises a path the application
+    cannot produce -- the test passed while the behaviour it claimed to protect
+    did not exist.
+
+    These tests go through the migration that runs on load instead.
+    """
+
+    def test_legacy_modulo_becomes_a_visible_selection(self):
+        migrated = migrate_saved("udpfs", {"modulo_mode": True, "root_dir": "/games"})
+        self.assertEqual(migrated.get("protocol_mode"), "Modulo")
+        self.assertNotIn("modulo_mode", migrated)
+        self.assertEqual(migrated["root_dir"], "/games", "unrelated keys must survive")
+
+    def test_migrated_value_reaches_the_command_line(self):
+        migrated = migrate_saved("udpfs", {"modulo_mode": True, "root_dir": "/games"})
+        self.assertEqual(_mode_in(UDPFS.build_argv(migrated)), "modulo")
+
+    def test_an_explicit_new_choice_is_not_overwritten(self):
+        """Someone who has since chosen in the new control meant it."""
+        migrated = migrate_saved(
+            "udpfs", {"modulo_mode": True, "protocol_mode": "Proper"})
+        self.assertEqual(migrated["protocol_mode"], "Proper")
+
+    def test_nothing_happens_without_the_legacy_key(self):
+        original = {"root_dir": "/games", "protocol_mode": "Auto"}
+        self.assertEqual(migrate_saved("udpfs", original), original)
+
+    def test_other_servers_are_untouched(self):
+        original = {"modulo_mode": True}
+        self.assertEqual(migrate_saved("smbv1", original), original)
+
+    def test_empty_and_missing_saves_are_safe(self):
+        for probe in ({}, None):
+            with self.subTest(probe=probe):
+                self.assertEqual(migrate_saved("udpfs", probe), probe)
+
+    def test_the_card_actually_applies_the_migration(self):
+        """End to end through the widgets, which is where it was being lost.
+
+        Builds a real card, loads a settings dict written before the dropdown
+        existed, then collects the values back out the way start_server does.
+        """
+        try:
+            import tkinter as tk
+        except ImportError:
+            self.skipTest("no tkinter")
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            self.skipTest("no display")
+        self.addCleanup(root.destroy)
+        root.withdraw()
+
+        from launcher import gui
+
+        card = gui.ServerCard.__new__(gui.ServerCard)
+        card.server = UDPFS
+        card.vars = {}
+        frame = gui.ttk.Frame(root)
+        row = 0
+        for field in UDPFS.fields:
+            row = card._add_field(frame, field, row)
+
+        card.set_values({"modulo_mode": True, "root_dir": "/games"})
+        collected = card.values()
+        self.assertEqual(collected.get("protocol_mode"), "Modulo")
+        self.assertEqual(_mode_in(UDPFS.build_argv(collected)), "modulo")
 
 
 if __name__ == "__main__":

--- a/tests/test_protocol_mode_selector.py
+++ b/tests/test_protocol_mode_selector.py
@@ -1,0 +1,132 @@
+"""The protocol-mode selector must reach the server as a value it accepts.
+
+The mode used to be a global "Modulo mode" checkbox, which applied one client's
+quirk to every client at once. It was replaced by per-session negotiation, and
+the checkbox was removed -- correctly, but that left no way to override a
+misjudgement except by hand-editing a settings file.
+
+It is a visible three-way choice again: Auto, Proper, Modulo. What makes that
+worth testing is that the label and the wire value deliberately differ. The user
+picks "Proper"; the servers only accept "standard". A mapping that silently
+returned "Proper" would be rejected by the server at startup, and under procd or
+the launcher's respawn that is a mode that simply never comes up.
+
+Run:  python -m unittest tests.test_protocol_mode_selector -v
+"""
+
+import os
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from launcher.servers import (  # noqa: E402
+    PROTOCOL_MODE_CHOICES, REGISTRY, protocol_mode_value)
+
+UDPFS = REGISTRY["udpfs"]
+# The three words both servers accept; anything else makes them exit.
+ACCEPTED_ON_THE_WIRE = {"auto", "standard", "modulo"}
+
+
+def _argv(**values):
+    values.setdefault("root_dir", "/games")
+    return UDPFS.build_argv(values)
+
+
+def _mode_in(argv):
+    if "--protocol-mode" not in argv:
+        return None
+    return argv[argv.index("--protocol-mode") + 1]
+
+
+class ChoicesAreServable(unittest.TestCase):
+    def test_every_choice_maps_to_a_value_the_servers_accept(self):
+        for label, value in PROTOCOL_MODE_CHOICES:
+            with self.subTest(label=label):
+                self.assertIn(value, ACCEPTED_ON_THE_WIRE)
+
+    def test_the_labels_are_the_ones_asked_for(self):
+        self.assertEqual([label for label, _ in PROTOCOL_MODE_CHOICES],
+                         ["Auto", "Proper", "Modulo"])
+
+    def test_auto_is_first_so_it_is_what_an_empty_selection_lands_on(self):
+        self.assertEqual(PROTOCOL_MODE_CHOICES[0], ("Auto", "auto"))
+
+    def test_the_field_is_visible_not_advanced(self):
+        """Hidden behind Advanced it is no use to whoever needs it."""
+        field = next(f for f in UDPFS.fields if f.key == "protocol_mode")
+        self.assertFalse(field.advanced)
+        self.assertEqual(field.kind, "choice")
+        self.assertEqual(field.default, "Auto")
+        self.assertEqual(field.choices, PROTOCOL_MODE_CHOICES)
+
+
+class ValueMapping(unittest.TestCase):
+    def test_labels_map_to_wire_values(self):
+        self.assertEqual(protocol_mode_value("Auto"), "auto")
+        self.assertEqual(protocol_mode_value("Proper"), "standard")
+        self.assertEqual(protocol_mode_value("Modulo"), "modulo")
+
+    def test_wire_values_map_to_themselves(self):
+        """A settings file written before the dropdown holds the wire value."""
+        for value in ("auto", "standard", "modulo"):
+            with self.subTest(value=value):
+                self.assertEqual(protocol_mode_value(value), value)
+
+    def test_casing_and_padding_are_tolerated(self):
+        for raw in ("proper", "PROPER", "  Proper  ", "sTaNdArD"):
+            with self.subTest(raw=raw):
+                self.assertEqual(protocol_mode_value(raw), "standard")
+
+    def test_unknown_values_do_not_become_arguments(self):
+        """A bad string must not reach the server, which exits on one.
+
+        Returning it unchanged would turn a typo in a settings file into a
+        server that never starts, and under the launcher's respawn that reads as
+        a mode which simply does not work.
+        """
+        for raw in ("nonsense", "", "  ", None, "auto-ish"):
+            with self.subTest(raw=raw):
+                self.assertIsNone(protocol_mode_value(raw))
+
+
+class ArgvContract(unittest.TestCase):
+    def test_proper_is_sent_as_standard(self):
+        self.assertEqual(_mode_in(_argv(protocol_mode="Proper")), "standard")
+
+    def test_modulo_is_sent(self):
+        self.assertEqual(_mode_in(_argv(protocol_mode="Modulo")), "modulo")
+
+    def test_auto_is_not_sent_at_all(self):
+        """Auto is the server default; omitting it keeps the command line honest."""
+        self.assertIsNone(_mode_in(_argv(protocol_mode="Auto")))
+
+    def test_no_selection_sends_nothing(self):
+        self.assertIsNone(_mode_in(_argv()))
+
+    def test_a_bad_saved_value_sends_nothing_rather_than_itself(self):
+        argv = _argv(protocol_mode="Propper")
+        self.assertIsNone(_mode_in(argv))
+        self.assertNotIn("Propper", argv)
+
+    def test_the_legacy_checkbox_still_wins(self):
+        """An upgraded settings file must not silently lose its Modulo setting."""
+        self.assertEqual(_mode_in(_argv(modulo_mode=True)), "modulo")
+        # Even against an explicit Auto, because the old checkbox was the only
+        # way to say Modulo and dropping it would move a working console.
+        self.assertEqual(_mode_in(_argv(protocol_mode="Auto", modulo_mode=True)),
+                         "modulo")
+
+    def test_every_emitted_value_is_one_the_servers_accept(self):
+        for raw in ("Auto", "Proper", "Modulo", "standard", "modulo", "auto",
+                    "nonsense", None):
+            with self.subTest(raw=raw):
+                mode = _mode_in(_argv(protocol_mode=raw))
+                if mode is not None:
+                    self.assertIn(mode, ACCEPTED_ON_THE_WIRE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why it was gone, and why it's back

The old **Modulo mode** checkbox was removed for a good reason: it was a *global*
switch for a *per-client* property. Turning it on for one console turned it on
for every console, so a Proper client and a Modulo client couldn't share a
server. Automatic per-session negotiation replaced it and classifies each client
independently.

What that left behind was **no way to disagree with the classifier**. When Auto
misjudges a client, the only recourse was hand-editing a settings file or running
the server from a terminal — neither available to the person the launcher exists
for.

Now it's a visible three-way choice, **Auto by default**:

| Label | On the wire |
|---|---|
| Auto | *(nothing — it's the server default)* |
| Proper | `--protocol-mode standard` |
| Modulo | `--protocol-mode modulo` |

Visible on the card, not behind Advanced — a setting you have to already know
about is no use to whoever needs it, and the moment you need this one is the
moment nothing is connecting.

## "Proper", not "Standard"

The choice being offered is between the protocol as specified and a client that
counts sequences differently. "Standard" reads like a recommendation, and the
recommended setting is Auto.

The **wire value stays `standard`** — it's what the Python server
([ps2servers_core.py:95](udpfs_server/ps2servers_core.py:95)) and Edge
([main.go:136](native/ps2servers-edge/cmd/ps2servers-edge/main.go:136)) both
accept, and what every existing config and command line already contains.

## Why this carries tests

That split between label and wire value is the whole risk. A mapping that passed
`"Proper"` through unchanged would be **rejected by the server at startup** — and
under the launcher's respawn, a server that exits immediately reads as "this mode
doesn't work" rather than "bad argument."

Unrecognised values now send *nothing* rather than themselves, so a typo in a
settings file falls back to Auto instead of producing a server that won't start.

15 tests, including: every choice maps to a value both servers accept, casing and
padding tolerated, bad values never become arguments, and the legacy
`modulo_mode` key still wins — including over an explicit Auto, since it was the
only way to say Modulo before this and silently dropping it on upgrade would move
someone off the setting that made their console work.

## New field kind

`kind="choice"` didn't exist. Without a branch in `_add_field` the field fell
through to the **free-text entry**, where a typo would reach the server — so the
combobox is `readonly`. `ttk.Combobox` was already themed in
[main.py:125](launcher/main.py:125), so it inherits the palette.

## Verified by rendering it

No unit test can tell you a widget appeared, so I built the real card in a real
Tk window:

```
comboboxes created : 1
values shown       : ['Auto', 'Proper', 'Modulo']
state              : readonly
current selection  : Auto
labels in the card : ['Protocol mode:', 'Auto handles Proper and Modulo...']
```

252 Python tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a UDPFS “Protocol mode” dropdown with Auto, Proper, and Modulo options.
  * Choice-type fields now render as read-only dropdowns to prevent invalid free-text input.

* **Bug Fixes**
  * Legacy Modulo settings are migrated to the new Protocol mode selection and applied correctly.
  * Auto no longer sends unnecessary protocol-mode configuration; only non-default selections are included.
  * Invalid or empty saved values are safely ignored.

* **Tests**
  * Added end-to-end coverage for protocol-mode value mapping, command-line behavior, and legacy migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->