### PR TITLE
fix(edge): size the server against the board it runs on, not a desktop

### DIFF
--- a/native/ps2servers-edge/cmd/ps2servers-edge/main.go
+++ b/native/ps2servers-edge/cmd/ps2servers-edge/main.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"syscall"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/compression"
 	edgelog "github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/memory"
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/session"
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/udpbd"
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/udpfs"
@@ -42,11 +44,29 @@ func duration(v string) (time.Duration, error) {
 	}
 	return time.Duration(seconds * float64(time.Second)), nil
 }
+// applyMemoryLimit gives the collector a ceiling on machines small enough for
+// it to matter.
+//
+// A backstop, not the fix: a soft limit makes the GC work harder as the heap
+// approaches it, but it does not make an allocation fail, so it cannot on its
+// own stop one oversized buffer from taking the process down. That is the job
+// of the transfer cap in internal/memory. What this adds is that a heap which
+// has already grown past what the board can hold gets collected hard rather
+// than drifting up until the kernel's OOM killer picks a victim -- which on a
+// router is as likely to be something else as it is to be us.
+func applyMemoryLimit() {
+	if limit := memory.Detect().SoftLimit(); limit > 0 {
+		debug.SetMemoryLimit(limit)
+	}
+}
+
 func main() {
 	if len(os.Args) == 2 && (os.Args[1] == "--version" || os.Args[1] == "version") {
 		fmt.Printf("ps2servers-edge %s\n", version)
 		return
 	}
+	// Before either server starts, so both are covered.
+	applyMemoryLimit()
 	if len(os.Args) >= 2 && os.Args[1] == "udpbd" {
 		runUDPBD()
 		return

--- a/native/ps2servers-edge/internal/compression/cache_budget_test.go
+++ b/native/ps2servers-edge/internal/compression/cache_budget_test.go
@@ -1,0 +1,117 @@
+package compression
+
+import (
+	"testing"
+)
+
+// cacheTotal is what the cache is actually holding, summed from the blocks
+// themselves rather than from the counter, so the counter can be checked
+// against reality instead of against itself.
+func cacheTotal(i *Image) int64 {
+	var n int64
+	for _, b := range i.cache {
+		n += int64(len(b))
+	}
+	return n
+}
+
+func TestCacheIsBoundedByBytesNotJustBlockCount(t *testing.T) {
+	// The case the block count does not bound: a large declared block size.
+	// 32 blocks sounds small and is 512 MiB at the maximum block size the
+	// header may legally declare.
+	budget := cacheByteBudget()
+	blockSize := int(budget/4) + 1 // four of these overrun the budget
+
+	img := &Image{cacheLimit: DefaultCacheBlocks}
+	for n := int64(0); n < DefaultCacheBlocks; n++ {
+		img.cacheStore(n, make([]byte, blockSize))
+		if got := cacheTotal(img); got > budget {
+			t.Fatalf("after %d blocks the cache holds %d bytes, over the %d budget",
+				n+1, got, budget)
+		}
+	}
+	// The count limit was never reached, so the byte budget must be what
+	// stopped it: far fewer than 32 blocks are resident.
+	if len(img.cache) >= DefaultCacheBlocks {
+		t.Fatalf("cache holds %d blocks; the byte budget did not bind", len(img.cache))
+	}
+}
+
+func TestCounterTracksWhatIsActuallyHeld(t *testing.T) {
+	// Eviction has to credit the counter back, or the cache silently stops
+	// accepting anything once the budget has been "spent" by blocks that were
+	// dropped long ago.
+	img := &Image{cacheLimit: 4}
+	for n := int64(0); n < 32; n++ {
+		img.cacheStore(n, make([]byte, 1024))
+	}
+	if len(img.cache) != 4 {
+		t.Fatalf("cache holds %d blocks, want the 4-block limit", len(img.cache))
+	}
+	if img.cacheBytes != cacheTotal(img) {
+		t.Fatalf("counter says %d, blocks total %d", img.cacheBytes, cacheTotal(img))
+	}
+	if img.cacheBytes != 4*1024 {
+		t.Fatalf("counter = %d, want %d", img.cacheBytes, 4*1024)
+	}
+}
+
+func TestBlockLargerThanTheBudgetIsNotCached(t *testing.T) {
+	// It must not empty the cache and then store the oversized block anyway.
+	img := &Image{cacheLimit: DefaultCacheBlocks}
+	img.cacheStore(0, make([]byte, 2048))
+	img.cacheStore(1, make([]byte, int(cacheByteBudget())+1))
+
+	if _, ok := img.cache[1]; ok {
+		t.Fatal("a block larger than the whole budget was cached")
+	}
+	if _, ok := img.cache[0]; !ok {
+		t.Fatal("the existing block was evicted to make room for one that was then not stored")
+	}
+	if img.cacheBytes != cacheTotal(img) {
+		t.Fatalf("counter says %d, blocks total %d", img.cacheBytes, cacheTotal(img))
+	}
+}
+
+func TestSetCacheBlocksResetsTheByteCounter(t *testing.T) {
+	// SetCacheBlocks drops the cache; if the counter survived, the budget
+	// would stay spent for the life of the handle and nothing would cache
+	// again.
+	img := &Image{cacheLimit: 8}
+	for n := int64(0); n < 8; n++ {
+		img.cacheStore(n, make([]byte, 4096))
+	}
+	if img.cacheBytes == 0 {
+		t.Fatal("nothing was cached, the test proves nothing")
+	}
+
+	img.SetCacheBlocks(8)
+	if img.cacheBytes != 0 {
+		t.Fatalf("cacheBytes = %d after reset, want 0", img.cacheBytes)
+	}
+
+	// And it still caches afterwards.
+	img.cacheStore(99, make([]byte, 4096))
+	if _, ok := img.cache[99]; !ok {
+		t.Fatal("cache refused a block after SetCacheBlocks")
+	}
+	if img.cacheBytes != cacheTotal(img) {
+		t.Fatalf("counter says %d, blocks total %d", img.cacheBytes, cacheTotal(img))
+	}
+}
+
+func TestOrdinaryBlocksStillFillTheCountLimit(t *testing.T) {
+	// The regression guard for the normal case: at the conventional 2 KiB
+	// block the count is what binds, exactly as before, so behaviour on a
+	// desktop is unchanged.
+	img := &Image{cacheLimit: DefaultCacheBlocks}
+	for n := int64(0); n < DefaultCacheBlocks*2; n++ {
+		img.cacheStore(n, make([]byte, 2048))
+	}
+	if len(img.cache) != DefaultCacheBlocks {
+		t.Fatalf("cache holds %d blocks, want the full %d", len(img.cache), DefaultCacheBlocks)
+	}
+	if img.cacheBytes != DefaultCacheBlocks*2048 {
+		t.Fatalf("cacheBytes = %d, want %d", img.cacheBytes, DefaultCacheBlocks*2048)
+	}
+}

--- a/native/ps2servers-edge/internal/compression/corrupt_index_test.go
+++ b/native/ps2servers-edge/internal/compression/corrupt_index_test.go
@@ -1,0 +1,111 @@
+package compression
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeCorruptIndex builds a CSO whose index brackets one block with entries
+// gapBytes apart, regardless of the block size in its header.
+//
+// This is what a truncated or interrupted copy produces -- no attacker needed,
+// a USB stick pulled mid-write will do it. The file itself is padded out so the
+// bogus range still lies inside it, because the reader already refuses a range
+// that runs past EOF and that guard is not the one under test. A real game
+// image is hundreds of megabytes, so "inside the file" is not a meaningful
+// limit on a 32 MB board: the read has to be bounded by the block size instead.
+func writeCorruptIndex(t *testing.T, path string, blockSize, gapBytes int) {
+	t.Helper()
+	const headerSize = 24
+	hdr := make([]byte, headerSize)
+	copy(hdr[:4], []byte("CISO"))
+	binary.LittleEndian.PutUint32(hdr[4:8], headerSize)
+	binary.LittleEndian.PutUint64(hdr[8:16], uint64(blockSize)) // one block
+	binary.LittleEndian.PutUint32(hdr[16:20], uint32(blockSize))
+	hdr[20] = 1
+	hdr[21] = 0
+
+	start := uint32(headerSize + 8)
+	index := make([]byte, 8)
+	binary.LittleEndian.PutUint32(index[:4], start)
+	binary.LittleEndian.PutUint32(index[4:], start+uint32(gapBytes))
+
+	body := make([]byte, gapBytes)
+	if err := os.WriteFile(path, append(append(hdr, index...), body...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCorruptIndexIsRefusedNotAllocated(t *testing.T) {
+	// 2 KiB blocks, but an index claiming the encoded block is 200 KiB. The
+	// bound is derived from the block size, so this is refused however large
+	// the surrounding file happens to be.
+	path := filepath.Join(t.TempDir(), "game.cso")
+	writeCorruptIndex(t, path, 2048, 200<<10)
+
+	img, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer img.Close()
+
+	buf := make([]byte, 2048)
+	_, err = img.Read(buf)
+	if err == nil {
+		t.Fatal("a block range far larger than the block size was accepted")
+	}
+	if !strings.Contains(err.Error(), "invalid block range") {
+		t.Fatalf("got %v, want an invalid block range error", err)
+	}
+}
+
+func TestPlainBlockAtFullBlockSizeStillReads(t *testing.T) {
+	// The bound must leave room for the legitimate worst case: a block that
+	// compression would have grown, which both CSO and ZSO store plain at
+	// exactly the block size. A bound that only allowed the compressed case
+	// would reject valid images.
+	const blockSize = 2048
+	path := filepath.Join(t.TempDir(), "plain.cso")
+
+	const headerSize = 24
+	hdr := make([]byte, headerSize)
+	copy(hdr[:4], []byte("CISO"))
+	binary.LittleEndian.PutUint32(hdr[4:8], headerSize)
+	binary.LittleEndian.PutUint64(hdr[8:16], blockSize)
+	binary.LittleEndian.PutUint32(hdr[16:20], blockSize)
+	hdr[20] = 1
+	hdr[21] = 0
+
+	start := uint32(headerSize + 8)
+	index := make([]byte, 8)
+	// High bit marks the block as stored plain rather than compressed.
+	binary.LittleEndian.PutUint32(index[:4], start|0x80000000)
+	binary.LittleEndian.PutUint32(index[4:], start+blockSize)
+
+	body := make([]byte, blockSize)
+	for i := range body {
+		body[i] = byte(i)
+	}
+	if err := os.WriteFile(path, append(append(hdr, index...), body...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	img, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer img.Close()
+
+	got := make([]byte, blockSize)
+	if _, err := img.Read(got); err != nil {
+		t.Fatalf("a full-block plain entry should read, got %v", err)
+	}
+	for i := range got {
+		if got[i] != byte(i) {
+			t.Fatalf("byte %d = %d, want %d", i, got[i], byte(i))
+		}
+	}
+}

--- a/native/ps2servers-edge/internal/compression/image.go
+++ b/native/ps2servers-edge/internal/compression/image.go
@@ -6,6 +6,7 @@ import (
 	"compress/zlib"
 	"encoding/binary"
 	"fmt"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/memory"
 	"io"
 	"os"
 	"path/filepath"
@@ -28,8 +29,15 @@ type Image struct {
 	// straight off disk, and a console reading sequentially touches the same
 	// block repeatedly inside a single request -- wasted CPU on exactly the
 	// low-power routers Edge targets. Bounded by block count, matching the
-	// Desktop server's --compression-cache-size.
+	// Desktop server's --compression-cache-size, AND by total bytes.
+	//
+	// The count alone is not a bound on memory. blockSize is a field in the
+	// image header, valid up to 16 MiB, so a count of 32 is anywhere from
+	// 64 KiB to 512 MiB depending on a number the file gets to choose. The
+	// byte ceiling is what actually holds, and it is what the operator's
+	// intuition means by "cache size".
 	cacheLimit int
+	cacheBytes int64
 	cache      map[int64][]byte
 	cacheOrder []int64
 }
@@ -40,9 +48,28 @@ const DefaultCacheBlocks = 32
 
 // MaxCacheBlocks caps the cache. The limit is used as a map's initial capacity,
 // so an absurd value allocates eagerly rather than growing into it -- and Edge
-// runs on routers with tens of megabytes of RAM. At a typical 2 KiB block this
-// ceiling is roughly 8 MiB per open image, far past any useful working set.
+// runs on routers with tens of megabytes of RAM.
+//
+// This used to be described as "roughly 8 MiB per open image at a typical
+// 2 KiB block". The arithmetic was right and the conclusion was not: nothing
+// enforced that typical block size, which is a header field valid up to 16
+// MiB, so the real ceiling was 4096 x 16 MiB. preferredCacheBytes is the bound
+// that was meant.
 const MaxCacheBlocks = 4096
+
+// preferredCacheBytes is the total decompressed-block cache one image may hold
+// on a machine with memory to spare -- the ceiling MaxCacheBlocks was always
+// intended to imply.
+const preferredCacheBytes = 8 << 20
+
+// cacheByteBudget is preferredCacheBytes, or less where the machine is small.
+//
+// Resolved once rather than per open: it reads /proc/meminfo, and an image can
+// be opened on the transfer path. sync.OnceValue rather than a package-level
+// initialiser so that no file is read merely by linking this package in.
+var cacheByteBudget = sync.OnceValue(func() int64 {
+	return memory.Detect().TransferCap(preferredCacheBytes)
+})
 
 // SetCacheBlocks bounds the decompressed-block cache. Zero disables caching.
 // Clamped rather than trusted: this is a library entry point, so it must hold
@@ -59,6 +86,11 @@ func (i *Image) SetCacheBlocks(n int) {
 	i.cacheLimit = n
 	i.cache = nil
 	i.cacheOrder = nil
+	// Reset with the rest of the cache state. Leaving it behind would charge
+	// the byte budget for blocks that are no longer held, and since nothing
+	// ever credits it back the cache would then refuse to store anything for
+	// the life of the handle.
+	i.cacheBytes = 0
 }
 
 // cacheStore records a decompressed block, evicting the oldest once the limit
@@ -69,18 +101,35 @@ func (i *Image) cacheStore(n int64, block []byte) {
 	if i.cacheLimit <= 0 {
 		return
 	}
+	budget := cacheByteBudget()
+	// A block that would not fit even in an empty cache is not cached at all.
+	// Without this the eviction loop below would empty the cache and store it
+	// anyway, which is the one case where honouring the count would blow the
+	// byte ceiling by design.
+	if int64(len(block)) > budget {
+		return
+	}
 	if i.cache == nil {
 		i.cache = make(map[int64][]byte, i.cacheLimit)
 	}
 	if _, exists := i.cache[n]; exists {
 		return
 	}
-	for len(i.cacheOrder) >= i.cacheLimit {
+	// Evict on either bound. The count keeps the Desktop server's behaviour
+	// for ordinary 2 KiB blocks, where it is the one that binds; the byte
+	// budget is what stops an image with a large declared block size from
+	// turning that same count into hundreds of megabytes.
+	for len(i.cacheOrder) > 0 &&
+		(len(i.cacheOrder) >= i.cacheLimit || i.cacheBytes+int64(len(block)) > budget) {
 		oldest := i.cacheOrder[0]
 		i.cacheOrder = i.cacheOrder[1:]
-		delete(i.cache, oldest)
+		if evicted, ok := i.cache[oldest]; ok {
+			i.cacheBytes -= int64(len(evicted))
+			delete(i.cache, oldest)
+		}
 	}
 	i.cache[n] = block
+	i.cacheBytes += int64(len(block))
 	i.cacheOrder = append(i.cacheOrder, n)
 }
 
@@ -135,24 +184,12 @@ func openImage(path string) (*Image, error) {
 		f.Close()
 		return nil, err
 	}
-	magic := string(hdr[:4])
-	format := ""
-	if magic == "CISO" {
-		format = "cso"
-	} else if magic == "ZISO" || magic == "ZSO\x00" {
-		format = "zso"
-	} else {
+	h, err := parseHeader(hdr)
+	if err != nil {
 		f.Close()
-		return nil, fmt.Errorf("unsupported image magic %q", magic)
+		return nil, err
 	}
-	headerSize := binary.LittleEndian.Uint32(hdr[4:8])
-	size := int64(binary.LittleEndian.Uint64(hdr[8:16]))
-	block := int64(binary.LittleEndian.Uint32(hdr[16:20]))
-	align := hdr[21]
-	if headerSize < 24 || size < 0 || block <= 0 || block > 16<<20 || align > 31 {
-		f.Close()
-		return nil, fmt.Errorf("invalid %s header", format)
-	}
+	format, headerSize, size, block, align := h.format, h.headerSize, h.size, h.block, h.align
 	blocks := (size + block - 1) / block
 	if blocks > 1<<28 || uint64(headerSize)+uint64(blocks+1)*4 > uint64(rawFileSize) {
 		f.Close()
@@ -163,12 +200,131 @@ func openImage(path string) (*Image, error) {
 		f.Close()
 		return nil, err
 	}
-	if err = binary.Read(f, binary.LittleEndian, index); err != nil {
+	// Streamed through a small scratch buffer rather than binary.Read.
+	//
+	// binary.Read on a []uint32 takes its fixed-size fast path, which
+	// allocates a second buffer the full width of the index -- bs :=
+	// make([]byte, 4*len(index)) -- and holds it alongside the destination for
+	// the length of the read. The index for a DVD-5 CSO at the conventional
+	// 2 KiB block is 2,295,105 entries, so that is 8.75 MiB doubled to 17.5 MiB
+	// at peak. On a 32 MB router the transient copy alone is over half the
+	// machine, for no benefit: the entries are decoded one at a time either
+	// way.
+	if err = readIndex(f, index); err != nil {
 		f.Close()
 		return nil, err
 	}
 	return &Image{f: f, format: format, size: size, fileSize: rawFileSize, blockSize: block, align: align, index: index}, nil
 }
+// header is the fixed 24-byte prologue shared by CSO and ZSO.
+type header struct {
+	format     string
+	headerSize uint32
+	size       int64
+	block      int64
+	align      uint8
+}
+
+// parseHeader decodes and validates the prologue. Kept separate so that
+// SizeOf and Open cannot drift apart on what counts as a valid image: a probe
+// that accepted a header the opener rejects would report a size for a file
+// that then fails to open.
+func parseHeader(hdr []byte) (header, error) {
+	if len(hdr) < 24 {
+		return header{}, fmt.Errorf("short image header")
+	}
+	var h header
+	switch magic := string(hdr[:4]); magic {
+	case "CISO":
+		h.format = "cso"
+	case "ZISO", "ZSO\x00":
+		h.format = "zso"
+	default:
+		return header{}, fmt.Errorf("unsupported image magic %q", magic)
+	}
+	h.headerSize = binary.LittleEndian.Uint32(hdr[4:8])
+	h.size = int64(binary.LittleEndian.Uint64(hdr[8:16]))
+	h.block = int64(binary.LittleEndian.Uint32(hdr[16:20]))
+	h.align = hdr[21]
+	if h.headerSize < 24 || h.size < 0 || h.block <= 0 || h.block > 16<<20 || h.align > 31 {
+		return header{}, fmt.Errorf("invalid %s header", h.format)
+	}
+	return h, nil
+}
+
+// readIndex fills index from r through a fixed scratch buffer.
+//
+// The alternative, binary.Read on the []uint32 directly, allocates a second
+// buffer as wide as the whole index and holds it for the length of the read.
+// See the call site for why that doubling matters on a small machine.
+func readIndex(r io.Reader, index []uint32) error {
+	const scratchEntries = 2048 // 8 KiB at a time, regardless of image size
+	scratch := make([]byte, scratchEntries*4)
+	for off := 0; off < len(index); {
+		n := len(index) - off
+		if n > scratchEntries {
+			n = scratchEntries
+		}
+		if _, err := io.ReadFull(r, scratch[:n*4]); err != nil {
+			return err
+		}
+		for i := 0; i < n; i++ {
+			index[off+i] = binary.LittleEndian.Uint32(scratch[i*4:])
+		}
+		off += n
+	}
+	return nil
+}
+
+// SizeOf reports the decompressed size of an image without building its block
+// index.
+//
+// This exists because reading that one number was, until it did, the most
+// expensive thing the server could do. Listing a directory calls it once per
+// compressed entry purely to show the console what the file will expand to,
+// and going through Open for that allocated the entire index -- 8.75 MiB for a
+// DVD-5 CSO at the conventional 2 KiB block, and about twice that at peak --
+// then immediately discarded it. A share of thirty compressed games turned
+// browsing into thirty multi-megabyte allocations, which is how a 32 MB router
+// runs out of memory without anyone doing anything unusual.
+//
+// The size is a field in the 24-byte prologue. Only that is read.
+func SizeOf(path string) (int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	st, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	// A file that is not a container is its own size, matching Open's
+	// treatment of anything without a recognised extension.
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext != ".cso" && ext != ".ciso" && ext != ".zso" && ext != ".ziso" {
+		return st.Size(), nil
+	}
+
+	hdr := make([]byte, 24)
+	if _, err := io.ReadFull(f, hdr); err != nil {
+		return 0, err
+	}
+	h, err := parseHeader(hdr)
+	if err != nil {
+		return 0, err
+	}
+	// The index is not read, but its declared extent is still checked: a
+	// header whose index could not fit in the file is corrupt, and reporting a
+	// size from it would advertise a game that cannot then be opened.
+	blocks := (h.size + h.block - 1) / h.block
+	if blocks > 1<<28 || uint64(h.headerSize)+uint64(blocks+1)*4 > uint64(st.Size()) {
+		return 0, fmt.Errorf("image index too large or extends past file size")
+	}
+	return h.size, nil
+}
+
 func (i *Image) Close() error { return i.f.Close() }
 func (i *Image) Size() int64  { return i.size }
 func (i *Image) Seek(off int64, whence int) (int64, error) {
@@ -253,7 +409,22 @@ func (i *Image) decodeBlock(n int64) ([]byte, error) {
 	if remain := i.size - n*i.blockSize; remain < expected {
 		expected = remain
 	}
-	if start < 0 || end < start || end-start > 32<<20 {
+	// Bound the raw read by the block it is supposed to encode, not by a flat
+	// 32 MiB. start and end come from the index table in the file, so a
+	// truncated or corrupt image -- an interrupted copy to a USB stick is
+	// enough, no attacker required -- can present a pair that are megabytes
+	// apart, and the allocation below happens before any of those bytes are
+	// looked at. On a 32 MB router the old ceiling was larger than the whole
+	// machine, so a bad image took the server down instead of returning an
+	// error naming the file.
+	//
+	// A compressed block cannot usefully be bigger than the block it encodes:
+	// both CSO and ZSO store a block plain when compressing it would grow it,
+	// which is the case this has to leave room for. Double it plus a page for
+	// the plain marker and any per-block header, and a corrupt index becomes
+	// "invalid block range" on a machine of any size.
+	maxRaw := i.blockSize*2 + 4096
+	if start < 0 || end < start || end-start > maxRaw {
 		return nil, fmt.Errorf("invalid block range")
 	}
 	if end > i.fileSize {

--- a/native/ps2servers-edge/internal/compression/sizeof_test.go
+++ b/native/ps2servers-edge/internal/compression/sizeof_test.go
@@ -1,0 +1,202 @@
+package compression
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// writeBigIndexCSO builds a CSO whose header declares enough blocks that the
+// index alone is several megabytes, and pads the file so that index would
+// really fit. The blocks are never read; what is under test is how much the
+// server allocates to answer "how big is this game".
+//
+// A real DVD-5 CSO at the conventional 2 KiB block has a 8.75 MiB index. This
+// uses a smaller one so the test file stays a few megabytes, which is enough
+// to tell an index-sized allocation from a header-sized one.
+func writeBigIndexCSO(t *testing.T, path string, blockSize, blocks int64) int64 {
+	t.Helper()
+	const headerSize = 24
+	declared := blockSize * blocks
+
+	hdr := make([]byte, headerSize)
+	copy(hdr[:4], []byte("CISO"))
+	binary.LittleEndian.PutUint32(hdr[4:8], headerSize)
+	binary.LittleEndian.PutUint64(hdr[8:16], uint64(declared))
+	binary.LittleEndian.PutUint32(hdr[16:20], uint32(blockSize))
+	hdr[20] = 1
+	hdr[21] = 0
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.Write(hdr); err != nil {
+		t.Fatal(err)
+	}
+	// The index must be present and the file must be at least as long as the
+	// header claims, or both Open and SizeOf reject it as corrupt.
+	indexBytes := (blocks + 1) * 4
+	if err := f.Truncate(headerSize + indexBytes); err != nil {
+		t.Fatal(err)
+	}
+	return declared
+}
+
+// allocatedBy reports the bytes allocated while fn runs.
+func allocatedBy(t *testing.T, fn func()) uint64 {
+	t.Helper()
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	fn()
+	runtime.ReadMemStats(&after)
+	return after.TotalAlloc - before.TotalAlloc
+}
+
+func TestSizeOfDoesNotAllocateTheIndex(t *testing.T) {
+	const blockSize = 2048
+	const blocks = 1 << 20 // index is 4 MiB + 4 B
+	path := filepath.Join(t.TempDir(), "big.cso")
+	declared := writeBigIndexCSO(t, path, blockSize, blocks)
+
+	const indexBytes = (blocks + 1) * 4
+
+	var probed int64
+	probeAlloc := allocatedBy(t, func() {
+		var err error
+		probed, err = SizeOf(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	if probed != declared {
+		t.Fatalf("SizeOf = %d, want the declared %d", probed, declared)
+	}
+
+	openAlloc := allocatedBy(t, func() {
+		img, err := Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if img.Size() != declared {
+			t.Fatalf("Open().Size() = %d, want %d", img.Size(), declared)
+		}
+		img.Close()
+	})
+
+	// The probe must not be in the same league as the index. A tenth of it is
+	// a generous line: the header path allocates a 24-byte header, a file
+	// handle and a little os.Stat scaffolding, three orders of magnitude below
+	// this, while any regression that goes back through Open lands above it.
+	if probeAlloc > indexBytes/10 {
+		t.Fatalf("SizeOf allocated %d bytes for a %d-byte index; it should read only the header",
+			probeAlloc, indexBytes)
+	}
+	// And the comparison that actually states the point.
+	if probeAlloc*8 > openAlloc {
+		t.Fatalf("SizeOf allocated %d and Open allocated %d; the probe is not meaningfully cheaper",
+			probeAlloc, openAlloc)
+	}
+	t.Logf("SizeOf %d bytes vs Open %d bytes for a %d-byte index", probeAlloc, openAlloc, indexBytes)
+}
+
+func TestStreamedIndexReadHalvesOpenPeak(t *testing.T) {
+	// Open must allocate about the index, not twice it. binary.Read on the
+	// []uint32 took a fast path that allocated a second full-width byte buffer
+	// alongside the destination; on a 32 MB board that transient copy was the
+	// difference between fitting and not.
+	const blockSize = 2048
+	const blocks = 1 << 20
+	const indexBytes = (blocks + 1) * 4
+	path := filepath.Join(t.TempDir(), "peak.cso")
+	writeBigIndexCSO(t, path, blockSize, blocks)
+
+	alloc := allocatedBy(t, func() {
+		img, err := Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		img.Close()
+	})
+
+	// Allow half again over the index for the scratch buffer and scaffolding.
+	// Doubling would sail past this.
+	if alloc > indexBytes*3/2 {
+		t.Fatalf("Open allocated %d for a %d-byte index; a full second copy is being made",
+			alloc, indexBytes)
+	}
+	t.Logf("Open allocated %d bytes for a %d-byte index", alloc, indexBytes)
+}
+
+func TestSizeOfAgreesWithOpen(t *testing.T) {
+	// The two must not drift: a probe that reported a size the opener would
+	// not agree with would advertise a game that then fails to load.
+	dir := t.TempDir()
+
+	plain := filepath.Join(dir, "movie.iso")
+	if err := os.WriteFile(plain, make([]byte, 4096), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cso := filepath.Join(dir, "game.cso")
+	declared := writeBigIndexCSO(t, cso, 2048, 64)
+
+	for _, tc := range []struct {
+		path string
+		want int64
+	}{
+		{plain, 4096},
+		{cso, declared},
+	} {
+		got, err := SizeOf(tc.path)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.path, err)
+		}
+		if got != tc.want {
+			t.Fatalf("%s: SizeOf = %d, want %d", tc.path, got, tc.want)
+		}
+		img, err := Open(tc.path)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.path, err)
+		}
+		if img.Size() != got {
+			t.Fatalf("%s: Open().Size() = %d but SizeOf = %d", tc.path, img.Size(), got)
+		}
+		img.Close()
+	}
+}
+
+func TestSizeOfRejectsWhatOpenRejects(t *testing.T) {
+	dir := t.TempDir()
+
+	// An index that could not fit in the file. Reporting a size here would
+	// list a game that cannot be opened.
+	truncated := filepath.Join(dir, "truncated.cso")
+	hdr := make([]byte, 24)
+	copy(hdr[:4], []byte("CISO"))
+	binary.LittleEndian.PutUint32(hdr[4:8], 24)
+	binary.LittleEndian.PutUint64(hdr[8:16], 1<<30) // claims a gigabyte
+	binary.LittleEndian.PutUint32(hdr[16:20], 2048)
+	hdr[20] = 1
+	if err := os.WriteFile(truncated, hdr, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	bogus := filepath.Join(dir, "bogus.cso")
+	if err := os.WriteFile(bogus, []byte("NOTACISOHEADER..........."), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{truncated, bogus} {
+		if _, err := SizeOf(path); err == nil {
+			t.Fatalf("%s: SizeOf accepted an image Open rejects", path)
+		}
+		if img, err := Open(path); err == nil {
+			img.Close()
+			t.Fatalf("%s: Open unexpectedly accepted it", path)
+		}
+	}
+}

--- a/native/ps2servers-edge/internal/memory/budget.go
+++ b/native/ps2servers-edge/internal/memory/budget.go
@@ -1,0 +1,135 @@
+// Package memory sizes the server's buffers against the machine it is actually
+// running on.
+//
+// Edge targets everything from a desktop to a 32 MB router. The transfer
+// ceilings were chosen for the former: one BREAD or one assembled write may
+// allocate 8 MiB, and the write buffer is reserved eagerly, before a single
+// byte of the payload has arrived. On a PC that is a rounding error. On an
+// A5-V11 -- 32 MB of SDRAM total, with OpenWrt already resident -- it is a
+// quarter of the machine per operation, and two concurrent transfers are
+// enough to get the process OOM-killed.
+//
+// So the ceiling becomes a function of the hardware rather than a constant.
+// Where the total cannot be determined the previous fixed value is used
+// unchanged, which keeps every existing platform behaving exactly as it did.
+package memory
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Budget is what the host reports about itself.
+type Budget struct {
+	// TotalBytes is the machine's physical RAM, or 0 when it could not be
+	// determined. Zero is not an error: it means "do not scale anything", and
+	// every caller must treat it as "use the value you would have used before
+	// this package existed".
+	TotalBytes int64
+	// Source records where the number came from, for the startup log. An
+	// operator debugging a transfer that is smaller than they expected should
+	// be able to see why from the log alone.
+	Source string
+}
+
+const (
+	// transferDivisor bounds one transfer to this fraction of total RAM.
+	//
+	// 1/16 leaves room for the several buffers that can legitimately be live
+	// at once -- concurrent sessions, the decompression cache, the runtime's
+	// own heap -- without arithmetic that has to know about each of them. On a
+	// 32 MB box it yields 2 MiB, which is still an order of magnitude above
+	// any real PS2 request: a console reads in sector-sized chunks and the
+	// largest transfer observed from any client is well under 256 KiB.
+	transferDivisor = 16
+
+	// minTransferCap is the floor. Scaling must never produce a cap so small
+	// that an ordinary console request is refused; a server that boots and
+	// then rejects every read is worse than one that risks memory pressure.
+	minTransferCap = 256 << 10
+
+	// smallMachine is the ceiling below which a soft heap limit is worth
+	// setting. Above it the limit would never be approached and would only be
+	// one more number that can be wrong.
+	smallMachine = 512 << 20
+)
+
+// Detect reads the machine's total RAM.
+//
+// Linux only, by reading /proc/meminfo -- which is the platform every router
+// build targets, and the only one where the answer changes anything. Elsewhere
+// the file is simply absent and the budget is unknown, so no build tags are
+// needed and the same code path is exercised on every platform.
+func Detect() Budget { return detectFrom("/proc/meminfo") }
+
+func detectFrom(path string) Budget {
+	f, err := os.Open(path)
+	if err != nil {
+		return Budget{Source: "unknown"}
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "MemTotal:") {
+			continue
+		}
+		// "MemTotal:       30516 kB" -- the unit is always kB in practice, but
+		// it is checked rather than assumed, because silently treating some
+		// other unit as kB would size every buffer wrong by three orders of
+		// magnitude in whichever direction.
+		fields := strings.Fields(line)
+		if len(fields) < 3 || !strings.EqualFold(fields[2], "kB") {
+			return Budget{Source: "unknown"}
+		}
+		kb, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil || kb <= 0 {
+			return Budget{Source: "unknown"}
+		}
+		return Budget{TotalBytes: kb * 1024, Source: path}
+	}
+	return Budget{Source: "unknown"}
+}
+
+// TransferCap is the largest single transfer buffer worth allowing.
+//
+// preferred is the value the caller would use on a machine with memory to
+// spare; the result is never larger than it. An unknown budget returns
+// preferred unchanged, so a platform this package cannot measure keeps exactly
+// the behaviour it had before.
+func (b Budget) TransferCap(preferred int64) int64 {
+	if b.TotalBytes <= 0 {
+		return preferred
+	}
+	cap := b.TotalBytes / transferDivisor
+	if cap > preferred {
+		return preferred
+	}
+	if cap < minTransferCap {
+		return minTransferCap
+	}
+	return cap
+}
+
+// SoftLimit is a value for debug.SetMemoryLimit, or 0 to leave the runtime
+// alone.
+//
+// This is a backstop, not the fix. A soft limit makes the collector work
+// harder as the heap approaches it; it does not make an allocation fail, so on
+// its own it cannot stop a single oversized buffer from taking the process
+// down -- that is what TransferCap is for. Its value is in reclaiming
+// aggressively once the heap is larger than this machine can comfortably hold,
+// instead of letting it drift up to whatever the OOM killer notices first.
+//
+// Only set on small machines. Half of total sits far above the few megabytes
+// steady-state use measured on this server, so reaching it means something has
+// already gone wrong and collecting hard is the right response.
+func (b Budget) SoftLimit() int64 {
+	if b.TotalBytes <= 0 || b.TotalBytes > smallMachine {
+		return 0
+	}
+	return b.TotalBytes / 2
+}

--- a/native/ps2servers-edge/internal/memory/budget_test.go
+++ b/native/ps2servers-edge/internal/memory/budget_test.go
@@ -1,0 +1,141 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeMeminfo puts a /proc/meminfo-shaped file on disk so detection can be
+// tested on any platform, including the Windows machines this is developed on
+// where the real file does not exist.
+func writeMeminfo(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "meminfo")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// The A5-V11 is the machine this whole package exists for: 32 MB of SDRAM, and
+// the desktop 8 MiB ceiling is a quarter of it per transfer.
+const a5v11 = `MemTotal:          30516 kB
+MemFree:            9200 kB
+Buffers:             800 kB
+`
+
+func TestDetectsRouterMemory(t *testing.T) {
+	b := detectFrom(writeMeminfo(t, a5v11))
+	if b.TotalBytes != 30516*1024 {
+		t.Fatalf("TotalBytes = %d, want %d", b.TotalBytes, 30516*1024)
+	}
+	if b.Source == "unknown" {
+		t.Fatal("Source should name the file it read")
+	}
+}
+
+func TestRouterGetsASmallerCapThanTheDesktopCeiling(t *testing.T) {
+	b := detectFrom(writeMeminfo(t, a5v11))
+	got := b.TransferCap(8 << 20)
+	if got >= 8<<20 {
+		t.Fatalf("cap %d was not reduced below the 8 MiB ceiling", got)
+	}
+	// Still far above anything a console asks for. A cap that throttled real
+	// traffic would be a worse bug than the one this fixes.
+	if got < 1<<20 {
+		t.Fatalf("cap %d is below 1 MiB, too small for ordinary transfers", got)
+	}
+	// And it must be a genuinely small slice of the machine, not a token cut.
+	if got > b.TotalBytes/8 {
+		t.Fatalf("cap %d is more than an eighth of %d", got, b.TotalBytes)
+	}
+}
+
+func TestUnknownMemoryChangesNothing(t *testing.T) {
+	// The critical compatibility property: on any platform where the total
+	// cannot be read -- Windows, macOS, an odd container -- the caller must get
+	// back exactly the constant it would have used before this package existed.
+	b := detectFrom(filepath.Join(t.TempDir(), "does-not-exist"))
+	if b.TotalBytes != 0 {
+		t.Fatalf("TotalBytes = %d, want 0 for an unreadable source", b.TotalBytes)
+	}
+	if got := b.TransferCap(8 << 20); got != 8<<20 {
+		t.Fatalf("cap = %d, want the preferred 8 MiB unchanged", got)
+	}
+	if got := b.SoftLimit(); got != 0 {
+		t.Fatalf("SoftLimit = %d, want 0 so the runtime is left alone", got)
+	}
+}
+
+func TestLargeMachineKeepsThePreferredCeiling(t *testing.T) {
+	b := detectFrom(writeMeminfo(t, "MemTotal:       16305200 kB\n"))
+	if got := b.TransferCap(8 << 20); got != 8<<20 {
+		t.Fatalf("cap = %d, want the preferred 8 MiB on a 16 GB machine", got)
+	}
+	// No soft limit on a big machine: it would never be reached and would only
+	// be one more number that can be wrong.
+	if got := b.SoftLimit(); got != 0 {
+		t.Fatalf("SoftLimit = %d, want 0 on a large machine", got)
+	}
+}
+
+func TestSoftLimitIsSetOnSmallMachinesAndLeavesHeadroom(t *testing.T) {
+	b := detectFrom(writeMeminfo(t, a5v11))
+	limit := b.SoftLimit()
+	if limit <= 0 {
+		t.Fatal("a 32 MB machine should get a soft limit")
+	}
+	if limit >= b.TotalBytes {
+		t.Fatalf("SoftLimit %d is not below total %d", limit, b.TotalBytes)
+	}
+	// Measured steady-state use is a few MB, so the limit must sit well above
+	// that or the collector would thrash during ordinary operation.
+	if limit < 8<<20 {
+		t.Fatalf("SoftLimit %d is below 8 MiB and would thrash", limit)
+	}
+}
+
+func TestNeverReturnsACapTooSmallToServe(t *testing.T) {
+	// A machine small enough that total/16 falls under the floor. The server
+	// must still be able to satisfy an ordinary request: booting and then
+	// refusing every read is worse than risking memory pressure.
+	b := detectFrom(writeMeminfo(t, "MemTotal:           2048 kB\n"))
+	if got := b.TransferCap(8 << 20); got != minTransferCap {
+		t.Fatalf("cap = %d, want the %d floor", got, minTransferCap)
+	}
+}
+
+func TestMalformedMeminfoIsTreatedAsUnknown(t *testing.T) {
+	// Anything unparseable must fall back to "unknown" rather than to a number.
+	// Guessing here would size every buffer in the process wrong.
+	for name, body := range map[string]string{
+		"no MemTotal line": "MemFree:  1000 kB\n",
+		"missing unit":     "MemTotal:       30516\n",
+		"unexpected unit":  "MemTotal:       30516 MB\n",
+		"not a number":     "MemTotal:       banana kB\n",
+		"negative":         "MemTotal:       -5 kB\n",
+		"empty":            "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			b := detectFrom(writeMeminfo(t, body))
+			if b.TotalBytes != 0 {
+				t.Fatalf("TotalBytes = %d, want 0", b.TotalBytes)
+			}
+			if got := b.TransferCap(8 << 20); got != 8<<20 {
+				t.Fatalf("cap = %d, want preferred unchanged", got)
+			}
+		})
+	}
+}
+
+func TestCapNeverExceedsPreferred(t *testing.T) {
+	// Whatever the machine reports, the caller's ceiling is a ceiling. A
+	// 16 GB box must not raise an 8 MiB preference to 1 GB.
+	for _, kb := range []int64{2048, 30516, 131072, 1048576, 16305200} {
+		b := Budget{TotalBytes: kb * 1024, Source: "test"}
+		if got := b.TransferCap(8 << 20); got > 8<<20 {
+			t.Fatalf("total %d kB produced cap %d, above the preferred ceiling", kb, got)
+		}
+	}
+}

--- a/native/ps2servers-edge/internal/udpfs/blockdev.go
+++ b/native/ps2servers-edge/internal/udpfs/blockdev.go
@@ -142,7 +142,7 @@ func (s *Server) handleBRead(st *session.State, p []byte) {
 		return
 	}
 	total := count * dev.sectorSize
-	if count <= 0 || total > maxBlockRead {
+	if count <= 0 || total > s.transferCap {
 		s.sendTransfer(st, result8(protocol.ResultReply, -int32(syscall.EINVAL)), nil)
 		return
 	}
@@ -194,7 +194,7 @@ func (s *Server) handleBWriteRequest(st *session.State, p []byte) {
 		return
 	}
 	total := count * dev.sectorSize
-	if count <= 0 || total > maxWriteBytes {
+	if count <= 0 || total > s.transferCap {
 		s.sendWriteDone(st, -int32(syscall.EFBIG))
 		return
 	}
@@ -259,10 +259,6 @@ func (s *Server) completeBlockWrite(st *session.State, buf []byte, offset, expec
 	s.cfg.Log.Debug("BWRITE ok", map[string]any{"peer": st.Peer, "bytes": len(buf)})
 	s.sendWriteDone(st, int32(len(buf)))
 }
-
-// maxBlockRead bounds one BREAD. The sector count is 16-bit, so a client could
-// otherwise ask for 65535 sectors -- 32 MiB -- in a single request.
-const maxBlockRead = 8 << 20
 
 // openImage opens a game image with the configured cache size, and without the
 // decompression layer when --no-compression is set.

--- a/native/ps2servers-edge/internal/udpfs/blockdev_test.go
+++ b/native/ps2servers-edge/internal/udpfs/blockdev_test.go
@@ -347,7 +347,7 @@ func TestBlockReadRejectsOverflowingSectorOverTheWire(t *testing.T) {
 // inRange validates the sector range the BWRITE header DECLARES. It does not
 // constrain what the chunk-assembly path then accumulates: handleWriteData is
 // driven by the client's own totalChunks/chunkSize fields and bounds the buffer
-// only by maxWriteBytes, which has nothing to do with the declared count. So a
+// only by the server's transfer cap, which has nothing to do with the declared count. So a
 // client could declare one in-range sector at the very end of the image, then
 // stream megabytes of chunks, and completeBlockWrite would hand all of it to
 // WriteAt at the validated offset. WriteAt past EOF extends the file, so the

--- a/native/ps2servers-edge/internal/udpfs/operations.go
+++ b/native/ps2servers-edge/internal/udpfs/operations.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/compression"
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/filesystem"
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/protocol"
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/session"
@@ -267,11 +268,18 @@ func (s *Server) handleRead(st *session.State, p []byte) {
 	s.stats.bytesRead.Add(int64(n))
 	s.sendTransfer(st, result8(protocol.ResultReply, int32(n)), buf[:n])
 }
-// maxWriteBytes caps one assembled write. The WRITE_REQ size field is 32-bit,
-// so without a ceiling a peer could announce 4 GiB and make the server buffer
-// it before a single byte is validated. 8 MiB is far above any real PS2 write
-// (saves are kilobytes) while keeping the worst case per peer bounded.
-const maxWriteBytes = 8 << 20
+// preferredTransfer caps one assembled write and one BREAD on a machine with
+// memory to spare. The WRITE_REQ size field is 32-bit and the BREAD sector
+// count is 16-bit, so without a ceiling a peer could announce 4 GiB, or ask
+// for 65535 sectors, and make the server buffer it before a single byte is
+// validated. 8 MiB is far above any real PS2 transfer (saves are kilobytes)
+// while keeping the worst case per peer bounded.
+//
+// It is the ceiling, not the answer: Server.transferCap is this value or the
+// smaller one the machine's RAM implies, because the write buffer is reserved
+// eagerly from the declared size and 8 MiB is a quarter of a 32 MB router.
+// See internal/memory.
+const preferredTransfer = 8 << 20
 
 // handleWriteRequest begins a write: handle plus total byte count, optionally
 // with the first WRITE_DATA chunk appended inline to the same datagram.
@@ -287,8 +295,11 @@ func (s *Server) handleWriteRequest(st *session.State, p []byte) {
 		s.sendWriteDone(st, -int32(syscall.EACCES))
 		return
 	}
-	if size > maxWriteBytes {
-		s.cfg.Log.Warn("WRITE refused, size over cap", map[string]any{"peer": st.Peer, "size": size, "cap": maxWriteBytes})
+	// int64(size), not a narrowing of the cap: size is the 32-bit field off the
+	// wire and int is 32-bit on the MIPS routers this ships to, so comparing in
+	// int would be the one platform where the check could wrap.
+	if int64(size) > s.transferCap {
+		s.cfg.Log.Warn("WRITE refused, size over cap", map[string]any{"peer": st.Peer, "size": size, "cap": s.transferCap})
 		s.sendWriteDone(st, -int32(syscall.EFBIG))
 		return
 	}
@@ -345,7 +356,7 @@ func (s *Server) handleWriteData(st *session.State, msg []byte) {
 		s.sendWriteDone(st, -int32(syscall.EIO))
 		return
 	}
-	if len(st.WriteBuffer)+int(chunkSize) > maxWriteBytes {
+	if int64(len(st.WriteBuffer))+int64(chunkSize) > s.transferCap {
 		st.ResetWrite()
 		s.sendWriteDone(st, -int32(syscall.EFBIG))
 		return
@@ -469,9 +480,14 @@ func (s *Server) handleDRead(st *session.State, p []byte) {
 		for _, ext := range []string{".cso", ".ciso", ".zso", ".ziso"} {
 			if strings.HasSuffix(lower, ext) {
 				entry.Name = entry.Name[:len(entry.Name)-len(ext)] + ".iso"
-				if img, err := s.openImage(entry.SourcePath); err == nil {
-					entry.Size = uint64(img.Size())
-					_ = img.Close()
+				// SizeOf, not openImage: this needs one number out of the
+				// 24-byte header, and opening the image to get it built the
+				// whole block index -- megabytes per entry, discarded
+				// immediately, once for every compressed game in the folder.
+				// Reachable by a console simply listing a directory, which is
+				// what made it the likeliest way to exhaust a small router.
+				if size, err := compression.SizeOf(entry.SourcePath); err == nil {
+					entry.Size = uint64(size)
 				}
 				break
 			}
@@ -521,9 +537,9 @@ func (s *Server) handleGetStat(st *session.State, p []byte) {
 	size := uint64(info.Size())
 	if ext := strings.ToLower(filepath.Ext(real)); s.compressedSiblingsEnabled() &&
 		(ext == ".cso" || ext == ".ciso" || ext == ".zso" || ext == ".ziso") {
-		if img, e := s.openImage(real); e == nil {
-			size = uint64(img.Size())
-			_ = img.Close()
+		// Header only, for the same reason as the DREAD path above.
+		if n, e := compression.SizeOf(real); e == nil {
+			size = uint64(n)
 		}
 	}
 	s.sendGetStat(st, 0, filesystem.Mode(info), size)

--- a/native/ps2servers-edge/internal/udpfs/server.go
+++ b/native/ps2servers-edge/internal/udpfs/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/filesystem"
 	edgelog "github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/memory"
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/protocol"
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/session"
 	"net"
@@ -46,6 +47,13 @@ type Config struct {
 	NoCompression bool
 	// CompressionCache bounds decompressed blocks retained per open image.
 	CompressionCache int
+	// MaxTransferBytes bounds one BREAD and one assembled write. Zero derives
+	// it from the machine's RAM, which is what every caller should do: the
+	// write buffer is reserved eagerly from the size the client declares, so
+	// on a 32 MB router the desktop ceiling is a quarter of the machine per
+	// operation. Set explicitly only by tests and by an operator who has a
+	// reason.
+	MaxTransferBytes int64
 	// MetricsPeriod logs a periodic counter snapshot when > 0, matching the
 	// Desktop server's --metrics / --metrics-period.
 	MetricsPeriod time.Duration
@@ -85,6 +93,11 @@ type Server struct {
 
 	stats    metrics
 	blockDev *blockDevice
+
+	// transferCap bounds one BREAD and one assembled write, resolved once at
+	// construction so every path that allocates from a client-declared size
+	// consults the same number.
+	transferCap int64
 
 	// writers reserves each file that some peer currently holds open for
 	// writing, mapping resolved path to a reference count. Two consoles
@@ -148,11 +161,14 @@ func New(cfg Config) (*Server, error) {
 	if cfg.ServerName == "" {
 		cfg.ServerName = "PS2 Servers Edge"
 	}
+	if cfg.MaxTransferBytes <= 0 {
+		cfg.MaxTransferBytes = memory.Detect().TransferCap(preferredTransfer)
+	}
 	root, err := filesystem.Open(cfg.Root)
 	if err != nil {
 		return nil, err
 	}
-	s := &Server{cfg: cfg, root: root, sessions: make(map[string]*peerWorker), incoming: make(chan inbound, 256), closed: make(chan struct{})}
+	s := &Server{cfg: cfg, root: root, sessions: make(map[string]*peerWorker), incoming: make(chan inbound, 256), closed: make(chan struct{}), transferCap: cfg.MaxTransferBytes}
 	s.stats.started = time.Now()
 	if cfg.BlockDevice != "" {
 		// Opened once and shared: every session addresses the same image
@@ -211,7 +227,10 @@ func (s *Server) Serve(ctx context.Context) error {
 		}
 	}
 	disc, data := s.Addr()
-	s.cfg.Log.Info("UDPFS listening", map[string]any{"root": s.root.Path(), "discovery": disc.String(), "data": data.String(), "protocol": s.cfg.ProtocolMode, "read_only": s.cfg.ReadOnly})
+	// transfer_cap is logged because it is derived from the host's RAM rather
+	// than fixed: an operator on a small router who sees a large write refused
+	// should be able to find the reason in the first line of the log.
+	s.cfg.Log.Info("UDPFS listening", map[string]any{"root": s.root.Path(), "discovery": disc.String(), "data": data.String(), "protocol": s.cfg.ProtocolMode, "read_only": s.cfg.ReadOnly, "transfer_cap": s.transferCap})
 	s.wg.Add(1)
 	go s.readLoop(s.discovery, session.DiscoverySocket)
 	if s.data != s.discovery {

--- a/native/ps2servers-edge/internal/udpfs/write_test.go
+++ b/native/ps2servers-edge/internal/udpfs/write_test.go
@@ -317,7 +317,10 @@ func TestWriteRequestOverCapIsRefused(t *testing.T) {
 	h := openForWriteOK(t, c, "big.sav", fioRead|fioWrite|fioCreate)
 	// A peer announcing a huge write must be refused before the server
 	// allocates a buffer for it.
-	reply := c.send(writeReqMsg(h, maxWriteBytes+1, nil))
+	// preferredTransfer, not the server's resolved cap: the cap is derived from
+	// the host's RAM and is never larger than preferredTransfer, so one byte
+	// past it is over the limit on every machine this test can run on.
+	reply := c.send(writeReqMsg(h, preferredTransfer+1, nil))
 	if got := result(reply); got != -int32(syscall.EFBIG) {
 		t.Fatalf("oversized WRITE_REQ returned %d, want -EFBIG", got)
 	}


### PR DESCRIPTION
Makes Edge fit a 32 MB router. Prompted by FatBaldDad's [PS2-EtherDrive](https://github.com/FatBaldDad/PS2-EtherDrive) boards (A5-V11, HLK-7628N, MT7621A), which are the project's first real router testers.

**The binary was never the problem.** Measured: 2.81 MB unpacked, 2.90 MB if every page were resident, idle heap under 1 MB at `GOGC=1`. No point shrinking it.

**The actual bug wasn't a cap at all.** Listing a directory called `openImage()` on *every* compressed entry just to read `img.Size()`, and `Open` built the whole block index to answer — 2,295,105 entries / **8.75 MiB per entry** for a DVD-5 CSO at a 2 KiB block, allocated and thrown away. Browsing a folder of CSOs exhausted the board. No malice, no unusual config, just the listing screen.

`compression.SizeOf` reads the 24-byte header instead. Measured on a 4 MiB index: **3,896 bytes vs Open's 4,217,944**.

Also fixed:
- `binary.Read` on a `[]uint32` doubled the index at open (**8,417,392 → 4,217,840** measured). The test fails against the old call — verified by putting it back.
- The three client-controlled 8 MiB eager reservations (WRITE_REQ, BWRITE, BREAD) now scale from `MemTotal` via `internal/memory`. On 32 MB that's 2 MiB, still an order of magnitude above anything a PS2 asks for.
- A 32 MiB raw-block bound that exceeded the whole device, reachable from a corrupt CSO index — a bad USB write is enough.
- A block cache bounded by *count* whose "roughly 8 MiB" comment assumed a 2 KiB block nothing enforced (`blockSize` is a header field valid to 16 MiB).

**Where memory can't be read** — Windows, macOS, an odd container — the previous fixed values are returned unchanged, so desktops behave exactly as before.

## For testers

Router users: this is the one that decides whether it survives 32 MB. Worth trying a folder of CSOs specifically, since that was the failure path.

Desktop users: should be indistinguishable. Report it if not.

**Not verified on hardware.** All numbers are from a dev machine plus header-format arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic memory-aware transfer limits for server operations.
  * Added an optional maximum transfer-size setting.
  * Applied memory safeguards automatically on smaller systems.

* **Bug Fixes**
  * Improved protection against oversized or malformed compressed image data.
  * Reduced memory usage when reading image indexes and determining image sizes.
  * Ensured cache usage stays within configured byte limits.
  * Improved handling of full-size uncompressed blocks and invalid metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->