### PR TITLE
feat(packaging): a systemd unit for the servers Edge cannot run

### DIFF
--- a/packaging/systemd/README.md
+++ b/packaging/systemd/README.md
@@ -1,5 +1,58 @@
 # systemd deployment
 
+Two units here, and which one you want depends on whether you need SMB.
+
+| unit | build | serves |
+|---|---|---|
+| `ps2servers@.service` | the normal Linux download | **SMBv1**, UDPFS, UDPBD |
+| `ps2servers-edge.service` | the Go Edge build | UDPFS, UDPBD only |
+
+**Edge has no SMB.** If a console needs SMB — OPL's network game list, or
+POPSTARTER — Edge cannot serve it and `ps2servers@smbv1` is the unit you want.
+Edge is for routers and other small boxes where a Python runtime is not
+practical.
+
+## Any server, on a normal Linux box (`ps2servers@.service`)
+
+No desktop session required. `--serve` runs one server in the foreground and is
+dispatched before anything imports tkinter, so it needs no X, no display and no
+logged-in user.
+
+```sh
+# Grab the Linux build from the releases page (PS2Servers-linux-x64).
+sudo install -m 0755 PS2Servers-linux-x64 /usr/local/bin/ps2servers
+
+sudo useradd --system --home-dir /nonexistent --shell /usr/sbin/nologin ps2servers
+sudo mkdir -p /srv/ps2
+sudo chown root:ps2servers /srv/ps2
+sudo chmod 0775 /srv/ps2          # group-writable: OPL saves settings here
+
+sudo install -m 0644 packaging/systemd/ps2servers@.service /etc/systemd/system/
+sudo install -m 0644 packaging/systemd/ps2servers-smbv1.env /etc/default/ps2servers-smbv1
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now ps2servers@smbv1
+journalctl -u ps2servers@smbv1 -f
+```
+
+The instance name is the server key, so `ps2servers@udpfs` and
+`ps2servers@udpbd` work the same way — each reads its own
+`/etc/default/ps2servers-<key>`. Run `ps2servers --list` to see the keys
+available on your machine.
+
+Edit `/etc/default/ps2servers-smbv1` to set the share path and port before
+enabling. The port defaults to **1111**, not 445: binding 445 needs root, and
+on a machine already running Samba it is taken. Set OPL's *SMB Port* to match.
+
+The share is deliberately writable — OPL stores its settings on it, and a
+VMC-on-SMB lives there — which is why the unit sets `ReadWritePaths=/srv/ps2`
+under `ProtectSystem=strict`. Add `--read-only` only if you want saves to fail.
+
+If the share is on removable storage, add the mount unit to
+`After=`/`RequiresMountsFor=` with `systemctl edit ps2servers@smbv1`.
+
+## Edge, on a router or other small box (`ps2servers-edge.service`)
+
 ```sh
 sudo useradd --system --home-dir /nonexistent --shell /usr/sbin/nologin ps2edge
 sudo install -m 0755 ps2servers-edge /usr/local/bin/ps2servers-edge

--- a/packaging/systemd/README.md
+++ b/packaging/systemd/README.md
@@ -44,9 +44,26 @@ Edit `/etc/default/ps2servers-smbv1` to set the share path and port before
 enabling. The port defaults to **1111**, not 445: binding 445 needs root, and
 on a machine already running Samba it is taken. Set OPL's *SMB Port* to match.
 
-The share is deliberately writable — OPL stores its settings on it, and a
-VMC-on-SMB lives there — which is why the unit sets `ReadWritePaths=/srv/ps2`
-under `ProtectSystem=strict`. Add `--read-only` only if you want saves to fail.
+### Serving a share outside `/srv/ps2`
+
+**Change the unit as well as the env file.** `ProtectSystem=strict` makes the
+whole filesystem read-only apart from `ReadWritePaths=`, which ships as
+`/srv/ps2`. Point `--share` at `/mnt/games` and leave the unit alone and you
+get a share the console can read and never write — the server starts, the game
+list loads, and only saving fails, which looks like a network fault rather than
+a permissions one.
+
+```sh
+sudo systemctl edit ps2servers@smbv1
+```
+
+```ini
+[Service]
+ReadWritePaths=/mnt/games
+```
+
+The share is writable on purpose — OPL stores its settings on it and a
+VMC-on-SMB lives there. Add `--read-only` only if you want saves to fail.
 
 If the share is on removable storage, add the mount unit to
 `After=`/`RequiresMountsFor=` with `systemctl edit ps2servers@smbv1`.

--- a/packaging/systemd/README.md
+++ b/packaging/systemd/README.md
@@ -18,6 +18,8 @@ No desktop session required. `--serve` runs one server in the foreground and is
 dispatched before anything imports tkinter, so it needs no X, no display and no
 logged-in user.
 
+**1. Install the binary and create the service user.**
+
 ```sh
 # Grab the Linux build from the releases page (PS2Servers-linux-x64).
 sudo install -m 0755 PS2Servers-linux-x64 /usr/local/bin/ps2servers
@@ -26,23 +28,53 @@ sudo useradd --system --home-dir /nonexistent --shell /usr/sbin/nologin ps2serve
 sudo mkdir -p /srv/ps2
 sudo chown root:ps2servers /srv/ps2
 sudo chmod 0775 /srv/ps2          # group-writable: OPL saves settings here
-
-sudo install -m 0644 packaging/systemd/ps2servers@.service /etc/systemd/system/
-sudo install -m 0644 packaging/systemd/ps2servers-smbv1.env /etc/default/ps2servers-smbv1
-
-sudo systemctl daemon-reload
-sudo systemctl enable --now ps2servers@smbv1
-journalctl -u ps2servers@smbv1 -f
 ```
 
-The instance name is the server key, so `ps2servers@udpfs` and
-`ps2servers@udpbd` work the same way — each reads its own
-`/etc/default/ps2servers-<key>`. Run `ps2servers --list` to see the keys
-available on your machine.
+**2. Install the unit and the env file for the server you want.**
 
-Edit `/etc/default/ps2servers-smbv1` to set the share path and port before
-enabling. The port defaults to **1111**, not 445: binding 445 needs root, and
-on a machine already running Samba it is taken. Set OPL's *SMB Port* to match.
+```sh
+sudo install -m 0644 packaging/systemd/ps2servers@.service /etc/systemd/system/
+sudo install -m 0644 packaging/systemd/ps2servers-smbv1.env /etc/default/ps2servers-smbv1
+```
+
+The instance name is the server key. `ps2servers@udpfs` and `ps2servers@udpbd`
+work the same way, each with its own file — install
+`ps2servers-udpfs.env` or `ps2servers-udpbd.env` instead. The env file is
+**required**: every server here refuses to start without arguments, so a
+missing one fails immediately rather than looping. Run `ps2servers --list` to
+see the keys available on your machine.
+
+**3. Edit the env file before enabling anything.**
+
+```sh
+sudo nano /etc/default/ps2servers-smbv1
+```
+
+Set the share path and the port. The port defaults to **1111**, not 445:
+binding 445 needs root, and on a machine already running Samba it is taken. Set
+OPL's *SMB Port* to match.
+
+**4. Open the port if a firewall is running.** The GUI prints this hint when a
+server starts; running headless there is nobody to print it to. Ubuntu ships
+`ufw` inactive by default, so check before assuming:
+
+```sh
+sudo ufw status                      # skip the rest if inactive
+sudo ufw allow 1111/tcp              # smbv1; udpfs and udpbd are udp
+```
+
+`sudo firewall-cmd --add-port=1111/tcp --permanent && sudo firewall-cmd --reload`
+on firewalld distributions. A blocked port looks exactly like a server that is
+not running: the console simply never connects.
+
+**5. Start it.**
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now ps2servers@smbv1
+systemctl status ps2servers@smbv1
+journalctl -u ps2servers@smbv1 -f   # blocks; Ctrl-C to stop watching
+```
 
 ### Serving a share outside `/srv/ps2`
 

--- a/packaging/systemd/ps2servers-smbv1.env
+++ b/packaging/systemd/ps2servers-smbv1.env
@@ -1,0 +1,17 @@
+# /etc/default/ps2servers-smbv1
+#
+# Flags passed to `ps2servers --serve smbv1`. Split on whitespace by systemd,
+# so no value here may contain a space.
+
+# Port 1111 by default, not 445. 445 is the standard SMB port but binding it
+# needs root, and on a machine already running Samba it is taken -- which is
+# the usual reason to be running this at all. Set OPL's "SMB Port" to match.
+PS2SERVERS_ARGS=--share games=/srv/ps2 --port 1111
+
+# Writable by default: OPL saves its settings to the share and a VMC-on-SMB
+# lives there. Append --read-only only if you genuinely want saves to fail.
+#
+# Other flags: --bind ADDRESS to listen on one interface, -v for per-request
+# logging in `journalctl -u ps2servers@smbv1`.
+#
+# --take-445 is Windows-only (it pauses LanmanServer) and does nothing here.

--- a/packaging/systemd/ps2servers-udpbd.env
+++ b/packaging/systemd/ps2servers-udpbd.env
@@ -1,0 +1,21 @@
+# /etc/default/ps2servers-udpbd
+#
+# Flags passed to `ps2servers --serve udpbd`. Split on whitespace by systemd,
+# so no value here may contain a space.
+#
+# This file is REQUIRED. The unit does not mark it optional, so
+# `systemctl enable --now ps2servers@udpbd` fails before the server starts if
+# it is missing -- which is deliberate: the image path is a required positional
+# argument, so without it the server exits immediately and
+# Restart=on-failure would turn that into a restart loop instead of one clear
+# error.
+#
+# UDPBD serves ONE disk image, not a directory -- unlike smbv1 and udpfs. The
+# path is positional, so it carries no flag.
+PS2SERVERS_ARGS=/srv/ps2/ps2.img
+
+# Other flags: -i IP to bind one interface, -r to serve the image read-only,
+# -v to log every read/write in `journalctl -u ps2servers@udpbd`.
+#
+# The image must also be under the unit's ReadWritePaths= or writes fail
+# silently under ProtectSystem=strict. See ps2servers@.service.

--- a/packaging/systemd/ps2servers-udpfs.env
+++ b/packaging/systemd/ps2servers-udpfs.env
@@ -1,0 +1,19 @@
+# /etc/default/ps2servers-udpfs
+#
+# Flags passed to `ps2servers --serve udpfs`. Split on whitespace by systemd,
+# so no value here may contain a space.
+#
+# This file is REQUIRED. The unit does not mark it optional, so
+# `systemctl enable --now ps2servers@udpfs` fails before the server starts if
+# it is missing -- which is deliberate: without arguments the server exits
+# immediately ("at least one of --block-device or --root-dir is required") and
+# Restart=on-failure would turn that into a restart loop instead of one clear
+# error.
+PS2SERVERS_ARGS=--root-dir /srv/ps2 --port 62966
+
+# Other flags: --bind IP to listen on one interface, --read-only to refuse
+# writes, --protocol-mode auto|standard|modulo, -v for per-request logging in
+# `journalctl -u ps2servers@udpfs`.
+#
+# The share must also appear in the unit's ReadWritePaths= or writes fail
+# silently under ProtectSystem=strict. See ps2servers@.service.

--- a/packaging/systemd/ps2servers@.service
+++ b/packaging/systemd/ps2servers@.service
@@ -17,6 +17,13 @@ Group=ps2servers
 
 # Per-instance, so each server keeps its own share and port:
 #   /etc/default/ps2servers-smbv1
+#
+# Required, not optional (no `-` prefix), unlike ps2servers-edge.service. Every
+# one of these servers refuses to start without arguments -- smbv1 needs a
+# --share, udpfs a --root-dir, udpbd an image path -- so a missing env file
+# would otherwise become an argparse exit every 5s under Restart=on-failure. A
+# hard "Failed to load environment files" naming the unit is a better answer
+# than a restart loop. A sample ships for each key; install the matching one.
 EnvironmentFile=/etc/default/ps2servers-%i
 
 # --serve runs one server in this process with no GUI. It is dispatched before
@@ -54,7 +61,16 @@ TimeoutStopSec=15s
 #
 # tests/test_systemd_units.py checks the two shipped defaults agree.
 ProtectSystem=strict
-ReadWritePaths=/srv/ps2
+# The `-` matters. Without it a path that does not exist is fatal at
+# mount-namespace setup -- status=226/NAMESPACE, before ExecStart, looped by
+# Restart=on-failure -- so a user serving /mnt/games who never created (or
+# later removed) an empty /srv/ps2 gets a hard start failure naming a
+# directory that appears nowhere in their own configuration.
+#
+# Note that a `systemctl edit` override ADDS to this list rather than replacing
+# it: ReadWritePaths is a list directive, so the shipped entry survives unless
+# the drop-in first resets it with a bare `ReadWritePaths=`.
+ReadWritePaths=-/srv/ps2
 ProtectHome=read-only
 
 NoNewPrivileges=true

--- a/packaging/systemd/ps2servers@.service
+++ b/packaging/systemd/ps2servers@.service
@@ -37,6 +37,22 @@ TimeoutStopSec=15s
 # The share is writable on purpose. OPL stores its settings there and a
 # VMC-on-SMB lives there too, so a read-only share silently costs the user
 # their saves. ReadWritePaths is what re-opens it under ProtectSystem=strict.
+#
+# THIS PATH MUST MATCH THE --share PATH IN THE ENV FILE.
+#
+# ProtectSystem=strict makes the whole filesystem read-only apart from what is
+# listed here, so pointing --share at, say, /mnt/games while this still says
+# /srv/ps2 gives a share the console can read and never write. Nothing reports
+# that: the server starts, the game list loads, and only saving fails -- which
+# looks like a network fault rather than a permissions one.
+#
+# Serving a share elsewhere therefore needs both edited together:
+#
+#   systemctl edit ps2servers@smbv1
+#     [Service]
+#     ReadWritePaths=/mnt/games
+#
+# tests/test_systemd_units.py checks the two shipped defaults agree.
 ProtectSystem=strict
 ReadWritePaths=/srv/ps2
 ProtectHome=read-only

--- a/packaging/systemd/ps2servers@.service
+++ b/packaging/systemd/ps2servers@.service
@@ -1,0 +1,62 @@
+[Unit]
+# A template: %i is the server key -- smbv1, udpfs or udpbd.
+#   systemctl enable --now ps2servers@smbv1
+#
+# Separate from ps2servers-edge.service, which runs the Go build and serves
+# only UDPFS and UDPBD. Edge has no SMB at all, so a user who needs SMB -- the
+# OPL/POPSTARTER case -- cannot use that unit and needs this one.
+Description=PS2 Servers (%i)
+Documentation=https://github.com/NathanNeurotic/PS2-Servers/blob/main/packaging/systemd/README.md
+After=network-online.target local-fs.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ps2servers
+Group=ps2servers
+
+# Per-instance, so each server keeps its own share and port:
+#   /etc/default/ps2servers-smbv1
+EnvironmentFile=/etc/default/ps2servers-%i
+
+# --serve runs one server in this process with no GUI. It is dispatched before
+# anything imports tkinter, so this needs no display, no X and no desktop
+# session -- which is the point of running it under systemd rather than leaving
+# a logged-in session open.
+#
+# $PS2SERVERS_ARGS is deliberately unbraced: systemd splits an unbraced
+# variable on whitespace into separate arguments, which is how the flags in the
+# env file reach the server. The cost is that a path containing a space cannot
+# be passed this way; keep the share somewhere like /srv/ps2.
+ExecStart=/usr/local/bin/ps2servers --serve %i $PS2SERVERS_ARGS
+
+Restart=on-failure
+RestartSec=5s
+TimeoutStopSec=15s
+
+# The share is writable on purpose. OPL stores its settings there and a
+# VMC-on-SMB lives there too, so a read-only share silently costs the user
+# their saves. ReadWritePaths is what re-opens it under ProtectSystem=strict.
+ProtectSystem=strict
+ReadWritePaths=/srv/ps2
+ProtectHome=read-only
+
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+RestrictSUIDSGID=true
+LockPersonality=true
+RestrictAddressFamilies=AF_INET AF_UNIX
+SystemCallArchitectures=native
+
+# MemoryDenyWriteExecute is NOT set here, unlike the Edge unit. Edge is a
+# static Go binary; these servers are the Python build, and CPython allocates
+# write-then-execute pages, so the flag would stop the service from starting.
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/test_systemd_units.py
+++ b/tests/test_systemd_units.py
@@ -1,0 +1,142 @@
+"""The headless deployment path has to keep working unattended.
+
+Someone running PS2 Servers under systemd is not watching a window, and the
+ways this breaks are all silent: a flag renamed out from under the env file, an
+instance name that is not a real server key, or an import added to the launcher
+that drags in tkinter and makes every service on a machine with no display fail
+to start.
+
+Requested by a Linux user who wanted to log out and have the server keep
+running. Edge already had a unit but Edge serves no SMB, which is exactly what
+that user needed.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import unittest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+_SYSTEMD = os.path.join(_ROOT, "packaging", "systemd")
+
+from launcher.servers import REGISTRY  # noqa: E402
+
+
+def _read(name):
+    with open(os.path.join(_SYSTEMD, name), "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _directives(name):
+    """The unit's actual settings, with comments stripped.
+
+    Parsed rather than grepped, because these files explain themselves: a
+    comment saying why a directive is deliberately absent would otherwise read
+    as the directive being present.
+    """
+    settings = {}
+    for line in _read(name).splitlines():
+        line = line.strip()
+        if not line or line.startswith(("#", ";", "[")):
+            continue
+        if "=" in line:
+            key, value = line.split("=", 1)
+            settings.setdefault(key.strip(), []).append(value.strip())
+    return settings
+
+
+class HeadlessGuarantee(unittest.TestCase):
+    def test_serve_does_not_import_tkinter(self):
+        """The whole reason a systemd unit is possible.
+
+        --serve is dispatched before the GUI is imported. If that ever stops
+        being true, every headless install breaks at once with an import error
+        about a missing display, and nobody running a service would connect it
+        to a launcher change.
+        """
+        code = (
+            "import sys; sys.argv = ['x', '--serve', 'smbv1', '--help'];"
+            "import launcher.main;"
+            "sys.exit(1 if 'tkinter' in sys.modules else 0)"
+        )
+        result = subprocess.run([sys.executable, "-c", code], cwd=_ROOT,
+                                capture_output=True, text=True, timeout=120)
+        self.assertEqual(
+            result.returncode, 0,
+            "importing launcher.main pulled in tkinter; --serve must stay "
+            "usable on a machine with no display.\n" + result.stderr[-500:])
+
+
+class UnitFiles(unittest.TestCase):
+    def test_template_instance_keys_are_real_servers(self):
+        # The unit passes %i straight to --serve, so a name in the docs that is
+        # not a registry key produces a service that starts and immediately
+        # fails.
+        readme = _read("README.md")
+        for key in re.findall(r"ps2servers@([a-z0-9]+)", readme):
+            with self.subTest(key=key):
+                self.assertIn(key, REGISTRY,
+                              f"README references ps2servers@{key} but {key!r} "
+                              "is not a server key")
+
+    def test_template_uses_unbraced_args_so_they_split(self):
+        # systemd splits an unbraced $VAR into separate arguments and does not
+        # split ${VAR}. Braced here would hand the server one long argument.
+        exec_start = _directives("ps2servers@.service")["ExecStart"][0]
+        self.assertIn("--serve %i $PS2SERVERS_ARGS", exec_start)
+        self.assertNotIn("${PS2SERVERS_ARGS}", exec_start)
+
+    def test_share_is_writable_under_protectsystem_strict(self):
+        # ProtectSystem=strict without ReadWritePaths makes the whole
+        # filesystem read-only, and OPL writes its settings to the share. The
+        # failure would look like a network problem, not a permissions one.
+        unit = _directives("ps2servers@.service")
+        self.assertEqual(unit.get("ProtectSystem"), ["strict"])
+        self.assertTrue(unit.get("ReadWritePaths"),
+                        "the share must be writable or OPL cannot save")
+
+    def test_no_memory_deny_write_execute_for_the_python_build(self):
+        # Set on the Edge unit, which is a static Go binary. CPython allocates
+        # write-then-execute pages, so the same directive here would stop the
+        # service from starting at all.
+        self.assertNotIn("MemoryDenyWriteExecute", _directives("ps2servers@.service"))
+        self.assertIn("MemoryDenyWriteExecute", _directives("ps2servers-edge.service"))
+
+
+class EnvFileFlagsAreReal(unittest.TestCase):
+    def test_every_flag_in_the_env_file_exists(self):
+        """A renamed flag would leave the env file pointing at nothing.
+
+        Checked against the server's own --help rather than a hardcoded list,
+        so this fails when the CLI changes rather than when someone remembers
+        to update a test.
+        """
+        env = _read("ps2servers-smbv1.env")
+        args = ""
+        for line in env.splitlines():
+            if line.startswith("PS2SERVERS_ARGS="):
+                args = line.split("=", 1)[1]
+        self.assertTrue(args, "no PS2SERVERS_ARGS line in the env file")
+
+        flags = [tok for tok in args.split() if tok.startswith("--")]
+        self.assertTrue(flags, "env file passes no flags")
+
+        entry = REGISTRY["smbv1"]
+        help_text = subprocess.run(
+            [sys.executable, entry.module_file, "--help"],
+            capture_output=True, text=True, timeout=120).stdout
+
+        for flag in flags:
+            name = flag.split("=", 1)[0]
+            with self.subTest(flag=name):
+                self.assertIn(name, help_text,
+                              f"{name} is in the env file but not in the "
+                              "smbv1 server's --help")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_systemd_units.py
+++ b/tests/test_systemd_units.py
@@ -53,22 +53,42 @@ class HeadlessGuarantee(unittest.TestCase):
     def test_serve_does_not_import_tkinter(self):
         """The whole reason a systemd unit is possible.
 
-        --serve is dispatched before the GUI is imported. If that ever stops
-        being true, every headless install breaks at once with an import error
-        about a missing display, and nobody running a service would connect it
-        to a launcher change.
+        --serve must reach a running server without the GUI. If that stops
+        being true, every headless install breaks at once with an error about a
+        missing display, and nobody running a service would connect it to a
+        launcher change.
+
+        main() is CALLED, not merely imported. An earlier version of this test
+        only imported launcher.main and checked sys.modules, which sounded
+        equivalent and was not: an `import tkinter` placed directly in
+        launcher/serve.py still passed it, because nothing ever executed the
+        dispatch. Verified by doing exactly that before rewriting it.
+
+        --help makes the server's own argparse exit as soon as it is reached,
+        so this walks the whole path -- main() -> run_serve() -> the server
+        module -- without binding a socket.
         """
         code = (
-            "import sys; sys.argv = ['x', '--serve', 'smbv1', '--help'];"
-            "import launcher.main;"
-            "sys.exit(1 if 'tkinter' in sys.modules else 0)"
+            "import sys\n"
+            "import launcher.main\n"
+            "try:\n"
+            "    launcher.main.main(['--serve', 'smbv1', '--help'])\n"
+            "except SystemExit:\n"
+            "    pass\n"
+            "sys.stderr.write('REACHED\\n')\n"
+            "sys.exit(1 if 'tkinter' in sys.modules else 0)\n"
         )
         result = subprocess.run([sys.executable, "-c", code], cwd=_ROOT,
                                 capture_output=True, text=True, timeout=120)
+        # Proves the dispatch actually ran. Without it a crash on the way in
+        # would look like a pass, since tkinter would not be loaded either.
+        self.assertIn("REACHED", result.stderr,
+                      "the --serve dispatch did not complete, so this test "
+                      "proved nothing:\n" + result.stderr[-800:])
         self.assertEqual(
             result.returncode, 0,
-            "importing launcher.main pulled in tkinter; --serve must stay "
-            "usable on a machine with no display.\n" + result.stderr[-500:])
+            "the --serve path pulled in tkinter; it must stay usable on a "
+            "machine with no display.\n" + result.stderr[-500:])
 
 
 class UnitFiles(unittest.TestCase):
@@ -98,6 +118,38 @@ class UnitFiles(unittest.TestCase):
         self.assertEqual(unit.get("ProtectSystem"), ["strict"])
         self.assertTrue(unit.get("ReadWritePaths"),
                         "the share must be writable or OPL cannot save")
+
+    def test_shipped_share_path_is_actually_writable(self):
+        """The two shipped files must agree on the share path.
+
+        ProtectSystem=strict re-opens only what ReadWritePaths lists, so an
+        env file pointing --share somewhere the unit does not cover produces a
+        share that reads fine and silently cannot be written. Nothing reports
+        it -- the server starts and the game list loads.
+
+        This checks only the defaults we ship. A user who moves the share has
+        to edit both, which the unit and the README now say in the places they
+        would be reading.
+        """
+        share = None
+        for line in _read("ps2servers-smbv1.env").splitlines():
+            if line.startswith("PS2SERVERS_ARGS="):
+                for token in line.split("=", 1)[1].split():
+                    if token.startswith("games=") or "=" in token and "/" in token:
+                        candidate = token.split("=", 1)[1]
+                        if candidate.startswith("/"):
+                            share = candidate
+        self.assertIsNotNone(share, "no --share path found in the env file")
+
+        writable = _directives("ps2servers@.service").get("ReadWritePaths", [])
+        covered = any(
+            share == path or share.startswith(path.rstrip("/") + "/")
+            for path in (p.lstrip("-") for p in writable))
+        self.assertTrue(
+            covered,
+            f"the env file shares {share} but the unit only makes {writable} "
+            "writable; under ProtectSystem=strict that share cannot be written "
+            "and OPL's saves would fail silently")
 
     def test_no_memory_deny_write_execute_for_the_python_build(self):
         # Set on the Edge unit, which is a static Go binary. CPython allocates

--- a/tests/test_systemd_units.py
+++ b/tests/test_systemd_units.py
@@ -31,22 +31,39 @@ def _read(name):
         return handle.read()
 
 
-def _directives(name):
-    """The unit's actual settings, with comments stripped.
+def _directives(name, section="Service"):
+    """One section's settings, with comments stripped.
 
     Parsed rather than grepped, because these files explain themselves: a
     comment saying why a directive is deliberately absent would otherwise read
     as the directive being present.
+
+    Section-aware on purpose. A flat parse would let a directive in [Unit]
+    satisfy an assertion about [Service], which is not merely untidy -- systemd
+    ignores a [Service] directive placed in [Unit], so the test would pass
+    while the setting did nothing.
     """
     settings = {}
+    current = None
     for line in _read(name).splitlines():
         line = line.strip()
-        if not line or line.startswith(("#", ";", "[")):
+        if not line or line.startswith(("#", ";")):
             continue
-        if "=" in line:
+        if line.startswith("[") and line.endswith("]"):
+            current = line[1:-1]
+            continue
+        if current == section and "=" in line:
             key, value = line.split("=", 1)
             settings.setdefault(key.strip(), []).append(value.strip())
     return settings
+
+
+def _env_args(name):
+    """The PS2SERVERS_ARGS token list from an env file."""
+    for line in _read(name).splitlines():
+        if line.startswith("PS2SERVERS_ARGS="):
+            return line.split("=", 1)[1].split()
+    return []
 
 
 class HeadlessGuarantee(unittest.TestCase):
@@ -80,11 +97,18 @@ class HeadlessGuarantee(unittest.TestCase):
         )
         result = subprocess.run([sys.executable, "-c", code], cwd=_ROOT,
                                 capture_output=True, text=True, timeout=120)
-        # Proves the dispatch actually ran. Without it a crash on the way in
-        # would look like a pass, since tkinter would not be loaded either.
+        # Proves the dispatch reached the SERVER, not merely that main()
+        # returned. `except SystemExit` also swallows run_serve's own early
+        # bail-outs ("unknown server", missing module), and in those cases
+        # tkinter would not be loaded either -- so without this the test could
+        # pass having executed almost nothing. This string comes from
+        # smbserver_opl.py's own argparse description.
         self.assertIn("REACHED", result.stderr,
-                      "the --serve dispatch did not complete, so this test "
-                      "proved nothing:\n" + result.stderr[-800:])
+                      "the --serve dispatch did not complete:\n" + result.stderr[-800:])
+        self.assertIn("Minimal SMBv1 server", result.stdout,
+                      "the server's own --help never printed, so the dispatch "
+                      "bailed out before reaching it and this test proved "
+                      "nothing:\n" + result.stdout[-800:] + result.stderr[-800:])
         self.assertEqual(
             result.returncode, 0,
             "the --serve path pulled in tkinter; it must stay usable on a "
@@ -106,9 +130,14 @@ class UnitFiles(unittest.TestCase):
     def test_template_uses_unbraced_args_so_they_split(self):
         # systemd splits an unbraced $VAR into separate arguments and does not
         # split ${VAR}. Braced here would hand the server one long argument.
+        #
+        # Matched exactly, not with assertIn: a substring check passes on
+        # $PS2SERVERS_ARGS_EXTRA, which expands to a different (unset)
+        # variable and silently drops every flag.
         exec_start = _directives("ps2servers@.service")["ExecStart"][0]
-        self.assertIn("--serve %i $PS2SERVERS_ARGS", exec_start)
-        self.assertNotIn("${PS2SERVERS_ARGS}", exec_start)
+        self.assertTrue(
+            exec_start.endswith("--serve %i $PS2SERVERS_ARGS"),
+            f"ExecStart must end with the exact unbraced variable, got: {exec_start}")
 
     def test_share_is_writable_under_protectsystem_strict(self):
         # ProtectSystem=strict without ReadWritePaths makes the whole
@@ -131,25 +160,58 @@ class UnitFiles(unittest.TestCase):
         to edit both, which the unit and the README now say in the places they
         would be reading.
         """
-        share = None
-        for line in _read("ps2servers-smbv1.env").splitlines():
-            if line.startswith("PS2SERVERS_ARGS="):
-                for token in line.split("=", 1)[1].split():
-                    if token.startswith("games=") or "=" in token and "/" in token:
-                        candidate = token.split("=", 1)[1]
-                        if candidate.startswith("/"):
-                            share = candidate
-        self.assertIsNotNone(share, "no --share path found in the env file")
+        # EVERY absolute path in the args, not just the last one seen. An
+        # earlier version overwrote a single variable as it scanned, so a
+        # second --share would have gone unchecked -- exactly the mistake this
+        # test exists to catch in the config it validates.
+        shares = [tok.split("=", 1)[1] for tok in _env_args("ps2servers-smbv1.env")
+                  if "=" in tok and tok.split("=", 1)[1].startswith("/")]
+        self.assertTrue(shares, "no --share path found in the env file")
 
+        writable = [p.lstrip("-") for p in
+                    _directives("ps2servers@.service").get("ReadWritePaths", [])]
+        for share in shares:
+            covered = any(share == path or share.startswith(path.rstrip("/") + "/")
+                          for path in writable)
+            self.assertTrue(
+                covered,
+                f"the env file shares {share} but the unit only makes {writable} "
+                "writable; under ProtectSystem=strict that share cannot be written "
+                "and OPL's saves would fail silently")
+
+    def test_every_advertised_instance_ships_an_env_file(self):
+        """The env file is required, so an advertised instance without one fails.
+
+        ps2servers@.service does not mark EnvironmentFile optional, so
+        `systemctl enable --now ps2servers@udpfs` dies before ExecStart with
+        "Failed to load environment files" if no sample was ever shipped for
+        that key -- and the user has nothing to copy, because the flag set
+        appears nowhere else.
+        """
+        readme = _read("README.md")
+        for key in sorted(set(re.findall(r"ps2servers@([a-z0-9]+)", readme))):
+            with self.subTest(key=key):
+                path = os.path.join(_SYSTEMD, f"ps2servers-{key}.env")
+                self.assertTrue(
+                    os.path.isfile(path),
+                    f"README advertises ps2servers@{key} but "
+                    f"ps2servers-{key}.env does not exist; the unit requires it "
+                    "and the instance would fail before starting")
+                self.assertTrue(
+                    _env_args(f"ps2servers-{key}.env"),
+                    f"ps2servers-{key}.env sets no PS2SERVERS_ARGS; every server "
+                    "here exits immediately without arguments")
+
+    def test_readwritepaths_tolerates_a_missing_directory(self):
+        # Without the `-` prefix a non-existent path is fatal at mount-namespace
+        # setup (226/NAMESPACE) before ExecStart, and Restart=on-failure loops
+        # it. A user serving /mnt/games has no reason to keep an empty /srv/ps2.
         writable = _directives("ps2servers@.service").get("ReadWritePaths", [])
-        covered = any(
-            share == path or share.startswith(path.rstrip("/") + "/")
-            for path in (p.lstrip("-") for p in writable))
-        self.assertTrue(
-            covered,
-            f"the env file shares {share} but the unit only makes {writable} "
-            "writable; under ProtectSystem=strict that share cannot be written "
-            "and OPL's saves would fail silently")
+        for path in writable:
+            self.assertTrue(
+                path.startswith("-"),
+                f"ReadWritePaths={path} is fatal if the directory is missing; "
+                "prefix it with - to make it tolerated")
 
     def test_no_memory_deny_write_execute_for_the_python_build(self):
         # Set on the Edge unit, which is a static Go binary. CPython allocates
@@ -167,27 +229,27 @@ class EnvFileFlagsAreReal(unittest.TestCase):
         so this fails when the CLI changes rather than when someone remembers
         to update a test.
         """
-        env = _read("ps2servers-smbv1.env")
-        args = ""
-        for line in env.splitlines():
-            if line.startswith("PS2SERVERS_ARGS="):
-                args = line.split("=", 1)[1]
-        self.assertTrue(args, "no PS2SERVERS_ARGS line in the env file")
+        for key in ("smbv1", "udpfs", "udpbd"):
+            args = _env_args(f"ps2servers-{key}.env")
+            self.assertTrue(args, f"no PS2SERVERS_ARGS in ps2servers-{key}.env")
 
-        flags = [tok for tok in args.split() if tok.startswith("--")]
-        self.assertTrue(flags, "env file passes no flags")
+            flags = [tok.split("=", 1)[0] for tok in args if tok.startswith("-")]
+            if not flags:
+                continue  # udpbd takes a bare positional image path
 
-        entry = REGISTRY["smbv1"]
-        help_text = subprocess.run(
-            [sys.executable, entry.module_file, "--help"],
-            capture_output=True, text=True, timeout=120).stdout
+            help_text = subprocess.run(
+                [sys.executable, REGISTRY[key].module_file, "--help"],
+                capture_output=True, text=True, timeout=120).stdout
 
-        for flag in flags:
-            name = flag.split("=", 1)[0]
-            with self.subTest(flag=name):
-                self.assertIn(name, help_text,
-                              f"{name} is in the env file but not in the "
-                              "smbv1 server's --help")
+            for flag in flags:
+                with self.subTest(server=key, flag=flag):
+                    # Word-bounded, not a substring search. `--root` appears
+                    # inside `--root-dir`, and a flag named in prose would
+                    # satisfy a plain `in` check while argparse rejects it.
+                    self.assertRegex(
+                        help_text, r"(?<![\w-])" + re.escape(flag) + r"(?![\w-])",
+                        f"{flag} is in ps2servers-{key}.env but is not a real "
+                        f"flag of the {key} server")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
An Ubuntu user asked for a headless mode so they could log out and leave a server running.

**Headless already existed** — `--serve <key>` runs one server in the foreground with no GUI, and it's dispatched before anything imports tkinter, so it needs no X and no display. What was missing was anything to point them at: the only systemd unit here is for the Go **Edge** build, and **Edge serves no SMB at all**. SMB was exactly what they needed, since that's what OPL's game list and POPSTARTER use.

`ps2servers@.service` is a template, so the instance name is the server key and one file covers all three:

```sh
systemctl enable --now ps2servers@smbv1
```

## Details that each hide a silent failure

- **`$PS2SERVERS_ARGS` is unbraced on purpose.** systemd splits an unbraced variable on whitespace into separate arguments and does *not* split `${VAR}` — braced, the server gets one long argument and rejects it. Cost: a share path can't contain a space, which the env file says.
- **`ProtectSystem=strict` + `ReadWritePaths`**, because the share must be writable. OPL stores its settings there and a VMC-on-SMB lives there, so a read-only share costs the user their saves — and it surfaces looking like a network problem.
- **`MemoryDenyWriteExecute` deliberately absent**, unlike the Edge unit. Edge is a static Go binary; this runs the Python build, and CPython allocates write-then-execute pages, so the directive would stop the service starting at all.
- **Port 1111, not 445.** Binding 445 needs root, and on a box already running Samba it's taken — which is usually why someone is running this.

## Tested, not asserted

The headless guarantee is pinned by actually importing `launcher.main` with `--serve` in argv and failing if `tkinter` lands in `sys.modules`. If a GUI import ever creeps into the launcher, every headless install breaks at once with an error nobody would trace back to a launcher change.

Env-file flags are checked against the server's real `--help`, template instance names against the actual registry, and unit directives are parsed rather than grepped — the first version of that test failed on its own explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added systemd service support for running PS2 Servers as headless instances on standard Linux systems.
  - Added an SMBv1 configuration for sharing the games directory on port 1111.
  - Added service hardening and automatic restart behavior.

- **Documentation**
  - Expanded deployment instructions for standard Linux systems and lightweight Edge devices.
  - Clarified when to use each systemd service variant and documented instance configuration, SMB settings, and share permissions.

- **Tests**
  - Added coverage validating service configuration, headless operation, security settings, and SMBv1 options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->