### PR TITLE
fix(udpfs): close sessions after their workers stop, not under a mutex

### DIFF
--- a/native/ps2servers-edge/internal/udpfs/server.go
+++ b/native/ps2servers-edge/internal/udpfs/server.go
@@ -268,15 +268,35 @@ func (s *Server) Close() error {
 		if s.data != nil && s.data != s.discovery {
 			_ = s.data.Close()
 		}
+		// Workers are stopped and drained BEFORE their session state is
+		// closed, rather than closing it under State.Mu.
+		//
+		// Taking that mutex here looked sufficient and was not: a peer worker
+		// owns its own state and reads it without locking -- correct, since
+		// exactly one goroutine handles a given peer -- so the mutex only ever
+		// held one side of the pair. Closing a session while its worker was
+		// mid-request was a real data race between State.ResetWrite and
+		// handleWriteData's read of WriteActive, and on shutdown during an
+		// active write it could free handles from under the goroutine using
+		// them. Found by the race detector in CI, intermittently, because it
+		// needs a write in flight at the moment of shutdown.
 		s.sessionsMu.Lock()
+		workers := make([]*peerWorker, 0, len(s.sessions))
 		for _, w := range s.sessions {
-			w.state.Mu.Lock()
-			w.state.Close()
-			w.state.Mu.Unlock()
-			w.stop()
+			workers = append(workers, w)
 		}
 		s.sessions = map[string]*peerWorker{}
 		s.sessionsMu.Unlock()
+
+		for _, w := range workers {
+			w.stop()
+		}
+		// Every worker is in s.wg, so this returns only once none of them can
+		// still be touching a session.
+		s.wg.Wait()
+		for _, w := range workers {
+			w.state.Close()
+		}
 	})
 	s.wg.Wait()
 	return err


### PR DESCRIPTION
The race detector caught this in CI, intermittently — it needs a write in flight at the moment of shutdown.

`Server.Close` took each session's `State.Mu` before calling `State.Close`. That looked sufficient and wasn't: **a peer worker owns its own state and reads it without locking** — correct by design, since exactly one goroutine handles a given peer — so the mutex only ever held one side of the pair.

Closing a session while its worker was mid-request raced `State.ResetWrite` against `handleWriteData`'s read of `WriteActive`. And worse than the race itself: it freed handles from under the goroutine still using them.

## Fixed by ordering, not more locking

More locking cannot work when one side deliberately doesn't lock. `Close` now snapshots the workers, clears the map, signals every worker to stop, and waits on `s.wg` — which every worker is registered in — **before** touching any session state. By the time `State.Close` runs, no goroutine can still be inside a handler.

Verified with the CI test at `-count=30` under `-race`, and the full package suite under `-race`.

## Why this is separate

It surfaced on the SMB branch but has nothing to do with SMB — it's a shutdown bug in udpfs that predates it, and it will intermittently redden *any* PR until it's fixed. That branch only touched udpfs via `gofmt` field alignment.

## Noted, not fixed

`internal/udpbd`'s `TestReadsMatchTheImageAcrossBlockRegimes` fails under `-count=3` **on main as well**, and passes in isolation. CI runs `-count=1` so it never sees it. The symptom is a UDP read timeout rather than a race, which points at a fixed port or a timing assumption that doesn't survive repetition — worth its own cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)