### PR TITLE
feat(status): router readiness handshake, and a launcher that stops lying about it

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -45,6 +45,10 @@ from launcher.servers import REGISTRY
 # udpfs_server/ps2servers_core.py does `from udpfs_server import (...)`.
 SUPPORT_FILES = [
     "udpfs_server/udpfs_server.py",
+    # udpfs_server.py does `import router_status` on load. Without this the
+    # packaged build imports fine in source mode and fails at runtime, which is
+    # exactly the failure tests/test_packaging_data_files.py exists to catch.
+    "udpfs_server/router_status.py",
 ]
 
 

--- a/docs/ROUTER-STATUS.md
+++ b/docs/ROUTER-STATUS.md
@@ -1,0 +1,150 @@
+# Router status protocol
+
+A launcher, a loader, or a script can ask a PS2-Servers box "are you ready?"
+and get a useful answer, instead of discovering the answer by trying a transfer
+and waiting for it to fail.
+
+This exists for hardware like [PS2-EtherDrive](https://github.com/FatBaldDad/PS2-EtherDrive),
+where the server is a router mounted inside the console. Such a board may be
+power-cycled with the console, or reset independently, and it takes tens of
+seconds to boot. Without a status channel the user changes a game and stares at
+a loader that cannot distinguish "still booting" from "broken", so they wait
+too long, or reset something that did not need resetting.
+
+The second thing it answers is the one that matters for hardware: **is a
+transfer in flight right now.** A board wired to console power should not be
+cut mid-write. `busy` is how a launcher knows to say "don't".
+
+## The compatibility rule this is built on
+
+Every PS2-Servers release, and udpfsd upstream, drops a discovery packet whose
+service ID is not UDPFS, without replying:
+
+- Edge: `internal/udpfs/negotiation.go` — `if err != nil || dh.ServiceID != protocol.ServiceUDPFS { return }`
+- Desktop: `udpfs_server/ps2servers_core.py` — `if hdr.packet_type != PacketType.DISCOVERY or disc.service_id != UDPRDMA_SVC_UDPFS: return`
+
+So a status query is a discovery-shaped packet carrying a **different service
+ID**, sent to the **discovery port that is already open**. Consequences, all of
+them deliberate:
+
+- A server that predates this spec ignores the query. The client times out and
+  reports `unknown`, which is exactly the behaviour every client has today.
+  Nothing regresses.
+- No new port, so no new firewall rule and no second UAC prompt on Windows.
+- No existing packet changes by one byte. In particular the DISCOVERY/INFORM
+  exchange the PS2 itself uses is untouched, which is not negotiable: INFORM is
+  six bytes with no spare field, and its exact shape is load-bearing for real
+  clients.
+- Only new clients ever send the query, so the reply format is unconstrained by
+  history.
+
+## Service ID
+
+    UDPRDMA_SVC_STATUS = 0xF5F7
+
+Claimed by this project, adjacent to `UDPRDMA_SVC_UDPFS = 0xF5F5` and the
+default port `0xF5F6`. That is upstream's numbering range, so a client **must**
+validate the reply (service ID echo plus version byte, below) rather than
+assuming any reply to this query is a status reply. If upstream ever assigns
+0xF5F7, that validation is what keeps the collision harmless, and this document
+is what gets changed.
+
+## Query — client to server
+
+Six bytes. Structurally identical to a DISCOVERY, which is what makes older
+servers discard it on the path they already have.
+
+| offset | size | field | value |
+|---|---|---|---|
+| 0 | 2 | header | `type = 0` (DISCOVERY), `sequence = 0` |
+| 2 | 2 | service ID | `0xF5F7` |
+| 4 | 2 | port | `0` — unused; the reply goes to the query's UDP source |
+
+The header packs as the existing UDPRDMA header: `type & 0xF | (sequence & 0xFFF) << 4`,
+little-endian, as does every multi-byte field below.
+
+Send it to the server's discovery port (default `0xF5F6` / 62966). It may be
+unicast or broadcast. A server answers each query exactly once and keeps no
+state for it — a status query never creates a session, never disturbs one, and
+never resets a live transfer.
+
+## Reply — server to client
+
+| offset | size | field |
+|---|---|---|
+| 0 | 2 | header: `type = 1` (INFORM), `sequence = 0` |
+| 2 | 2 | service ID, echoed: `0xF5F7` |
+| 4 | 1 | payload version — `1` |
+| 5 | 1 | state |
+| 6 | 2 | service flags |
+| 8 | 2 | active sessions |
+| 10 | 4 | uptime, seconds |
+| 14 | 1 | name length, bytes |
+| 15 | … | name, UTF-8, not NUL-terminated |
+
+Fixed part is 15 bytes. A reply shorter than that, or whose service ID is not
+`0xF5F7`, must be discarded.
+
+**Version.** A client that does not recognise the version must treat the server
+as `unknown` rather than guess. Everything after offset 5 may change in a
+future version; offsets 0–4 may not.
+
+### State — offset 5
+
+| value | name | meaning |
+|---|---|---|
+| 0 | `starting` | process is up, not yet able to serve |
+| 1 | `ready` | serving, no transfer in flight — safe to power-cycle |
+| 2 | `busy` | at least one transfer in flight — **do not cut power** |
+| 3 | `degraded` | serving, but something is wrong (share unreadable, for example) |
+| 4 | `stopping` | shutting down |
+
+Unknown values must be treated as `degraded`, not as `ready`: a client that has
+not been taught a new state should be cautious rather than confident.
+
+### Service flags — offset 6, bitfield
+
+| bit | meaning |
+|---|---|
+| 0 | UDPFS is being served |
+| 1 | UDPBD is being served |
+| 2 | SMB is being served |
+| 3 | read-only |
+| 4 | compressed images (CSO/ZSO) will be decompressed |
+
+Unassigned bits are zero and must be ignored, so bits can be added without a
+version bump.
+
+### Active sessions — offset 8
+
+Peers with live state. `busy` is the authoritative "in flight" signal; this is
+for display.
+
+### Uptime — offset 10
+
+Seconds since the server began serving. Lets a launcher distinguish "it just
+came up" from "it has been up for an hour and is simply idle", which is the
+difference between waiting and investigating.
+
+### Name — offset 14
+
+The server's name and version, for display — e.g. `PS2 Servers Edge 0.4.9`.
+Capped at 255 bytes by the length field; a client should not assume any
+particular content.
+
+## Client guidance
+
+Poll rather than listen. A server does not broadcast state changes, because
+broadcast is filtered on enough networks to make it an unreliable primary
+signal. Once per second while a user is waiting is ample and costs six bytes.
+
+Timeout is `unknown`, never `down` — the server may simply be older than this
+spec. Distinguish the two by whether ordinary UDPFS DISCOVERY gets an INFORM: a
+box that answers DISCOVERY but not the status query is a working server that
+predates this feature.
+
+## Adoption
+
+Anything may implement this; that is the point of writing it down. It is
+deliberately small enough to add to a loader in an afternoon, and the
+compatibility rule means adding it cannot break a client that does not.

--- a/docs/ROUTER-STATUS.md
+++ b/docs/ROUTER-STATUS.md
@@ -38,27 +38,38 @@ them deliberate:
 - Only new clients ever send the query, so the reply format is unconstrained by
   history.
 
-## Service ID
+## Service ID and magic
 
     UDPRDMA_SVC_STATUS = 0xF5F7
+    STATUS_MAGIC       = "PS2S"
 
-Claimed by this project, adjacent to `UDPRDMA_SVC_UDPFS = 0xF5F5` and the
-default port `0xF5F6`. That is upstream's numbering range, so a client **must**
-validate the reply (service ID echo plus version byte, below) rather than
-assuming any reply to this query is a status reply. If upstream ever assigns
-0xF5F7, that validation is what keeps the collision harmless, and this document
-is what gets changed.
+The service ID is adjacent to `UDPRDMA_SVC_UDPFS = 0xF5F5` and the default port
+`0xF5F6`. That is upstream's numbering range, allocated consecutively, so
+`0xF5F7` is the next value upstream itself would reach for.
+
+**The number alone is therefore not the identifier — the number plus the magic
+is.** Validating a reply protects a client from a collision, but it does
+nothing about the other direction: a server keyed on the number alone would
+answer *any* discovery packet carrying `0xF5F7`, including a future udpfsd
+client asking about something else entirely. Requiring the magic means a server
+implementing this spec can only ever answer a question it actually understands.
+
+Both sides are required to check it. A server MUST ignore a query without it; a
+client MUST discard a reply without it.
 
 ## Query — client to server
 
-Six bytes. Structurally identical to a DISCOVERY, which is what makes older
-servers discard it on the path they already have.
+Ten bytes. The first six are structurally identical to a DISCOVERY, which is
+what makes older servers discard it on the path they already have — a longer
+packet with an unrecognised service ID hits the same guard and is dropped just
+the same.
 
 | offset | size | field | value |
 |---|---|---|---|
 | 0 | 2 | header | `type = 0` (DISCOVERY), `sequence = 0` |
 | 2 | 2 | service ID | `0xF5F7` |
 | 4 | 2 | port | `0` — unused; the reply goes to the query's UDP source |
+| 6 | 4 | magic | `PS2S` |
 
 The header packs as the existing UDPRDMA header: `type & 0xF | (sequence & 0xFFF) << 4`,
 little-endian, as does every multi-byte field below.
@@ -74,22 +85,25 @@ never resets a live transfer.
 |---|---|---|
 | 0 | 2 | header: `type = 1` (INFORM), `sequence = 0` |
 | 2 | 2 | service ID, echoed: `0xF5F7` |
-| 4 | 1 | payload version — `1` |
-| 5 | 1 | state |
-| 6 | 2 | service flags |
-| 8 | 2 | active sessions |
-| 10 | 4 | uptime, seconds |
-| 14 | 1 | name length, bytes |
-| 15 | … | name, UTF-8, not NUL-terminated |
+| 4 | 4 | magic, echoed: `PS2S` |
+| 8 | 1 | payload version — `1` |
+| 9 | 1 | state |
+| 10 | 2 | service flags |
+| 12 | 2 | active sessions |
+| 14 | 4 | uptime, seconds |
+| 18 | 1 | name length, bytes |
+| 19 | … | name, UTF-8, not NUL-terminated |
 
-Fixed part is 15 bytes. A reply shorter than that, or whose service ID is not
-`0xF5F7`, must be discarded.
+Fixed part is 19 bytes. A reply shorter than that, or whose service ID or magic
+does not match, must be discarded.
 
 **Version.** A client that does not recognise the version must treat the server
-as `unknown` rather than guess. Everything after offset 5 may change in a
-future version; offsets 0–4 may not.
+as `unknown` rather than guess. Everything after offset 8 may change in a future
+version; **offsets 0–8 may not** — header, service ID, magic and version are
+exactly what a client needs in order to decide whether the rest is addressed to
+it and whether it understands the layout.
 
-### State — offset 5
+### State — offset 9
 
 | value | name | meaning |
 |---|---|---|
@@ -102,7 +116,7 @@ future version; offsets 0–4 may not.
 Unknown values must be treated as `degraded`, not as `ready`: a client that has
 not been taught a new state should be cautious rather than confident.
 
-### Service flags — offset 6, bitfield
+### Service flags — offset 10, bitfield
 
 | bit | meaning |
 |---|---|
@@ -115,18 +129,18 @@ not been taught a new state should be cautious rather than confident.
 Unassigned bits are zero and must be ignored, so bits can be added without a
 version bump.
 
-### Active sessions — offset 8
+### Active sessions — offset 12
 
 Peers with live state. `busy` is the authoritative "in flight" signal; this is
 for display.
 
-### Uptime — offset 10
+### Uptime — offset 14
 
 Seconds since the server began serving. Lets a launcher distinguish "it just
 came up" from "it has been up for an hour and is simply idle", which is the
 difference between waiting and investigating.
 
-### Name — offset 14
+### Name — offset 18
 
 The server's name and version, for display — e.g. `PS2 Servers Edge 0.4.9`.
 Capped at 255 bytes by the length field; a client should not assume any
@@ -136,7 +150,7 @@ particular content.
 
 Poll rather than listen. A server does not broadcast state changes, because
 broadcast is filtered on enough networks to make it an unreliable primary
-signal. Once per second while a user is waiting is ample and costs six bytes.
+signal. Once per second while a user is waiting is ample and costs ten bytes.
 
 Timeout is `unknown`, never `down` — the server may simply be older than this
 spec. Distinguish the two by whether ordinary UDPFS DISCOVERY gets an INFORM: a

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -763,7 +763,7 @@ class LauncherApp:
             remove = ttk.Button(footer, text="Remove PS2 Servers firewall rules",
                                 command=self.remove_windows_setup)
             remove.grid(row=0, column=1, sticky="w", padx=(8, 0))
-        ttk.Button(footer, text="Stop all", command=self.stop_all).grid(
+        ttk.Button(footer, text="Stop all", command=self.stop_all_confirmed).grid(
             row=0, column=3, sticky="e")
         ttk.Button(footer, text="Restart", command=self.restart_app).grid(
             row=0, column=4, sticky="e", padx=(8, 0))
@@ -2028,14 +2028,25 @@ class LauncherApp:
         self._append_log(key, "[launcher] stopped\n")
 
     def stop_all(self):
-        keys = list(self.procs)
-        # Asked once for the whole set, naming every busy server, rather than
-        # once per server: a prompt per card would be clicked through.
-        if not self.confirm_stop_while_busy(keys):
-            return
-        for key in keys:
+        """Stop every server. Unconditional, and it must stay that way.
+
+        Every caller but the footer button is a teardown or an
+        elevate-and-relaunch that frees ports before the new instance binds
+        them. A prompt in here would let a "No" skip the stopping while the
+        caller carried on regardless -- quitting anyway and orphaning the
+        children, or relaunching as admin into ports that were never released.
+        The asking belongs at the points where a person actually chose to stop
+        something: stop_all_confirmed, stop_server, and _confirm_app_shutdown.
+        """
+        for key in list(self.procs):
             self.stop_server(key, confirm=False)
         self._stop_direct_responder()
+
+    def stop_all_confirmed(self):
+        """The footer's Stop all: the one caller that is a person deciding."""
+        if not self.confirm_stop_while_busy(list(self.procs)):
+            return
+        self.stop_all()
 
     # -- logging (thread-safe) ------------------------------------------- #
     def _on_output(self, key, line):
@@ -2336,6 +2347,22 @@ class LauncherApp:
                    for key in self.procs if self.is_running(key)]
         if not running:
             return True
+        # A server that reports a transfer in flight is called out by name and
+        # the prompt defaults to No. Quitting mid-write truncates whatever the
+        # console was writing, and a save is the one thing here that cannot be
+        # got back -- so this is the case where the habitual Enter should not
+        # be the destructive answer.
+        busy = [TAB_TITLES.get(key, key.upper()) for key in self.procs
+                if status_client.is_busy(self.status_poller.status(key))]
+        if busy:
+            return messagebox.askyesno(
+                title,
+                "{} reports a transfer in progress.\n\n"
+                "Quitting now will interrupt it. If a console is writing a "
+                "save, that save will be incomplete.\n\n"
+                "This will stop running servers:\n\n{}\n\nQuit anyway?".format(
+                    ", ".join(busy), ", ".join(running)),
+                icon="warning", default="no")
         return messagebox.askyesno(
             title,
             "This will stop running servers:\n\n{}\n\nContinue?".format(

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -29,7 +29,7 @@ def _direct_link_experimental():
     """Non-Windows: the setup path is real but unverified on hardware."""
     return platform.system() in ("Linux", "Darwin")
 
-from . import config, directlink, elevate, netinfo, posix_firewall, servers, theme, tray, windows_setup
+from . import config, directlink, elevate, netinfo, posix_firewall, servers, status_client, theme, tray, windows_setup
 from .process import ServerProcess
 from .release_metadata import DISPLAY_VERSION
 from .servers import REGISTRY, REPO_ROOT, frozen_self_exe, is_frozen, serve_command
@@ -395,6 +395,29 @@ class ServerCard(ttk.LabelFrame):
         else:
             self.app.start_server(self.server.key)
 
+    # What the server says about itself, when it says anything. A build that
+    # does not implement the status protocol reports nothing, and the label
+    # falls back to the process-derived "Running" it has always shown.
+    _STATE_LABELS = {"ready": "Running", "busy": "Transferring",
+                     "degraded": "Degraded", "starting": "Starting",
+                     "stopping": "Stopping"}
+
+    def _reported_state(self):
+        status = self.app.status_poller.status(self.server.key)
+        if not status:
+            return None
+        name = status.get("state_name")
+        return name if name in self._STATE_LABELS else None
+
+    def _running_label(self):
+        return self._STATE_LABELS.get(self._reported_state(), "Running")
+
+    def _running_colour(self):
+        # Degraded is the one that must not look healthy: the process is alive,
+        # so the old display called it Running and sent people hunting for a
+        # network fault when the share had simply been unplugged.
+        return COLOR_ERROR if self._reported_state() == "degraded" else COLOR_RUNNING
+
     def refresh_status(self, running, error=False):
         if error or not running:
             self._active_values = None
@@ -402,7 +425,12 @@ class ServerCard(ttk.LabelFrame):
         if error:
             self.status.config(text=DOT_RUNNING + " Error", foreground=COLOR_ERROR)
         elif running:
-            self.status.config(text=DOT_RUNNING + " Running", foreground=COLOR_RUNNING)
+            # "Running" is what the process check can say. Where the server
+            # itself answers, say what it actually reports instead -- a share
+            # that has been unplugged is Degraded, not Running, and a transfer
+            # in flight is worth seeing before reaching for Stop.
+            self.status.config(text=DOT_RUNNING + " " + self._running_label(),
+                               foreground=self._running_colour())
         else:
             self.status.config(text=DOT_RUNNING + " Stopped", foreground=COLOR_STOPPED)
         self.toggle_btn.config(text="Stop" if running else "Start")
@@ -419,6 +447,16 @@ class LauncherApp:
         self.root = root
         self.procs = {}
         self.cards = {}
+        # Truthful per-server state, polled off the Tk thread. The dot used
+        # to mean only "the child process is alive", which stays green when
+        # the share has been unplugged and says nothing about a transfer in
+        # flight. Servers that do not implement the protocol report unknown
+        # and fall back to the process check, so nothing regresses.
+        self.status_poller = status_client.Poller()
+        self.status_poller.start()
+        # Last state painted per card, so the status line is only rebuilt when
+        # the answer actually changes rather than on every 600 ms tick.
+        self._last_reported = {}
         self.out_queue = queue.Queue()
         self.logs = {}
         self.saved = config.load()
@@ -1656,6 +1694,10 @@ class LauncherApp:
             return
         self.procs[key] = proc
         card._active_values = dict(values)
+        # Ask this server what state it is actually in, rather than inferring
+        # it from the child process being alive. Loopback, because the launcher
+        # is asking about a server it started itself.
+        self.status_poller.set_target(key, "127.0.0.1", values.get("port") or 0)
         card.refresh_status(True)
         card.toggle_btn.config(state="normal")
         self.nb.select(self.terminal_tab)
@@ -1947,20 +1989,52 @@ class LauncherApp:
         messagebox.showerror("Firewall removal failed", str(error))
         self._append_log("setup", "[setup] firewall cleanup failed:\n{}\n".format(error))
 
-    def stop_server(self, key):
+    def confirm_stop_while_busy(self, keys):
+        """Ask before stopping a server that says it is mid-transfer.
+
+        Stopping a server while a console is writing truncates whatever it was
+        writing, and a save is the one thing here a user cannot get back. The
+        launcher could not previously tell, so it could not warn.
+
+        Only a server that positively reports busy triggers this. A server that
+        did not answer -- an older build, or one still starting -- is not busy,
+        because a prompt that fired on every unreachable server would be
+        dismissed reflexively long before it mattered.
+        """
+        busy = [k for k in keys
+                if status_client.is_busy(self.status_poller.status(k))]
+        if not busy:
+            return True
+        names = ", ".join(REGISTRY[k].label if k in REGISTRY else k for k in busy)
+        return messagebox.askyesno(
+            "Transfer in progress",
+            "{} reports a transfer in progress.\n\n"
+            "Stopping now will interrupt it. If a console is writing a save, "
+            "that save will be incomplete.\n\nStop anyway?".format(names),
+            icon="warning", default="no")
+
+    def stop_server(self, key, confirm=True):
         proc = self.procs.get(key)
         if not proc:
             return
+        if confirm and not self.confirm_stop_while_busy([key]):
+            return
         if proc.is_running():
             proc.stop()
+        self.status_poller.clear_target(key)
         self.cards[key]._active_values = None
         self.cards[key].refresh_status(False)
         self.cards[key].toggle_btn.config(state="normal")
         self._append_log(key, "[launcher] stopped\n")
 
     def stop_all(self):
-        for key in list(self.procs):
-            self.stop_server(key)
+        keys = list(self.procs)
+        # Asked once for the whole set, naming every busy server, rather than
+        # once per server: a prompt per card would be clicked through.
+        if not self.confirm_stop_while_busy(keys):
+            return
+        for key in keys:
+            self.stop_server(key, confirm=False)
         self._stop_direct_responder()
 
     # -- logging (thread-safe) ------------------------------------------- #
@@ -2004,10 +2078,19 @@ class LauncherApp:
             current = self.cards[key].toggle_btn.cget("text") == "Stop"
             if current and not running:  # server exited on its own
                 self.cards[key]._active_values = None
+                self.status_poller.clear_target(key)
                 self.cards[key].refresh_status(False)
                 self.cards[key].toggle_btn.config(state="normal")
                 self._append_log(key, "[launcher] server exited (code {})\n".format(
                     proc.returncode))
+            elif running:
+                # Repaint from the poller's latest answer. Cheap: the socket
+                # work happened on the poller thread, and this only reads the
+                # result it left behind.
+                reported = self.cards[key]._reported_state()
+                if reported != self._last_reported.get(key):
+                    self._last_reported[key] = reported
+                    self.cards[key].refresh_status(True)
         if (self._direct_expected and self._direct_proc is not None
                 and not self._direct_proc.is_running()):
             code = self._direct_proc.returncode

--- a/launcher/status_client.py
+++ b/launcher/status_client.py
@@ -1,0 +1,190 @@
+"""Ask a running server what state it is actually in.
+
+The launcher has always shown two states per server, derived from whether the
+child process is alive: green disc for running, grey ring for stopped. That is
+cheap and it is often wrong in the two ways that matter.
+
+A process can be alive and not serving. Pull the USB stick out and the share
+root vanishes; the process keeps running and the launcher keeps showing green,
+so the user goes looking for a network fault that is not there.
+
+And a process being alive says nothing about whether it is in the middle of
+something. Stopping a server, or quitting the launcher, while a console is
+writing a save truncates that save. Until now the GUI had no way to know, so it
+could not even warn.
+
+The status protocol answers both. See docs/ROUTER-STATUS.md.
+
+Only the UDPFS server implements it today. Nothing here assumes otherwise: a
+server that does not answer is reported as UNKNOWN, which the caller must treat
+as "fall back to the process check", never as "down".
+"""
+
+import importlib.util
+import os
+import socket
+import threading
+
+# No reply. Not the same as stopped: the server may simply be a build that
+# predates the protocol, or one that never implemented it. A caller must fall
+# back to whatever it knew before rather than reporting a fault.
+UNKNOWN = "unknown"
+
+_protocol = None
+_protocol_lock = threading.Lock()
+
+
+def protocol():
+    """The shared router_status module, loaded from the server tree.
+
+    Loaded by path rather than imported, and deliberately not duplicated here.
+    The launcher and the server must agree byte for byte on this format, and
+    the surest way to guarantee that is for there to be exactly one copy of it.
+    The path is derived from the registry entry, so it resolves the same way in
+    a packaged build as it does from source.
+    """
+    global _protocol
+    with _protocol_lock:
+        if _protocol is not None:
+            return _protocol
+        from launcher.servers import REGISTRY
+
+        entry = REGISTRY.get("udpfs")
+        if entry is None or not entry.module_file:
+            return None
+        path = os.path.join(os.path.dirname(entry.module_file), "router_status.py")
+        if not os.path.isfile(path):
+            return None
+        spec = importlib.util.spec_from_file_location(
+            "ps2servers_router_status", path)
+        if spec is None or spec.loader is None:
+            return None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        _protocol = module
+        return _protocol
+
+
+def query(host, port, timeout=0.4):
+    """Ask one server for its status. Returns the decoded reply, or None.
+
+    None means "did not answer, or answered with something that is not ours".
+    Every failure funnels here rather than raising, because this is called from
+    a poll loop where an exception would be a worse outcome than a missing
+    answer.
+    """
+    proto = protocol()
+    if proto is None or not port:
+        return None
+    sock = None
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.settimeout(timeout)
+        sock.sendto(proto.build_status_query(), (host, int(port)))
+        data, _ = sock.recvfrom(2048)
+        return proto.parse_status_reply(data)
+    except (OSError, ValueError):
+        # Includes the timeout, a refused port, and a host that will not
+        # resolve. All of them mean the same thing to a caller: no answer.
+        return None
+    finally:
+        if sock is not None:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+
+def is_busy(status):
+    """True only when a server has positively said it is mid-transfer.
+
+    Written so that UNKNOWN and None are not busy. A warning that fires when
+    the launcher simply could not reach a server would be ignored within a day,
+    and then it would not be there for the case that matters.
+    """
+    proto = protocol()
+    if not status or proto is None:
+        return False
+    return status.get("state") == proto.STATE_BUSY
+
+
+class Poller:
+    """Polls the servers the launcher is running, off the GUI thread.
+
+    Tk has one thread and a blocked socket in the middle of a periodic callback
+    freezes the window. So the waiting happens here and the GUI only ever reads
+    the last answer, which is at worst one interval stale -- fine for something
+    a person is looking at, and never a stall.
+    """
+
+    def __init__(self, interval=1.0, timeout=0.4):
+        self.interval = max(0.2, float(interval))
+        self.timeout = max(0.05, float(timeout))
+        self._targets = {}
+        self._results = {}
+        self._lock = threading.Lock()
+        self._wake = threading.Event()
+        self._stop = threading.Event()
+        self._thread = None
+
+    def set_target(self, key, host, port):
+        """Start polling one server. Replaces any previous target for `key`."""
+        with self._lock:
+            self._targets[key] = (host, int(port))
+        # Poll immediately rather than waiting out the interval: this is called
+        # when a server starts, which is exactly when someone is watching.
+        self._wake.set()
+
+    def clear_target(self, key):
+        with self._lock:
+            self._targets.pop(key, None)
+            self._results.pop(key, None)
+
+    def snapshot(self):
+        """The most recent answer per key. UNKNOWN where there was none."""
+        with self._lock:
+            return dict(self._results)
+
+    def status(self, key):
+        with self._lock:
+            return self._results.get(key)
+
+    def start(self):
+        if self._thread is not None:
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._run, name="status-poller", daemon=True)
+        self._thread.start()
+
+    def stop(self, join_timeout=1.0):
+        self._stop.set()
+        self._wake.set()
+        thread, self._thread = self._thread, None
+        if thread is not None:
+            thread.join(timeout=join_timeout)
+
+    def poll_once(self):
+        """One sweep. Separated from the loop so tests need no threads."""
+        with self._lock:
+            targets = dict(self._targets)
+        for key, (host, port) in targets.items():
+            reply = query(host, port, timeout=self.timeout)
+            with self._lock:
+                # Only record for targets that still exist: a server stopped
+                # mid-sweep must not have a stale answer reinstated behind
+                # clear_target.
+                if key in self._targets:
+                    self._results[key] = reply if reply else {"state_name": UNKNOWN}
+
+    def _run(self):
+        while not self._stop.is_set():
+            try:
+                self.poll_once()
+            except Exception:
+                # A poller that dies takes the launcher's status display with
+                # it, silently. Nothing here is important enough to be worth
+                # that, so every sweep is allowed to fail on its own.
+                pass
+            self._wake.wait(self.interval)
+            self._wake.clear()

--- a/native/ps2servers-edge/internal/protocol/status.go
+++ b/native/ps2servers-edge/internal/protocol/status.go
@@ -24,12 +24,32 @@ import (
 // query is a status reply.
 const ServiceStatus uint16 = 0xF5F7
 
-// StatusVersion is the payload version. Offsets 0-4 of a reply are frozen
-// across versions; everything after may change.
+// StatusMagic identifies this protocol independently of the service ID.
+//
+// The number alone is not enough. 0xF5F5 is UDPFS and 0xF5F6 is the default
+// port, so upstream is allocating consecutively and 0xF5F7 is the next one it
+// would reach for. Validating a reply protects our client from that, but it
+// does nothing about the other direction: without this tag a server here would
+// answer ANY discovery packet carrying 0xF5F7, including a future udpfsd
+// client asking about something else entirely. Requiring the magic means this
+// server can only ever answer a question it actually understands.
+//
+// Safe to append because a longer packet with a service ID a server does not
+// recognise is still dropped on the guard it already has -- verified against
+// both implementations before this was added.
+var StatusMagic = [4]byte{'P', 'S', '2', 'S'}
+
+// StatusVersion is the payload version. A reply's first ten bytes -- header,
+// service ID, magic, version -- are frozen across versions, because they are
+// what a client needs in order to decide whether the rest is addressed to it
+// and whether it understands the layout. Everything after may change.
 const StatusVersion uint8 = 1
 
+// StatusQueryLen is the exact length of a query.
+const StatusQueryLen = 10
+
 // StatusFixedLen is the reply length before the variable-length name.
-const StatusFixedLen = 15
+const StatusFixedLen = 19
 
 type ServerState uint8
 
@@ -90,7 +110,7 @@ type StatusReply struct {
 // deliberately strict about length: a six-byte packet whose service ID is
 // 0xF5F7 is the only thing that qualifies.
 func IsStatusQuery(packet []byte) bool {
-	if len(packet) < 6 {
+	if len(packet) < StatusQueryLen {
 		return false
 	}
 	h, err := ParseHeader(packet)
@@ -98,13 +118,18 @@ func IsStatusQuery(packet []byte) bool {
 		return false
 	}
 	dh, err := ParseDiscoveryHeader(packet[2:])
-	return err == nil && dh.ServiceID == ServiceStatus
+	if err != nil || dh.ServiceID != ServiceStatus {
+		return false
+	}
+	// The magic, not just the number. See StatusMagic.
+	return [4]byte(packet[6:10]) == StatusMagic
 }
 
-// MarshalStatusQuery builds the six-byte query.
+// MarshalStatusQuery builds the query.
 func MarshalStatusQuery() []byte {
-	return append(Header{Type: Discovery, Sequence: 0}.Marshal(),
+	q := append(Header{Type: Discovery, Sequence: 0}.Marshal(),
 		DiscoveryHeader{ServiceID: ServiceStatus, Port: 0}.Marshal()...)
+	return append(q, StatusMagic[:]...)
 }
 
 // Marshal encodes a status reply.
@@ -123,12 +148,13 @@ func (r StatusReply) Marshal() []byte {
 	b := make([]byte, StatusFixedLen, StatusFixedLen+len(name))
 	copy(b, Header{Type: Inform, Sequence: 0}.Marshal())
 	binary.LittleEndian.PutUint16(b[2:], ServiceStatus)
-	b[4] = StatusVersion
-	b[5] = uint8(r.State)
-	binary.LittleEndian.PutUint16(b[6:], r.Flags)
-	binary.LittleEndian.PutUint16(b[8:], r.Sessions)
-	binary.LittleEndian.PutUint32(b[10:], r.Uptime)
-	b[14] = uint8(len(name))
+	copy(b[4:8], StatusMagic[:])
+	b[8] = StatusVersion
+	b[9] = uint8(r.State)
+	binary.LittleEndian.PutUint16(b[10:], r.Flags)
+	binary.LittleEndian.PutUint16(b[12:], r.Sessions)
+	binary.LittleEndian.PutUint32(b[14:], r.Uptime)
+	b[18] = uint8(len(name))
 	return append(b, name...)
 }
 
@@ -154,22 +180,25 @@ func ParseStatusReply(b []byte) (StatusReply, error) {
 	if binary.LittleEndian.Uint16(b[2:]) != ServiceStatus {
 		return StatusReply{}, ErrNotStatusReply
 	}
-	if b[4] != StatusVersion {
+	if [4]byte(b[4:8]) != StatusMagic {
+		return StatusReply{}, ErrNotStatusReply
+	}
+	if b[8] != StatusVersion {
 		return StatusReply{}, ErrStatusVersion
 	}
 	r := StatusReply{
-		Version:  b[4],
-		State:    ServerState(b[5]),
-		Flags:    binary.LittleEndian.Uint16(b[6:]),
-		Sessions: binary.LittleEndian.Uint16(b[8:]),
-		Uptime:   binary.LittleEndian.Uint32(b[10:]),
+		Version:  b[8],
+		State:    ServerState(b[9]),
+		Flags:    binary.LittleEndian.Uint16(b[10:]),
+		Sessions: binary.LittleEndian.Uint16(b[12:]),
+		Uptime:   binary.LittleEndian.Uint32(b[14:]),
 	}
 	// An unrecognised state degrades rather than passing through. A client
 	// taught only these five must not read a future "6" as something benign.
 	if r.State > StateStopping {
 		r.State = StateDegraded
 	}
-	nameLen := int(b[14])
+	nameLen := int(b[18])
 	if nameLen > 0 {
 		if len(b) < StatusFixedLen+nameLen {
 			return StatusReply{}, ErrStatusTruncated

--- a/native/ps2servers-edge/internal/protocol/status.go
+++ b/native/ps2servers-edge/internal/protocol/status.go
@@ -1,0 +1,180 @@
+package protocol
+
+import (
+	"encoding/binary"
+	"errors"
+)
+
+// The router status protocol. See docs/ROUTER-STATUS.md for the wire format and
+// for why it is shaped this way; the short version is that a query is a
+// DISCOVERY-shaped packet with a service ID that is not UDPFS, sent to the
+// discovery port that is already open. Every server shipped before this feature
+// -- including udpfsd upstream -- drops such a packet without replying, so a
+// status query is invisible to them and the client simply reports "unknown".
+//
+// Nothing here touches the DISCOVERY/INFORM exchange the console uses. That
+// reply is six bytes with no spare field and its exact shape is load-bearing
+// for real clients, so it is left alone.
+
+// ServiceStatus is the service ID claimed for status queries.
+//
+// Adjacent to ServiceUDPFS (0xF5F5) and the default port (0xF5F6), which is
+// upstream's numbering range -- hence ParseStatusReply checking both the echoed
+// service ID and the version byte rather than trusting that any reply to this
+// query is a status reply.
+const ServiceStatus uint16 = 0xF5F7
+
+// StatusVersion is the payload version. Offsets 0-4 of a reply are frozen
+// across versions; everything after may change.
+const StatusVersion uint8 = 1
+
+// StatusFixedLen is the reply length before the variable-length name.
+const StatusFixedLen = 15
+
+type ServerState uint8
+
+const (
+	StateStarting ServerState = 0
+	StateReady    ServerState = 1
+	// StateBusy means a transfer is in flight. It is the signal a launcher
+	// uses to tell someone not to cut power to a board wired to console power,
+	// which is the whole reason this protocol carries a state rather than just
+	// answering "yes I am here".
+	StateBusy     ServerState = 2
+	StateDegraded ServerState = 3
+	StateStopping ServerState = 4
+)
+
+func (s ServerState) String() string {
+	switch s {
+	case StateStarting:
+		return "starting"
+	case StateReady:
+		return "ready"
+	case StateBusy:
+		return "busy"
+	case StateDegraded:
+		return "degraded"
+	case StateStopping:
+		return "stopping"
+	default:
+		// Not "unknown": an unrecognised state must read as a reason for
+		// caution, never as something safe. See ParseStatusReply.
+		return "degraded"
+	}
+}
+
+// Service flags. Unassigned bits are zero and must be ignored, so a bit can be
+// added without a version bump.
+const (
+	FlagServesUDPFS  uint16 = 1 << 0
+	FlagServesUDPBD  uint16 = 1 << 1
+	FlagServesSMB    uint16 = 1 << 2
+	FlagReadOnly     uint16 = 1 << 3
+	FlagDecompresses uint16 = 1 << 4
+)
+
+// StatusReply is the decoded payload.
+type StatusReply struct {
+	Version  uint8
+	State    ServerState
+	Flags    uint16
+	Sessions uint16
+	Uptime   uint32
+	Name     string
+}
+
+// IsStatusQuery reports whether a received packet is a status query.
+//
+// Checked before the UDPFS service-ID guard in the discovery handler, and
+// deliberately strict about length: a six-byte packet whose service ID is
+// 0xF5F7 is the only thing that qualifies.
+func IsStatusQuery(packet []byte) bool {
+	if len(packet) < 6 {
+		return false
+	}
+	h, err := ParseHeader(packet)
+	if err != nil || h.Type != Discovery {
+		return false
+	}
+	dh, err := ParseDiscoveryHeader(packet[2:])
+	return err == nil && dh.ServiceID == ServiceStatus
+}
+
+// MarshalStatusQuery builds the six-byte query.
+func MarshalStatusQuery() []byte {
+	return append(Header{Type: Discovery, Sequence: 0}.Marshal(),
+		DiscoveryHeader{ServiceID: ServiceStatus, Port: 0}.Marshal()...)
+}
+
+// Marshal encodes a status reply.
+//
+// The name is truncated rather than rejected: a display string is never a
+// reason to fail a health check, and the length field caps it at 255 bytes.
+func (r StatusReply) Marshal() []byte {
+	name := []byte(r.Name)
+	if len(name) > 255 {
+		// Truncated on a byte boundary that may split a UTF-8 rune. The field
+		// is for display and the length is authoritative, so a client renders
+		// a replacement character at worst; validating runes here would mean
+		// this could fail, which it must not.
+		name = name[:255]
+	}
+	b := make([]byte, StatusFixedLen, StatusFixedLen+len(name))
+	copy(b, Header{Type: Inform, Sequence: 0}.Marshal())
+	binary.LittleEndian.PutUint16(b[2:], ServiceStatus)
+	b[4] = StatusVersion
+	b[5] = uint8(r.State)
+	binary.LittleEndian.PutUint16(b[6:], r.Flags)
+	binary.LittleEndian.PutUint16(b[8:], r.Sessions)
+	binary.LittleEndian.PutUint32(b[10:], r.Uptime)
+	b[14] = uint8(len(name))
+	return append(b, name...)
+}
+
+var (
+	ErrNotStatusReply  = errors.New("not a status reply")
+	ErrStatusVersion   = errors.New("unsupported status version")
+	ErrStatusTruncated = errors.New("truncated status reply")
+)
+
+// ParseStatusReply decodes and validates a reply.
+//
+// Rejects rather than guesses on every axis, because this runs against a
+// service ID in a range this project does not own: a foreign reply must not be
+// mistaken for a healthy server.
+func ParseStatusReply(b []byte) (StatusReply, error) {
+	if len(b) < StatusFixedLen {
+		return StatusReply{}, ErrStatusTruncated
+	}
+	h, err := ParseHeader(b)
+	if err != nil || h.Type != Inform {
+		return StatusReply{}, ErrNotStatusReply
+	}
+	if binary.LittleEndian.Uint16(b[2:]) != ServiceStatus {
+		return StatusReply{}, ErrNotStatusReply
+	}
+	if b[4] != StatusVersion {
+		return StatusReply{}, ErrStatusVersion
+	}
+	r := StatusReply{
+		Version:  b[4],
+		State:    ServerState(b[5]),
+		Flags:    binary.LittleEndian.Uint16(b[6:]),
+		Sessions: binary.LittleEndian.Uint16(b[8:]),
+		Uptime:   binary.LittleEndian.Uint32(b[10:]),
+	}
+	// An unrecognised state degrades rather than passing through. A client
+	// taught only these five must not read a future "6" as something benign.
+	if r.State > StateStopping {
+		r.State = StateDegraded
+	}
+	nameLen := int(b[14])
+	if nameLen > 0 {
+		if len(b) < StatusFixedLen+nameLen {
+			return StatusReply{}, ErrStatusTruncated
+		}
+		r.Name = string(b[StatusFixedLen : StatusFixedLen+nameLen])
+	}
+	return r, nil
+}

--- a/native/ps2servers-edge/internal/udpfs/server.go
+++ b/native/ps2servers-edge/internal/udpfs/server.go
@@ -386,6 +386,15 @@ func (s *Server) dispatch(in inbound) {
 	}
 	switch h.Type {
 	case protocol.Discovery:
+		// Before handleDiscovery, which creates a session for the peer. A
+		// status query must not do that: a launcher polling once a second
+		// would otherwise manufacture sessions, occupy slots against the
+		// concurrent-session cap, and show up in the very session count it is
+		// asking about.
+		if protocol.IsStatusQuery(in.packet) {
+			s.handleStatusQuery(in)
+			return
+		}
 		s.handleDiscovery(in, h)
 	case protocol.Data:
 		w := s.getWorker(in.peer)

--- a/native/ps2servers-edge/internal/udpfs/status.go
+++ b/native/ps2servers-edge/internal/udpfs/status.go
@@ -1,0 +1,103 @@
+package udpfs
+
+import (
+	"os"
+	"time"
+
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/protocol"
+)
+
+// handleStatusQuery answers "are you ready?" for a launcher or loader.
+//
+// See docs/ROUTER-STATUS.md. Deliberately stateless: it creates no session,
+// touches none, and cannot disturb a transfer in progress. A launcher polling
+// once a second must be invisible to the console being served.
+//
+// The reply goes back on the socket the query arrived on rather than on the
+// data socket, so this behaves under --single-port without a special case.
+func (s *Server) handleStatusQuery(in inbound) {
+	reply := protocol.StatusReply{
+		State:    s.serverState(),
+		Flags:    s.serviceFlags(),
+		Sessions: uint16(s.sessionCount()),
+		Uptime:   uint32(time.Since(s.stats.started).Seconds()),
+		Name:     s.cfg.ServerName,
+	}
+	s.cfg.Log.Debug("status query", map[string]any{
+		"peer": in.peer.String(), "state": reply.State.String(), "sessions": reply.Sessions})
+	s.sendOn(in.socket, reply.Marshal(), in.peer)
+}
+
+// serverState collapses the server into the five states a client understands.
+func (s *Server) serverState() protocol.ServerState {
+	select {
+	case <-s.closed:
+		return protocol.StateStopping
+	default:
+	}
+
+	// Busy means a transfer is in flight, and it is the reason this protocol
+	// carries a state at all: a board wired to console power must not be cut
+	// mid-write, and this is how a launcher knows to say so.
+	if s.anyTransferInFlight() {
+		return protocol.StateBusy
+	}
+
+	// A share that has become unreadable -- an unmounted USB stick, most
+	// likely, which is the ordinary failure on this hardware -- is reported
+	// rather than hidden. The server is still listening, so it is degraded and
+	// not stopping, but answering "ready" would send someone hunting the
+	// network for a storage fault.
+	if s.root == nil {
+		return protocol.StateDegraded
+	}
+	if info, err := os.Stat(s.root.Path()); err != nil || !info.IsDir() {
+		return protocol.StateDegraded
+	}
+	return protocol.StateReady
+}
+
+// anyTransferInFlight reports whether any peer is mid-transfer.
+func (s *Server) anyTransferInFlight() bool {
+	s.sessionsMu.Lock()
+	workers := make([]*peerWorker, 0, len(s.sessions))
+	for _, w := range s.sessions {
+		workers = append(workers, w)
+	}
+	s.sessionsMu.Unlock()
+
+	// The session lock is released before taking per-session locks. Holding
+	// both would invert the order the transfer path takes them in, and a
+	// status poll is the last thing that should be able to deadlock a server.
+	for _, w := range workers {
+		st := w.state
+		st.Mu.Lock()
+		active := st.Streaming || st.WriteActive
+		st.Mu.Unlock()
+		if active {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Server) sessionCount() int {
+	s.sessionsMu.Lock()
+	defer s.sessionsMu.Unlock()
+	return len(s.sessions)
+}
+
+func (s *Server) serviceFlags() uint16 {
+	flags := protocol.FlagServesUDPFS
+	if s.cfg.ReadOnly {
+		flags |= protocol.FlagReadOnly
+	}
+	if !s.cfg.NoCompression {
+		flags |= protocol.FlagDecompresses
+	}
+	// FlagServesUDPBD is deliberately not set when a --block-device is
+	// attached. That is block access carried inside UDPFS, which is a
+	// different thing from the UDPBD protocol the flag names, and a launcher
+	// that lit up a "UDPBD" indicator for it would be lying.
+	return flags
+}

--- a/native/ps2servers-edge/internal/udpfs/status_test.go
+++ b/native/ps2servers-edge/internal/udpfs/status_test.go
@@ -1,0 +1,173 @@
+package udpfs
+
+import (
+	"encoding/binary"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/protocol"
+)
+
+// statusQuery asks a running server for its status and decodes the reply.
+func statusQuery(t *testing.T, disc *net.UDPAddr) (protocol.StatusReply, error) {
+	t.Helper()
+	c, err := net.DialUDP("udp4", nil, disc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if _, err := c.Write(protocol.MarshalStatusQuery()); err != nil {
+		t.Fatal(err)
+	}
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 1500)
+	n, err := c.Read(buf)
+	if err != nil {
+		return protocol.StatusReply{}, err
+	}
+	return protocol.ParseStatusReply(buf[:n])
+}
+
+func TestStatusQueryReportsReady(t *testing.T) {
+	root := t.TempDir()
+	disc := startServerAt(t, root, false)
+
+	reply, err := statusQuery(t, disc)
+	if err != nil {
+		t.Fatalf("no usable status reply: %v", err)
+	}
+	if reply.State != protocol.StateReady {
+		t.Fatalf("state = %v, want ready", reply.State)
+	}
+	if reply.Flags&protocol.FlagServesUDPFS == 0 {
+		t.Fatal("UDPFS flag not set on a UDPFS server")
+	}
+	if reply.Flags&protocol.FlagReadOnly != 0 {
+		t.Fatal("read-only flag set on a writable server")
+	}
+	if reply.Name == "" {
+		t.Fatal("no server name in the reply")
+	}
+}
+
+func TestStatusReportsReadOnly(t *testing.T) {
+	disc := startServerAt(t, t.TempDir(), true)
+	reply, err := statusQuery(t, disc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply.Flags&protocol.FlagReadOnly == 0 {
+		t.Fatal("read-only server did not set the read-only flag")
+	}
+}
+
+func TestStatusQueryCreatesNoSession(t *testing.T) {
+	// The property that makes polling safe. A launcher asking once a second
+	// must not manufacture sessions -- they would occupy slots against the
+	// concurrent-session cap and show up in the very count being reported.
+	disc := startServerAt(t, t.TempDir(), false)
+
+	for i := 0; i < 5; i++ {
+		reply, err := statusQuery(t, disc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reply.Sessions != 0 {
+			t.Fatalf("after %d status queries the server reports %d sessions; polling is creating them",
+				i+1, reply.Sessions)
+		}
+	}
+}
+
+func TestStatusDegradesWhenTheShareDisappears(t *testing.T) {
+	// The ordinary hardware failure: someone pulls the USB stick. Answering
+	// "ready" would send them hunting the network for a storage fault.
+	root := filepath.Join(t.TempDir(), "games")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	disc := startServerAt(t, root, false)
+
+	if reply, err := statusQuery(t, disc); err != nil || reply.State != protocol.StateReady {
+		t.Fatalf("expected ready before removal, got %v (%v)", reply.State, err)
+	}
+	if err := os.Remove(root); err != nil {
+		t.Skipf("cannot remove the share root on this platform: %v", err)
+	}
+	reply, err := statusQuery(t, disc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply.State != protocol.StateDegraded {
+		t.Fatalf("state = %v after the share vanished, want degraded", reply.State)
+	}
+}
+
+func TestOrdinaryDiscoveryStillWorksAlongsideStatus(t *testing.T) {
+	// The compatibility guarantee, from the server side: adding the status
+	// path must not have altered the DISCOVERY/INFORM exchange the console
+	// depends on. INFORM is six bytes and its shape is load-bearing.
+	disc := startServerAt(t, t.TempDir(), false)
+
+	c, err := net.DialUDP("udp4", nil, disc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	query := append(protocol.Header{Type: protocol.Discovery, Sequence: 0}.Marshal(),
+		protocol.DiscoveryHeader{ServiceID: protocol.ServiceUDPFS, Port: 0}.Marshal()...)
+	if _, err := c.Write(query); err != nil {
+		t.Fatal(err)
+	}
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 1500)
+	n, err := c.Read(buf)
+	if err != nil {
+		t.Fatalf("no INFORM for an ordinary DISCOVERY: %v", err)
+	}
+	// Length is not asserted. In Pending mode the reply arriving on the
+	// discovery socket is the Modulo compatibility INFORM, which carries an
+	// info payload after the six-byte core -- the canonical six-byte INFORM
+	// goes to the data socket. Pinning a length here would be pinning which
+	// profile the fallback happened to pick, which is not what this test is
+	// about.
+	if n < 6 {
+		t.Fatalf("INFORM is %d bytes, shorter than the six-byte core", n)
+	}
+	h, err := protocol.ParseHeader(buf[:n])
+	if err != nil || h.Type != protocol.Inform {
+		t.Fatalf("reply is not an INFORM: %v %v", h, err)
+	}
+	if got := binary.LittleEndian.Uint16(buf[2:]); got != protocol.ServiceUDPFS {
+		t.Fatalf("INFORM service ID = %#x, want %#x", got, protocol.ServiceUDPFS)
+	}
+}
+
+func TestUnknownServiceIDIsStillIgnored(t *testing.T) {
+	// The other half of the compatibility rule: a service ID that is neither
+	// UDPFS nor status must still be dropped silently. That is the behaviour
+	// this whole design is built on, so it is pinned rather than assumed --
+	// answering foreign discovery packets would make this server a reflector.
+	disc := startServerAt(t, t.TempDir(), false)
+
+	c, err := net.DialUDP("udp4", nil, disc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	query := append(protocol.Header{Type: protocol.Discovery, Sequence: 0}.Marshal(),
+		protocol.DiscoveryHeader{ServiceID: 0x1234, Port: 0}.Marshal()...)
+	if _, err := c.Write(query); err != nil {
+		t.Fatal(err)
+	}
+	_ = c.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 1500)
+	if n, err := c.Read(buf); err == nil {
+		t.Fatalf("server replied with %d bytes to an unknown service ID", n)
+	}
+}

--- a/tests/test_router_status.py
+++ b/tests/test_router_status.py
@@ -36,17 +36,29 @@ import router_status  # noqa: E402
 
 
 class WireFormat(unittest.TestCase):
-    def test_query_is_six_bytes_and_discovery_shaped(self):
+    def test_query_is_discovery_shaped_and_carries_the_magic(self):
         # The shape is what makes an older server discard it on the guard it
         # already has. A query that did not look like a DISCOVERY would fall
         # through to some other path and might get an answer.
         q = router_status.build_status_query()
-        self.assertEqual(len(q), 6)
+        self.assertEqual(len(q), router_status.QUERY_LEN)
         (header,) = struct.unpack_from("<H", q, 0)
         self.assertEqual(header & 0xF, 0, "packet type must be DISCOVERY")
         self.assertEqual(header >> 4, 0, "sequence must be 0")
         (service,) = struct.unpack_from("<H", q, 2)
         self.assertEqual(service, 0xF5F7)
+        self.assertEqual(q[6:10], router_status.MAGIC)
+
+    def test_query_without_the_magic_is_not_ours(self):
+        # The whole point of the tag: 0xF5F7 sits in upstream's numbering
+        # range, so the number alone must not be enough to make this server
+        # answer. A future udpfsd client using that ID for something else must
+        # get silence from us.
+        bare = struct.pack("<HHH", 0, 0xF5F7, 0)
+        self.assertFalse(router_status.is_status_query(bare))
+        wrong = bare + b"XXXX"
+        self.assertFalse(router_status.is_status_query(wrong))
+        self.assertTrue(router_status.is_status_query(router_status.build_status_query()))
 
     def test_reply_round_trips(self):
         packet = router_status.build_status_reply(
@@ -63,17 +75,25 @@ class WireFormat(unittest.TestCase):
         self.assertTrue(got["flags"] & router_status.FLAG_READ_ONLY)
 
     def test_fixed_offsets_are_where_the_spec_says(self):
-        # Offsets 0-4 are frozen across payload versions; a client keys its
-        # version check on them. If this test has to change, the spec changes.
+        # The first ten bytes are frozen across payload versions; a client keys
+        # its "is this mine, do I understand it" check on them. If this test
+        # has to change, the spec changes and every implementation with it.
         packet = router_status.build_status_reply(router_status.STATE_READY, 0, 0, 0, "")
         self.assertEqual(struct.unpack_from("<H", packet, 2)[0], 0xF5F7)
-        self.assertEqual(packet[4], router_status.VERSION)
+        self.assertEqual(packet[4:8], router_status.MAGIC)
+        self.assertEqual(packet[8], router_status.VERSION)
         self.assertEqual(len(packet), router_status.FIXED_LEN)
+
+    def test_reply_without_the_magic_is_rejected(self):
+        packet = bytearray(router_status.build_status_reply(
+            router_status.STATE_READY, 0, 0, 0, "x"))
+        packet[4:8] = b"NOPE"
+        self.assertIsNone(router_status.parse_status_reply(bytes(packet)))
 
     def test_unknown_version_is_rejected_not_guessed(self):
         packet = bytearray(router_status.build_status_reply(
             router_status.STATE_READY, 0, 0, 0, "x"))
-        packet[4] = 99
+        packet[8] = 99
         self.assertIsNone(router_status.parse_status_reply(bytes(packet)))
 
     def test_unknown_state_degrades(self):
@@ -81,7 +101,7 @@ class WireFormat(unittest.TestCase):
         # something benign.
         packet = bytearray(router_status.build_status_reply(
             router_status.STATE_READY, 0, 0, 0, ""))
-        packet[5] = 200
+        packet[9] = 200
         got = router_status.parse_status_reply(bytes(packet))
         self.assertEqual(got["state"], router_status.STATE_DEGRADED)
 
@@ -97,7 +117,7 @@ class WireFormat(unittest.TestCase):
                               f"accepted a reply truncated to {cut} bytes")
         # A name length that runs past the packet.
         lying = bytearray(good)
-        lying[14] = 200
+        lying[18] = 200
         self.assertIsNone(router_status.parse_status_reply(bytes(lying)))
 
     def test_long_name_is_truncated_not_rejected(self):

--- a/tests/test_router_status.py
+++ b/tests/test_router_status.py
@@ -249,6 +249,21 @@ class LiveServer(unittest.TestCase):
                 f"after {i + 1} status polls the server has sessions; polling is creating them")
             self.assertEqual(got["sessions"], 0)
 
+    def test_reply_names_the_product_not_just_the_host(self):
+        # A bare hostname tells a launcher nothing about what answered, and
+        # Edge identifies itself as "PS2 Servers Edge". The modulo INFORM's
+        # server_name is a different field and must stay the bare hostname,
+        # because a real PS2 loader displays that one.
+        server = self._serve()
+        client = self._client(2.0)
+        server._handle_discovery(router_status.build_status_query(), client.getsockname())
+        got = router_status.parse_status_reply(client.recvfrom(2048)[0])
+        self.assertIsNotNone(got)
+        self.assertTrue(got["name"].startswith("PS2 Servers"),
+                        f"status name {got['name']!r} does not identify the product")
+        self.assertNotEqual(got["name"], server.server_name,
+                            "status name must not be the bare modulo INFORM name")
+
     def test_read_only_is_reported(self):
         server = self._serve(read_only=True)
         client = self._client(2.0)

--- a/tests/test_router_status.py
+++ b/tests/test_router_status.py
@@ -1,0 +1,281 @@
+"""The router status protocol must mean the same thing in every edition.
+
+Two servers implement this -- Edge in Go and the Desktop server in Python --
+and outside projects are invited to implement it too, so the wire format is
+tested as a contract rather than as whatever each side happens to produce. The
+cross-implementation test here compares Python's bytes against the Go
+encoder's, byte for byte.
+
+The compatibility tests matter as much as the format ones. This feature is
+built entirely on the fact that every server shipped so far drops a discovery
+packet whose service ID is not UDPFS. If that ever stopped being true, a status
+query would start disturbing consoles, so it is pinned here.
+"""
+
+import os
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+# Matches ps2servers_core.DEFAULT_FALLBACK_SECONDS; imported lazily below would
+# drag the server in at module scope, which the wire-format tests do not need.
+DEFAULT_FALLBACK_SECONDS = 0.25
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_UDPFS_DIR = os.path.join(_ROOT, "udpfs_server")
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+if _UDPFS_DIR not in sys.path:
+    sys.path.insert(0, _UDPFS_DIR)
+
+import router_status  # noqa: E402
+
+
+class WireFormat(unittest.TestCase):
+    def test_query_is_six_bytes_and_discovery_shaped(self):
+        # The shape is what makes an older server discard it on the guard it
+        # already has. A query that did not look like a DISCOVERY would fall
+        # through to some other path and might get an answer.
+        q = router_status.build_status_query()
+        self.assertEqual(len(q), 6)
+        (header,) = struct.unpack_from("<H", q, 0)
+        self.assertEqual(header & 0xF, 0, "packet type must be DISCOVERY")
+        self.assertEqual(header >> 4, 0, "sequence must be 0")
+        (service,) = struct.unpack_from("<H", q, 2)
+        self.assertEqual(service, 0xF5F7)
+
+    def test_reply_round_trips(self):
+        packet = router_status.build_status_reply(
+            router_status.STATE_BUSY,
+            router_status.FLAG_UDPFS | router_status.FLAG_READ_ONLY,
+            3, 1234, "PS2 Servers 0.4.9")
+        got = router_status.parse_status_reply(packet)
+        self.assertIsNotNone(got)
+        self.assertEqual(got["state"], router_status.STATE_BUSY)
+        self.assertEqual(got["state_name"], "busy")
+        self.assertEqual(got["sessions"], 3)
+        self.assertEqual(got["uptime"], 1234)
+        self.assertEqual(got["name"], "PS2 Servers 0.4.9")
+        self.assertTrue(got["flags"] & router_status.FLAG_READ_ONLY)
+
+    def test_fixed_offsets_are_where_the_spec_says(self):
+        # Offsets 0-4 are frozen across payload versions; a client keys its
+        # version check on them. If this test has to change, the spec changes.
+        packet = router_status.build_status_reply(router_status.STATE_READY, 0, 0, 0, "")
+        self.assertEqual(struct.unpack_from("<H", packet, 2)[0], 0xF5F7)
+        self.assertEqual(packet[4], router_status.VERSION)
+        self.assertEqual(len(packet), router_status.FIXED_LEN)
+
+    def test_unknown_version_is_rejected_not_guessed(self):
+        packet = bytearray(router_status.build_status_reply(
+            router_status.STATE_READY, 0, 0, 0, "x"))
+        packet[4] = 99
+        self.assertIsNone(router_status.parse_status_reply(bytes(packet)))
+
+    def test_unknown_state_degrades(self):
+        # A client taught only the five states must not read a future value as
+        # something benign.
+        packet = bytearray(router_status.build_status_reply(
+            router_status.STATE_READY, 0, 0, 0, ""))
+        packet[5] = 200
+        got = router_status.parse_status_reply(bytes(packet))
+        self.assertEqual(got["state"], router_status.STATE_DEGRADED)
+
+    def test_foreign_and_truncated_replies_are_rejected(self):
+        good = router_status.build_status_reply(router_status.STATE_READY, 0, 0, 0, "hi")
+        # Wrong service ID: the numbering range is not ours, so a reply from
+        # something else must not be read as a healthy server.
+        foreign = bytearray(good)
+        struct.pack_into("<H", foreign, 2, 0xF5F5)
+        self.assertIsNone(router_status.parse_status_reply(bytes(foreign)))
+        for cut in range(len(good)):
+            self.assertIsNone(router_status.parse_status_reply(good[:cut]),
+                              f"accepted a reply truncated to {cut} bytes")
+        # A name length that runs past the packet.
+        lying = bytearray(good)
+        lying[14] = 200
+        self.assertIsNone(router_status.parse_status_reply(bytes(lying)))
+
+    def test_long_name_is_truncated_not_rejected(self):
+        got = router_status.parse_status_reply(
+            router_status.build_status_reply(router_status.STATE_READY, 0, 0, 0, "n" * 400))
+        self.assertIsNotNone(got, "an over-long display name must not fail a health check")
+        self.assertEqual(len(got["name"]), 255)
+
+    def test_is_status_query_rejects_ordinary_discovery(self):
+        # The packet a console sends must never be mistaken for a status query.
+        console = struct.pack("<HHH", 0, 0xF5F5, 0)
+        self.assertFalse(router_status.is_status_query(console))
+        self.assertTrue(router_status.is_status_query(router_status.build_status_query()))
+
+
+class CrossImplementation(unittest.TestCase):
+    """Python and Go must produce identical bytes."""
+
+    def test_go_and_python_encoders_agree(self):
+        go = shutil_which("go")
+        if not go:
+            self.skipTest("no Go toolchain on PATH")
+        edge = os.path.join(_ROOT, "native", "ps2servers-edge")
+        if not os.path.isdir(edge):
+            self.skipTest("Edge source not present")
+
+        program = '''
+package main
+
+import (
+	"fmt"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/protocol"
+)
+
+func main() {
+	r := protocol.StatusReply{
+		State:    protocol.StateBusy,
+		Flags:    protocol.FlagServesUDPFS | protocol.FlagReadOnly,
+		Sessions: 3,
+		Uptime:   1234,
+		Name:     "PS2 Servers 0.4.9",
+	}
+	fmt.Printf("%x\\n", r.Marshal())
+	fmt.Printf("%x\\n", protocol.MarshalStatusQuery())
+}
+'''
+        # The probe must live INSIDE the Edge module. internal/ packages are
+        # importable only from within the module that declares them, so a
+        # program in the system temp directory cannot reach protocol.
+        with tempfile.TemporaryDirectory(dir=edge) as tmp:
+            src = os.path.join(tmp, "main.go")
+            with open(src, "w", encoding="utf-8") as fh:
+                fh.write(program)
+            try:
+                out = subprocess.run(
+                    [go, "run", src], cwd=edge, capture_output=True, text=True, timeout=180)
+            except subprocess.TimeoutExpired:
+                self.skipTest("go run timed out")
+            if out.returncode != 0:
+                self.fail(f"go run failed, so the two encoders were never compared: {out.stderr[:600]}")
+
+        lines = [l.strip() for l in out.stdout.splitlines() if l.strip()]
+        self.assertEqual(len(lines), 2, f"unexpected go output: {out.stdout!r}")
+        go_reply, go_query = bytes.fromhex(lines[0]), bytes.fromhex(lines[1])
+
+        py_reply = router_status.build_status_reply(
+            router_status.STATE_BUSY,
+            router_status.FLAG_UDPFS | router_status.FLAG_READ_ONLY,
+            3, 1234, "PS2 Servers 0.4.9")
+        py_query = router_status.build_status_query()
+
+        self.assertEqual(py_reply.hex(), go_reply.hex(), "reply encodings differ")
+        self.assertEqual(py_query.hex(), go_query.hex(), "query encodings differ")
+
+        # And Python must decode what Go produced.
+        decoded = router_status.parse_status_reply(go_reply)
+        self.assertIsNotNone(decoded)
+        self.assertEqual(decoded["state"], router_status.STATE_BUSY)
+        self.assertEqual(decoded["name"], "PS2 Servers 0.4.9")
+
+
+def shutil_which(name):
+    import shutil
+    return shutil.which(name)
+
+
+class LiveServer(unittest.TestCase):
+    """The Desktop server must answer through its real discovery handler.
+
+    _handle_discovery is driven directly rather than through run(), which loops
+    forever with no stop flag. The handler is the integration point under test
+    -- it is where the status hook sits, ahead of the service-ID guard -- and
+    it does its own real socket send, so nothing here is stubbed.
+    """
+
+    def _serve(self, read_only=False):
+        import ps2servers_core
+
+        root = tempfile.mkdtemp()
+        self.addCleanup(lambda: os.rmdir(root) if os.path.isdir(root) else None)
+        server = ps2servers_core.AutoUdpfsServer(
+            root_dir=root, port=0, bind_ip="127.0.0.1", read_only=read_only)
+        self.addCleanup(server.sock.close)
+        if server.dsock is not server.sock:
+            self.addCleanup(server.dsock.close)
+        return server
+
+    def _client(self, timeout):
+        client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        client.bind(("127.0.0.1", 0))
+        client.settimeout(timeout)
+        self.addCleanup(client.close)
+        return client
+
+    def test_answers_status_and_creates_no_session(self):
+        server = self._serve()
+        client = self._client(2.0)
+
+        for i in range(3):
+            server._handle_discovery(
+                router_status.build_status_query(), client.getsockname())
+            data, _ = client.recvfrom(2048)
+            got = router_status.parse_status_reply(data)
+            self.assertIsNotNone(got, "server did not send a valid status reply")
+            self.assertTrue(got["flags"] & router_status.FLAG_UDPFS)
+            self.assertEqual(got["state"], router_status.STATE_READY)
+            self.assertEqual(
+                len(server.sessions), 0,
+                f"after {i + 1} status polls the server has sessions; polling is creating them")
+            self.assertEqual(got["sessions"], 0)
+
+    def test_read_only_is_reported(self):
+        server = self._serve(read_only=True)
+        client = self._client(2.0)
+        server._handle_discovery(router_status.build_status_query(), client.getsockname())
+        got = router_status.parse_status_reply(client.recvfrom(2048)[0])
+        self.assertIsNotNone(got)
+        self.assertTrue(got["flags"] & router_status.FLAG_READ_ONLY)
+
+    def test_degrades_when_the_share_disappears(self):
+        server = self._serve()
+        client = self._client(2.0)
+        os.rmdir(server.root_dir)
+
+        server._handle_discovery(router_status.build_status_query(), client.getsockname())
+        got = router_status.parse_status_reply(client.recvfrom(2048)[0])
+        self.assertIsNotNone(got)
+        self.assertEqual(got["state"], router_status.STATE_DEGRADED,
+                         "a vanished share must not be reported as ready")
+
+    def test_unknown_service_id_is_still_ignored(self):
+        # The rule the whole design rests on. If this ever fails, a status
+        # query stops being invisible to servers that predate it.
+        server = self._serve()
+        client = self._client(0.4)
+        server._handle_discovery(struct.pack("<HHH", 0, 0x1234, 0), client.getsockname())
+        with self.assertRaises(socket.timeout):
+            client.recvfrom(2048)
+
+    def test_ordinary_discovery_still_gets_an_inform(self):
+        # The other half: adding the status branch must not have disturbed the
+        # exchange the console actually uses.
+        server = self._serve()
+        client = self._client(2.0)
+        server._handle_discovery(struct.pack("<HHH", 0, 0xF5F5, 0), client.getsockname())
+        data, _ = client.recvfrom(2048)
+        self.assertGreaterEqual(len(data), 6)
+        (header,) = struct.unpack_from("<H", data, 0)
+        self.assertEqual(header & 0xF, 1, "reply to DISCOVERY must be an INFORM")
+        self.assertEqual(struct.unpack_from("<H", data, 2)[0], 0xF5F5)
+
+        # An ordinary DISCOVERY schedules a delayed compatibility INFORM on a
+        # timer thread. Let it fire before cleanup closes the socket out from
+        # under it -- otherwise the thread raises WinError 10038 into the test
+        # output, which looks like a failure and is only this teardown race.
+        # Nothing in the server does this; a real server outlives its sockets.
+        time.sleep(DEFAULT_FALLBACK_SECONDS + 0.2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_status_client.py
+++ b/tests/test_status_client.py
@@ -1,0 +1,199 @@
+"""The launcher's side of the status protocol.
+
+The behaviour worth pinning is not "it can parse a packet" -- test_router_status
+covers the format. It is the two judgement calls the launcher makes with the
+answer:
+
+  * a server that does not reply is UNKNOWN, never "down", because it may
+    simply be a build that predates the protocol; and
+  * a busy warning fires only when a server has positively said it is
+    mid-transfer, never on a failure to reach it, or it would be dismissed
+    reflexively and would not be there for the save that matters.
+"""
+
+import os
+import socket
+import sys
+import tempfile
+import threading
+import unittest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from launcher import status_client  # noqa: E402
+
+
+class FakeServer:
+    """A socket that answers status queries however the test wants.
+
+    Real UDP on loopback rather than a stubbed query(): the point is to
+    exercise the actual send, receive and decode.
+    """
+
+    def __init__(self, reply_builder=None):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.bind(("127.0.0.1", 0))
+        self.port = self.sock.getsockname()[1]
+        self.reply_builder = reply_builder
+        self.queries = 0
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self):
+        self.sock.settimeout(0.2)
+        while not self._stop.is_set():
+            try:
+                data, addr = self.sock.recvfrom(2048)
+            except (socket.timeout, OSError):
+                continue
+            self.queries += 1
+            if self.reply_builder is not None:
+                try:
+                    self.sock.sendto(self.reply_builder(data), addr)
+                except OSError:
+                    pass
+
+    def close(self):
+        self._stop.set()
+        self._thread.join(timeout=1.0)
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+
+class ProtocolIsShared(unittest.TestCase):
+    def test_launcher_loads_the_servers_copy(self):
+        # Not a duplicate of the encoder. The launcher and the server must
+        # agree byte for byte, and one copy is the only way to be sure.
+        proto = status_client.protocol()
+        self.assertIsNotNone(proto, "launcher could not load router_status")
+        self.assertEqual(
+            os.path.normcase(os.path.basename(proto.__file__)), "router_status.py")
+        self.assertIn("udpfs_server", os.path.normcase(proto.__file__))
+
+
+class Query(unittest.TestCase):
+    def setUp(self):
+        self.proto = status_client.protocol()
+        if self.proto is None:
+            self.skipTest("router_status not loadable")
+
+    def test_reads_a_real_reply_over_the_wire(self):
+        def reply(_data):
+            return self.proto.build_status_reply(
+                self.proto.STATE_BUSY, self.proto.FLAG_UDPFS, 2, 99, "PS2 Servers")
+
+        server = FakeServer(reply)
+        self.addCleanup(server.close)
+        got = status_client.query("127.0.0.1", server.port, timeout=1.0)
+        self.assertIsNotNone(got)
+        self.assertEqual(got["state"], self.proto.STATE_BUSY)
+        self.assertEqual(got["sessions"], 2)
+        self.assertEqual(got["name"], "PS2 Servers")
+
+    def test_silence_is_none_not_an_exception(self):
+        # An older server ignores the query. That must be an ordinary answer of
+        # "no answer", not something that can break a poll loop.
+        server = FakeServer(reply_builder=None)
+        self.addCleanup(server.close)
+        self.assertIsNone(status_client.query("127.0.0.1", server.port, timeout=0.3))
+        self.assertGreaterEqual(server.queries, 1, "the query never arrived")
+
+    def test_garbage_reply_is_rejected(self):
+        server = FakeServer(lambda _d: b"not a status reply at all")
+        self.addCleanup(server.close)
+        self.assertIsNone(status_client.query("127.0.0.1", server.port, timeout=0.5))
+
+    def test_closed_port_and_bad_port_do_not_raise(self):
+        server = FakeServer(reply_builder=None)
+        server.close()
+        self.assertIsNone(status_client.query("127.0.0.1", server.port, timeout=0.2))
+        self.assertIsNone(status_client.query("127.0.0.1", 0, timeout=0.2))
+        self.assertIsNone(status_client.query("no.such.host.invalid", 9, timeout=0.2))
+
+
+class BusyIsPositiveOnly(unittest.TestCase):
+    def setUp(self):
+        self.proto = status_client.protocol()
+        if self.proto is None:
+            self.skipTest("router_status not loadable")
+
+    def test_only_a_stated_busy_counts(self):
+        self.assertTrue(status_client.is_busy({"state": self.proto.STATE_BUSY}))
+        for other in (self.proto.STATE_READY, self.proto.STATE_STARTING,
+                      self.proto.STATE_DEGRADED, self.proto.STATE_STOPPING):
+            self.assertFalse(status_client.is_busy({"state": other}))
+
+    def test_no_answer_is_not_busy(self):
+        # The important negative. If an unreachable server counted as busy, the
+        # warning would fire constantly against every older build and be
+        # trained away before it ever mattered.
+        self.assertFalse(status_client.is_busy(None))
+        self.assertFalse(status_client.is_busy({}))
+        self.assertFalse(status_client.is_busy({"state_name": status_client.UNKNOWN}))
+
+
+class PollerBehaviour(unittest.TestCase):
+    def setUp(self):
+        self.proto = status_client.protocol()
+        if self.proto is None:
+            self.skipTest("router_status not loadable")
+
+    def test_records_per_target_and_marks_silence_unknown(self):
+        talking = FakeServer(lambda _d: self.proto.build_status_reply(
+            self.proto.STATE_READY, self.proto.FLAG_UDPFS, 0, 5, "talks"))
+        silent = FakeServer(reply_builder=None)
+        self.addCleanup(talking.close)
+        self.addCleanup(silent.close)
+
+        poller = status_client.Poller(timeout=0.3)
+        poller.set_target("udpfs", "127.0.0.1", talking.port)
+        poller.set_target("old", "127.0.0.1", silent.port)
+        poller.poll_once()
+
+        snap = poller.snapshot()
+        self.assertEqual(snap["udpfs"]["state"], self.proto.STATE_READY)
+        self.assertEqual(snap["old"]["state_name"], status_client.UNKNOWN,
+                         "a server that does not answer must be unknown, not down")
+
+    def test_clearing_a_target_drops_its_result(self):
+        server = FakeServer(lambda _d: self.proto.build_status_reply(
+            self.proto.STATE_READY, 0, 0, 0, ""))
+        self.addCleanup(server.close)
+
+        poller = status_client.Poller(timeout=0.3)
+        poller.set_target("udpfs", "127.0.0.1", server.port)
+        poller.poll_once()
+        self.assertIn("udpfs", poller.snapshot())
+
+        poller.clear_target("udpfs")
+        self.assertNotIn("udpfs", poller.snapshot())
+        poller.poll_once()
+        self.assertNotIn("udpfs", poller.snapshot(),
+                         "a cleared target must not come back on the next sweep")
+
+    def test_a_failing_sweep_does_not_kill_the_thread(self):
+        # A poller that dies takes the status display with it, silently.
+        poller = status_client.Poller(interval=0.2, timeout=0.1)
+
+        calls = []
+
+        def boom():
+            calls.append(1)
+            raise RuntimeError("sweep exploded")
+
+        poller.poll_once = boom
+        poller.start()
+        self.addCleanup(poller.stop)
+        deadline = threading.Event()
+        deadline.wait(0.8)
+        self.assertGreaterEqual(len(calls), 2,
+                                "the loop stopped after the first failure")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_status_client.py
+++ b/tests/test_status_client.py
@@ -195,5 +195,79 @@ class PollerBehaviour(unittest.TestCase):
                                 "the loop stopped after the first failure")
 
 
+class StopAllStaysUnconditional(unittest.TestCase):
+    """stop_all() must never be able to decline to stop.
+
+    Checked at the source level because the GUI cannot be instantiated
+    headlessly, and because this is a mistake that was actually made: a busy
+    prompt was put inside stop_all, where a "No" would skip the stopping while
+    every caller carried on regardless. Seven of its eight callers are
+    elevate-and-relaunch paths that free ports before the new instance binds
+    them, and the eighth is _shutdown_app, which destroys the root immediately
+    afterwards -- so declining would have quit the app and orphaned the very
+    servers the user was trying to protect.
+
+    The asking belongs at the points where a person chose to stop something.
+    """
+
+    @staticmethod
+    def _method(name):
+        import ast
+
+        path = os.path.join(_ROOT, "launcher", "gui.py")
+        with open(path, "r", encoding="utf-8") as handle:
+            tree = ast.parse(handle.read(), filename=path)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "LauncherApp":
+                for item in node.body:
+                    if isinstance(item, ast.FunctionDef) and item.name == name:
+                        return item
+        return None
+
+    @staticmethod
+    def _calls(func):
+        import ast
+
+        names = set()
+        for node in ast.walk(func):
+            if isinstance(node, ast.Call):
+                target = node.func
+                if isinstance(target, ast.Attribute):
+                    names.add(target.attr)
+                elif isinstance(target, ast.Name):
+                    names.add(target.id)
+        return names
+
+    def test_stop_all_does_not_prompt(self):
+        func = self._method("stop_all")
+        self.assertIsNotNone(func, "LauncherApp.stop_all not found")
+        self.assertNotIn(
+            "confirm_stop_while_busy", self._calls(func),
+            "stop_all must not prompt: its callers proceed regardless of the "
+            "answer, so a 'No' would skip stopping and quit or relaunch anyway")
+        self.assertNotIn("askyesno", self._calls(func))
+
+    def test_the_user_facing_paths_do_prompt(self):
+        for name in ("stop_all_confirmed", "stop_server"):
+            func = self._method(name)
+            self.assertIsNotNone(func, f"LauncherApp.{name} not found")
+            self.assertIn("confirm_stop_while_busy", self._calls(func),
+                          f"{name} is a person deciding and should warn")
+
+    def test_quit_confirmation_consults_busy_state(self):
+        func = self._method("_confirm_app_shutdown")
+        self.assertIsNotNone(func)
+        self.assertIn("is_busy", self._calls(func),
+                      "quitting mid-transfer must warn; _shutdown_app calls "
+                      "stop_all unconditionally, so this is the only gate")
+
+    def test_footer_button_uses_the_confirming_wrapper(self):
+        path = os.path.join(_ROOT, "launcher", "gui.py")
+        with open(path, "r", encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn('text="Stop all", command=self.stop_all_confirmed', source,
+                      "the footer Stop all button should be the confirming one")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/udpfs_server/ps2servers_core.py
+++ b/udpfs_server/ps2servers_core.py
@@ -207,6 +207,11 @@ class AutoUdpfsServer(UdpfsServer):
     def _handle_discovery(self, data: bytes, addr):
         if len(data) < 6:
             return
+        # Before the service-ID guard below. Shared with the standalone server
+        # rather than overridden, so the two editions cannot answer a status
+        # query differently. See docs/ROUTER-STATUS.md.
+        if self._maybe_answer_status(data, addr):
+            return
         try:
             hdr = Header.unpack(data)
             disc = DiscHeader.unpack(data[2:6])

--- a/udpfs_server/router_status.py
+++ b/udpfs_server/router_status.py
@@ -22,12 +22,31 @@ import struct
 # rather than trusting that any reply to this query is a status reply.
 SVC_STATUS = 0xF5F7
 
-# Payload version. Offsets 0-4 of a reply are frozen across versions;
-# everything after may change.
+# Identifies this protocol independently of the service ID.
+#
+# The number alone is not enough. 0xF5F5 is UDPFS and 0xF5F6 is the default
+# port, so upstream allocates consecutively and 0xF5F7 is the next one it would
+# reach for. Validating a reply protects our client from that; it does nothing
+# about the other direction. Without this tag a server here would answer ANY
+# discovery packet carrying 0xF5F7 -- including a future udpfsd client asking
+# about something else. Requiring the magic means this server can only answer a
+# question it actually understands.
+#
+# Safe to append: a longer packet whose service ID a server does not recognise
+# is still dropped on the guard it already has, verified against both
+# implementations before this was added.
+MAGIC = b"PS2S"
+
+# Payload version. A reply's first ten bytes -- header, service ID, magic,
+# version -- are frozen across versions, being what a client needs to decide
+# whether the rest is addressed to it and whether it understands the layout.
 VERSION = 1
 
+# Exact length of a query.
+QUERY_LEN = 10
+
 # Length of a reply before the variable-length name.
-FIXED_LEN = 15
+FIXED_LEN = 19
 
 # Packet types, repeated here rather than imported so this module stays
 # free of the server it describes.
@@ -74,19 +93,22 @@ def is_status_query(data):
     that creates a session: a launcher polling once a second has to be
     invisible to the console being served.
     """
-    if len(data) < 6:
+    if len(data) < QUERY_LEN:
         return False
     try:
         packet_type, _ = _unpack_header(data)
         (service_id,) = struct.unpack_from("<H", data, 2)
     except struct.error:
         return False
-    return packet_type == _PKT_DISCOVERY and service_id == SVC_STATUS
+    # The magic, not just the number. See MAGIC.
+    return (packet_type == _PKT_DISCOVERY
+            and service_id == SVC_STATUS
+            and data[6:10] == MAGIC)
 
 
 def build_status_query():
-    """The six-byte query, for a client or a test."""
-    return _pack_header(_PKT_DISCOVERY, 0) + struct.pack("<HH", SVC_STATUS, 0)
+    """The query, for a client or a test."""
+    return _pack_header(_PKT_DISCOVERY, 0) + struct.pack("<HH", SVC_STATUS, 0) + MAGIC
 
 
 def build_status_reply(state, flags, sessions, uptime_seconds, name=""):
@@ -98,9 +120,10 @@ def build_status_reply(state, flags, sessions, uptime_seconds, name=""):
     encoded = name.encode("utf-8", "replace")[:255]
     return (
         _pack_header(_PKT_INFORM, 0)
+        + struct.pack("<H", SVC_STATUS)
+        + MAGIC
         + struct.pack(
-            "<HBBHHIB",
-            SVC_STATUS,
+            "<BBHHIB",
             VERSION,
             state & 0xFF,
             flags & 0xFFFF,
@@ -123,11 +146,14 @@ def parse_status_reply(data):
         return None
     try:
         packet_type, _ = _unpack_header(data)
-        service_id, version, state, flags, sessions, uptime, name_len = struct.unpack_from(
-            "<HBBHHIB", data, 2)
+        (service_id,) = struct.unpack_from("<H", data, 2)
+        version, state, flags, sessions, uptime, name_len = struct.unpack_from(
+            "<BBHHIB", data, 8)
     except struct.error:
         return None
     if packet_type != _PKT_INFORM or service_id != SVC_STATUS:
+        return None
+    if data[4:8] != MAGIC:
         return None
     if version != VERSION:
         # Not a guess. A client that does not know the version must report the

--- a/udpfs_server/router_status.py
+++ b/udpfs_server/router_status.py
@@ -1,0 +1,153 @@
+"""Router status protocol -- encoding only, no sockets.
+
+See docs/ROUTER-STATUS.md for the wire format and the reasoning. The short
+version: a status query is a DISCOVERY-shaped packet whose service ID is not
+UDPFS, sent to the discovery port that is already open. Every server shipped
+before this feature -- this one included, and udpfsd upstream -- drops such a
+packet on the service-ID guard it already has, so the query is invisible to
+them and a client simply reports "unknown". Nothing regresses, no new port is
+opened, and the six-byte DISCOVERY/INFORM exchange the console depends on is
+not touched by one byte.
+
+Kept free of I/O so it can be tested against the Go implementation's bytes
+without starting a server. The two must agree exactly; that is the point of
+writing the format down.
+"""
+
+import struct
+
+# Claimed by this project, adjacent to UDPRDMA_SVC_UDPFS (0xF5F5) and the
+# default port (0xF5F6). That is upstream's numbering range, which is why
+# parse_status_reply validates the echoed service ID and the version byte
+# rather than trusting that any reply to this query is a status reply.
+SVC_STATUS = 0xF5F7
+
+# Payload version. Offsets 0-4 of a reply are frozen across versions;
+# everything after may change.
+VERSION = 1
+
+# Length of a reply before the variable-length name.
+FIXED_LEN = 15
+
+# Packet types, repeated here rather than imported so this module stays
+# free of the server it describes.
+_PKT_DISCOVERY = 0
+_PKT_INFORM = 1
+
+STATE_STARTING = 0
+STATE_READY = 1
+# A transfer is in flight. This is the field the whole protocol exists for: a
+# board wired to console power must not be cut mid-write.
+STATE_BUSY = 2
+STATE_DEGRADED = 3
+STATE_STOPPING = 4
+
+STATE_NAMES = {
+    STATE_STARTING: "starting",
+    STATE_READY: "ready",
+    STATE_BUSY: "busy",
+    STATE_DEGRADED: "degraded",
+    STATE_STOPPING: "stopping",
+}
+
+FLAG_UDPFS = 1 << 0
+FLAG_UDPBD = 1 << 1
+FLAG_SMB = 1 << 2
+FLAG_READ_ONLY = 1 << 3
+FLAG_DECOMPRESSES = 1 << 4
+
+
+def _pack_header(packet_type, sequence):
+    """The shared UDPRDMA header: type in the low nibble, 12-bit sequence."""
+    return struct.pack("<H", (packet_type & 0xF) | ((sequence & 0xFFF) << 4))
+
+
+def _unpack_header(data):
+    (v,) = struct.unpack_from("<H", data, 0)
+    return v & 0xF, (v >> 4) & 0xFFF
+
+
+def is_status_query(data):
+    """True if a received datagram is a status query.
+
+    Must be checked before the UDPFS service-ID guard, and before anything
+    that creates a session: a launcher polling once a second has to be
+    invisible to the console being served.
+    """
+    if len(data) < 6:
+        return False
+    try:
+        packet_type, _ = _unpack_header(data)
+        (service_id,) = struct.unpack_from("<H", data, 2)
+    except struct.error:
+        return False
+    return packet_type == _PKT_DISCOVERY and service_id == SVC_STATUS
+
+
+def build_status_query():
+    """The six-byte query, for a client or a test."""
+    return _pack_header(_PKT_DISCOVERY, 0) + struct.pack("<HH", SVC_STATUS, 0)
+
+
+def build_status_reply(state, flags, sessions, uptime_seconds, name=""):
+    """Encode a reply.
+
+    The name is truncated rather than rejected: a display string is never a
+    reason to fail a health check, and the length field caps it at 255 bytes.
+    """
+    encoded = name.encode("utf-8", "replace")[:255]
+    return (
+        _pack_header(_PKT_INFORM, 0)
+        + struct.pack(
+            "<HBBHHIB",
+            SVC_STATUS,
+            VERSION,
+            state & 0xFF,
+            flags & 0xFFFF,
+            min(int(sessions), 0xFFFF),
+            min(max(int(uptime_seconds), 0), 0xFFFFFFFF),
+            len(encoded),
+        )
+        + encoded
+    )
+
+
+def parse_status_reply(data):
+    """Decode a reply, or return None if it is not one.
+
+    Rejects rather than guesses on every axis, because this runs against a
+    service ID in a range this project does not own: a foreign reply must not
+    be mistaken for a healthy server.
+    """
+    if len(data) < FIXED_LEN:
+        return None
+    try:
+        packet_type, _ = _unpack_header(data)
+        service_id, version, state, flags, sessions, uptime, name_len = struct.unpack_from(
+            "<HBBHHIB", data, 2)
+    except struct.error:
+        return None
+    if packet_type != _PKT_INFORM or service_id != SVC_STATUS:
+        return None
+    if version != VERSION:
+        # Not a guess. A client that does not know the version must report the
+        # server as unknown rather than read fields that may have moved.
+        return None
+    name = ""
+    if name_len:
+        if len(data) < FIXED_LEN + name_len:
+            return None
+        name = data[FIXED_LEN:FIXED_LEN + name_len].decode("utf-8", "replace")
+    if state > STATE_STOPPING:
+        # An unrecognised state degrades rather than passing through. A client
+        # taught only these five must not read a future value as benign.
+        state = STATE_DEGRADED
+    return {
+        "version": version,
+        "state": state,
+        "state_name": STATE_NAMES.get(state, "degraded"),
+        "flags": flags,
+        "sessions": sessions,
+        "uptime": uptime,
+        "name": name,
+    }

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -1123,10 +1123,26 @@ class UdpfsServer:
             self._status_flags(),
             len(self.sessions),
             time.monotonic() - self._start_time,
-            self.server_name,
+            self._status_name(),
         )
         _send_with_retry(self.sock, packet, addr, self.send_lock, self.tx_delay_s)
         return True
+
+    def _status_name(self) -> str:
+        """The display name for a status reply.
+
+        NOT self.server_name. That one is a protocol field: it goes out in the
+        modulo INFORM and a real PS2 loader shows it, so it stays exactly what
+        it has always been -- the bare hostname -- and is not touched here.
+
+        A status reply is read by launchers and dashboards, where a bare
+        hostname says nothing about what answered; Edge identifies itself as
+        "PS2 Servers Edge" and this should be as recognisable. The host is kept
+        after the product name because the field's real use is telling several
+        boxes apart when more than one answers.
+        """
+        host = (self.server_name or "").strip()
+        return "PS2 Servers ({})".format(host) if host else "PS2 Servers"
 
     def _status_state(self) -> int:
         """Collapse the server into the five states a client understands."""

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -49,6 +49,9 @@ from typing import Dict, List, Optional, Tuple, Union
 # Compressed ISO support
 from compressed_iso import CompressedFileWrapper, ZsoFileWrapper, CsoFileWrapper, ChdFileWrapper, LIBCHDR_AVAILABLE
 
+# Router status protocol. Encoding only -- see docs/ROUTER-STATUS.md.
+import router_status
+
 # Check LZ4 availability for ZSO format
 try:
     import lz4
@@ -1095,6 +1098,64 @@ class UdpfsServer:
 
     # --- UDPRDMA packet handling ---
 
+    def _maybe_answer_status(self, data: bytes, addr) -> bool:
+        """Answer a router status query. True if the packet was one.
+
+        Unlike almost everything else in this region, this is NOT overridden by
+        ps2servers_core.AutoUdpfsServer -- both discovery handlers call this one
+        implementation, so the two editions cannot answer differently. See
+        docs/ROUTER-STATUS.md.
+
+        Called before the UDPFS service-ID guard and before anything that
+        creates a session. A launcher polling once a second has to stay
+        invisible to the console being served, and must not occupy a slot in the
+        very session count it is reporting.
+
+        The reply goes out on the discovery socket, which is where the query
+        arrived, so a client using a connected UDP socket sees it come back from
+        the address it sent to. In --single-port mode dsock is aliased to sock,
+        so this is still the right socket.
+        """
+        if not router_status.is_status_query(data):
+            return False
+        packet = router_status.build_status_reply(
+            self._status_state(),
+            self._status_flags(),
+            len(self.sessions),
+            time.monotonic() - self._start_time,
+            self.server_name,
+        )
+        _send_with_retry(self.sock, packet, addr, self.send_lock, self.tx_delay_s)
+        return True
+
+    def _status_state(self) -> int:
+        """Collapse the server into the five states a client understands."""
+        # A share that has become unreadable -- an unmounted USB stick, the
+        # ordinary failure on router hardware -- is reported rather than
+        # hidden. Answering "ready" would send someone hunting the network for
+        # a storage fault.
+        if self.root_dir and not os.path.isdir(self.root_dir):
+            return router_status.STATE_DEGRADED
+        # Busy means a transfer is in flight, and it is why this protocol
+        # carries a state rather than just answering "yes, I am here": a board
+        # wired to console power must not be cut mid-write.
+        try:
+            sessions = list(self.sessions.values())
+        except RuntimeError:
+            # The dict changed while being copied. A status poll is the last
+            # thing that should raise, so report what is certain.
+            return router_status.STATE_READY
+        for sess in sessions:
+            if getattr(sess, "rx_streaming", False) or getattr(sess, "write_handle", -1) >= 0:
+                return router_status.STATE_BUSY
+        return router_status.STATE_READY
+
+    def _status_flags(self) -> int:
+        flags = router_status.FLAG_UDPFS
+        if self.read_only:
+            flags |= router_status.FLAG_READ_ONLY
+        return flags
+
     def _handle_discovery(self, data: bytes, addr: Tuple[str, int]):
         """Handle DISCOVERY packet.
 
@@ -1110,6 +1171,11 @@ class UdpfsServer:
         here only if the standalone server needs it too.
         """
         if len(data) < 6:
+            return
+
+        # Before the service-ID guard below, which is what makes older servers
+        # ignore this packet and therefore what makes the feature additive.
+        if self._maybe_answer_status(data, addr):
             return
 
         hdr = Header.unpack(data)


### PR DESCRIPTION
Asked for by FatBaldDad for [PS2-EtherDrive](https://github.com/FatBaldDad/PS2-EtherDrive), where the server is a router mounted inside the console. It boots in tens of seconds and may be power-cycled with the console, so a loader can't tell "still booting" from "broken" — the user waits too long, or resets something that didn't need it.

The second half matters more for that hardware: **a board wired to console power must not be cut mid-write.** `busy` is how a launcher knows to say so.

## Additive by construction

Every server shipped so far — both editions *and* udpfsd upstream — already drops a discovery packet whose service ID isn't UDPFS:

```
Edge     negotiation.go     dh.ServiceID != ServiceUDPFS      -> return
Desktop  ps2servers_core.py disc.service_id != SVC_UDPFS      -> return
```

So the query is a discovery-shaped packet on **the discovery port that's already open**, carrying service ID `0xF5F7` plus a `PS2S` magic. Consequences:

- An older server ignores it → client reports `unknown` → exactly today's behaviour. Nothing regresses.
- No new port, so no new firewall rule and no second UAC prompt.
- **No existing packet changes by a byte.** The console's DISCOVERY/INFORM is untouched — it's six bytes with no spare field and its shape is load-bearing.

The magic is required in both directions. `0xF5F5` is UDPFS and `0xF5F6` is the port, so upstream allocates consecutively and `0xF5F7` is the next value it'd reach for. Validating the reply only protects our client; without the magic our *server* would answer any packet carrying that ID, including a future udpfsd client asking about something else.

## Launcher

The dot has always meant "the child process is alive", which is wrong twice over:

- Unplug the USB stick → process alive, card said **Running**. Now says **Degraded**.
- Stop / Stop all mid-transfer → truncates the save. The launcher couldn't know, so it couldn't warn. Now it asks first, naming the servers.

Only a *positive* `busy` triggers the prompt. Silence means "fall back to the process check", never "down" — otherwise it'd fire against every older build and get trained away before it mattered.

Polling runs off the Tk thread; a blocking recv in a 600 ms callback would freeze the window.

## Testing

Cross-implementation test compiles a probe against Edge's encoder and compares bytes with Python's — it **fails rather than skips** if Go is present, since a skip would silently stop checking the only thing keeping two implementations honest.

Pinned both sides: a status poll creates no session, unknown service IDs still ignored, ordinary DISCOVERY still gets its INFORM, a vanished share reports `degraded`, unknown state/version refused rather than read as benign.

Verified end to end against a real launcher-spawned server, not just the fake one:
```
{'version': 1, 'state': 1, 'state_name': 'ready', 'flags': 1,
 'sessions': 0, 'uptime': 3, 'name': 'PS2 Servers (MSI)'}
```

## Scope

Only UDPFS implements it, so only that card gets truthful state — SMBv1 and UDPBD are unchanged. Console-side loaders (RiptOPL, NHDDL) are deliberately out of scope here; [docs/ROUTER-STATUS.md](docs/ROUTER-STATUS.md) is written so they can adopt it independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added router status reporting for server readiness, activity, health, sessions, uptime, and capabilities.
  * Launcher cards now display live states such as Ready, Busy, Starting, Stopping, and Degraded.
  * Stopping servers with active transfers now prompts for confirmation.

* **Bug Fixes**
  * Status checks no longer create server sessions or disrupt existing discovery behavior.
  * Packaged builds now include the required status functionality.

* **Compatibility**
  * Older servers continue operating normally and safely ignore unsupported status requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->