### PR TITLE
feat(edge): let the packaging start SMB, and let SMB answer status queries

### DIFF
--- a/docs/OPENWRT.md
+++ b/docs/OPENWRT.md
@@ -87,7 +87,7 @@ the service runs as, not by root. An image owned by `root:root` with mode `0644`
 produces a share that mounts and then fails every write.
 
 This is distinct from the `udpbd` subcommand, which speaks a different protocol
-on its own port. The package's init script starts `udpfs` only.
+on its own port and has its own config section — see below.
 
 ### Compression and metrics
 
@@ -147,12 +147,17 @@ Both are read-only by default here, for the same reason `udpfs` is.
 
 `status_port` answers router status queries, so a launcher can show whether the
 box is ready and whether a transfer is in flight — the point being not to cut
-power to a board mid-write. `-1` uses the standard discovery port.
+power to a board mid-write. `0` is off; `-1` is the standard discovery port.
 
-When `udpfs` is also enabled it already owns that address, so the `smb` and
-`udpbd` instances log that the status channel is unavailable and carry on
-serving. That is deliberate: losing a diagnostic should never take down the
-service it reports on. Set `0` to disable it outright.
+**Only one service should claim it.** That port is `udpfs`'s, and `udpfs`
+already serves discovery on it, so `smb` and `udpbd` ship with `status_port
+'0'`. Setting several to `-1` would not break anything — a bind failure there
+is logged and the service carries on — but *which* one answered would depend on
+the order `procd` happened to start them, so a launcher would get a different
+service's status across a reboot for no visible reason.
+
+Set `-1` on `smb` or `udpbd` when it is the only service enabled on the
+board.
 
 ### A bad value restarts the service in a loop
 

--- a/docs/OPENWRT.md
+++ b/docs/OPENWRT.md
@@ -106,6 +106,54 @@ not load compressed games.
 to syslog, and a router logging a snapshot every minute indefinitely is a cost
 worth opting into rather than inheriting.
 
+## Serving SMB, and running more than one service
+
+Edge serves three protocols, and the package starts each as its own `procd`
+instance, so a board can run several at once. Each has its own config section
+and its own `enabled` flag.
+
+**SMB is what OPL's network game list and POPSTARTER use.** Before Edge gained
+it, a router had to fall back on the host's Samba — which modern builds ship
+with SMBv1 disabled and OPL cannot talk to. It is off by default because
+enabling it exposes a share with no password, which should be a decision rather
+than something inherited from an upgrade.
+
+```
+config smb 'smb'
+        option enabled '1'
+        option share 'games=/mnt/sda1/PS2'
+        option port '1111'
+        option read_only '0'
+```
+
+`share` is `NAME=PATH`, and several may be given separated by spaces — so a
+share path cannot contain one.
+
+**Set OPL's *SMB Port* to 1111.** Not 445: ports below 1024 need root and this
+runs as `ps2edge`.
+
+`udpbd` serves **one disk image** rather than a directory, unlike `udpfs` and
+`smb`:
+
+```
+config udpbd 'udpbd'
+        option enabled '1'
+        option image '/mnt/sda1/ps2.img'
+```
+
+Both are read-only by default here, for the same reason `udpfs` is.
+
+### Telling a launcher the board is ready
+
+`status_port` answers router status queries, so a launcher can show whether the
+box is ready and whether a transfer is in flight — the point being not to cut
+power to a board mid-write. `-1` uses the standard discovery port.
+
+When `udpfs` is also enabled it already owns that address, so the `smb` and
+`udpbd` instances log that the status channel is unavailable and carry on
+serving. That is deliberate: losing a diagnostic should never take down the
+service it reports on. Set `0` to disable it outright.
+
 ### A bad value restarts the service in a loop
 
 Edge validates these options at startup and exits with status 2 when one is out

--- a/native/ps2servers-edge/cmd/ps2servers-edge/main.go
+++ b/native/ps2servers-edge/cmd/ps2servers-edge/main.go
@@ -257,6 +257,8 @@ func runUDPBD() {
 	bind := fs.String("bind", env("BIND", "0.0.0.0"), "IPv4 bind address")
 	port := fs.Int("port", envInt("UDPBD_PORT", udpbd.Port), "UDP port (default 0xBDBD)")
 	readOnly := fs.Bool("read-only", envBool("RO", false), "serve the image read-only")
+	bdStatusPort := fs.Int("status-port", envInt("STATUS_PORT", -1),
+		"UDP port answering router status queries; 0 disables")
 	logFormat := fs.String("log-format", env("LOG_FORMAT", "text"), "text or json")
 	verbose := fs.Bool("verbose", envBool("VERBOSE", false), "verbose protocol logging")
 	quiet := fs.Bool("quiet", false, "suppress informational logs")
@@ -278,7 +280,8 @@ func runUDPBD() {
 	}
 	logger := edgelog.New(os.Stdout, *logFormat, *quiet, *verbose)
 	server, err := udpbd.New(udpbd.Config{
-		Image: *image, Bind: *bind, Port: *port, ReadOnly: *readOnly, Log: logger,
+		Image: *image, Bind: *bind, Port: *port, ReadOnly: *readOnly,
+		StatusPort: *bdStatusPort, Log: logger,
 	})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
@@ -310,6 +313,11 @@ func runSMB() {
 	// init and the systemd unit run Edge unprivileged. See smb.DefaultPort.
 	port := fs.Int("port", envInt("SMB_PORT", smb.DefaultPort), "TCP port (set OPL's SMB Port to match)")
 	readOnly := fs.Bool("read-only", envBool("RO", false), "serve the shares read-only")
+	// Negative means the standard discovery port. A box already running Edge's
+	// udpfs owns that address, so the bind failure is logged and ignored --
+	// see smb.Config.StatusPort.
+	statusPort := fs.Int("status-port", envInt("STATUS_PORT", -1),
+		"UDP port answering router status queries; 0 disables")
 	logFormat := fs.String("log-format", env("LOG_FORMAT", "text"), "text or json")
 	verbose := fs.Bool("verbose", envBool("VERBOSE", false), "verbose protocol logging")
 	quiet := fs.Bool("quiet", false, "suppress informational logs")
@@ -345,7 +353,8 @@ func runSMB() {
 	}
 
 	server, err := smb.New(smb.Config{
-		Shares: parsed, Bind: *bind, Port: *port, ReadOnly: *readOnly, Log: logger,
+		Shares: parsed, Bind: *bind, Port: *port, ReadOnly: *readOnly,
+		StatusPort: *statusPort, Log: logger,
 	})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)

--- a/native/ps2servers-edge/internal/smb/server.go
+++ b/native/ps2servers-edge/internal/smb/server.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/filesystem"
 	edgelog "github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/protocol"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/statuslistener"
 )
 
 // Capability bits advertised in the NEGOTIATE reply.
@@ -63,6 +65,15 @@ type Config struct {
 	Port     int
 	ReadOnly bool
 	Log      *edgelog.Logger
+	// StatusPort answers router status queries, so a launcher can tell whether
+	// this server is ready and whether a transfer is in flight. Zero disables
+	// it; negative means "use the standard port".
+	//
+	// The standard port is UDPFS's discovery port, which is what a client
+	// probes. On a box already running Edge's udpfs that address is
+	// legitimately taken, and the failure is logged and ignored rather than
+	// taking SMB down over a diagnostic.
+	StatusPort int
 }
 
 // Server serves SMBv1 to Open-PS2-Loader.
@@ -86,6 +97,9 @@ type Server struct {
 	wg        sync.WaitGroup
 	closeOnce sync.Once
 	closed    chan struct{}
+
+	started time.Time
+	status  *statuslistener.Listener
 }
 
 // idleTimeout bounds how long a connection may sit without sending anything.
@@ -113,11 +127,12 @@ func New(cfg Config) (*Server, error) {
 		cfg.Log = edgelog.New(os.Stdout, "text", false, false)
 	}
 	s := &Server{
-		live:   make(map[net.Conn]struct{}),
-		cfg:    cfg,
-		shares: make(map[string]Share, len(cfg.Shares)),
-		sem:    make(chan struct{}, MaxConnections),
-		closed: make(chan struct{}),
+		live:    make(map[net.Conn]struct{}),
+		cfg:     cfg,
+		shares:  make(map[string]Share, len(cfg.Shares)),
+		sem:     make(chan struct{}, MaxConnections),
+		closed:  make(chan struct{}),
+		started: time.Now(),
 	}
 	for _, sh := range cfg.Shares {
 		// Keyed lowercase: SMB share names are case-insensitive, and matching
@@ -144,7 +159,76 @@ func (s *Server) Listen() error {
 		return err
 	}
 	s.listener = ln
+
+	if s.cfg.StatusPort != 0 {
+		port := s.cfg.StatusPort
+		if port < 0 {
+			port = int(protocol.DefaultPort)
+		}
+		sl, err := statuslistener.Start(s.cfg.Bind, port, s.statusReply, s.cfg.Log)
+		if err != nil {
+			// Non-fatal on purpose: see Config.StatusPort. Losing the status
+			// channel is a smaller harm than refusing to serve SMB.
+			s.cfg.Log.Warn("SMB status channel unavailable", map[string]any{
+				"port": port, "error": err.Error()})
+		} else {
+			s.status = sl
+			s.cfg.Log.Info("SMB status channel", map[string]any{"addr": sl.Addr().String()})
+		}
+	}
 	return nil
+}
+
+// statusReply reports what this server is doing, for the router status
+// protocol. See docs/ROUTER-STATUS.md.
+func (s *Server) statusReply() protocol.StatusReply {
+	flags := protocol.FlagServesSMB
+	if s.cfg.ReadOnly {
+		flags |= protocol.FlagReadOnly
+	}
+
+	s.mu.Lock()
+	sessions := len(s.live)
+	stopping := s.stopping
+	s.mu.Unlock()
+
+	state := protocol.StateReady
+	switch {
+	case stopping:
+		state = protocol.StateStopping
+	case s.sharesUnreadable():
+		// The ordinary hardware failure on a router: the USB stick went away.
+		// Reporting ready would send someone hunting the network for what is a
+		// storage fault.
+		state = protocol.StateDegraded
+	case sessions > 0:
+		// Busy is per-connection rather than per-transfer here. SMB has no
+		// idle state a server can see -- a console keeps the connection open
+		// across a whole game load -- so a live connection is the closest
+		// honest answer to "is something happening", and it is the one that
+		// matters for "do not cut power".
+		state = protocol.StateBusy
+	}
+
+	return protocol.StatusReply{
+		State:    state,
+		Flags:    flags,
+		Sessions: uint16(sessions),
+		Uptime:   statuslistener.Uptime(s.started),
+		Name:     "PS2 Servers Edge",
+	}
+}
+
+func (s *Server) sharesUnreadable() bool {
+	for _, sh := range s.cfg.Shares {
+		if sh.Root == nil {
+			return true
+		}
+		if info, err := os.Stat(sh.Root.Path()); err != nil || !info.IsDir() {
+			return true
+		}
+	}
+	return false
 }
 
 func itoa(n int) string {
@@ -245,6 +329,7 @@ func (s *Server) Close() error {
 			_ = c.Close()
 		}
 		s.mu.Unlock()
+		_ = s.status.Close()
 	})
 	s.wg.Wait()
 	return nil

--- a/native/ps2servers-edge/internal/smb/status_test.go
+++ b/native/ps2servers-edge/internal/smb/status_test.go
@@ -1,0 +1,208 @@
+package smb
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/filesystem"
+	edgelog "github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/protocol"
+)
+
+// The router status protocol exists because a board serving a console should
+// be able to say whether it is ready. Before this, only UDPFS answered -- so a
+// router running SMB, which is the case the protocol was actually requested
+// for, went dark to the launcher on the one service it was built to provide.
+
+func startSMBWithStatus(t *testing.T, root string, readOnly bool) *Server {
+	t.Helper()
+	r, err := filesystem.Open(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := New(Config{
+		Shares:     []Share{{Name: "games", Root: r}},
+		Bind:       "127.0.0.1",
+		Port:       0,
+		ReadOnly:   readOnly,
+		StatusPort: 0, // replaced below with an ephemeral port
+		Log:        edgelog.New(discardWriter{}, "text", true, false),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Ephemeral rather than the standard port: the tests must not fight each
+	// other, or a udpfs server on the same machine, for a fixed address.
+	srv.cfg.StatusPort = ephemeralUDP(t)
+	if err := srv.Listen(); err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = srv.Serve() }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return srv
+}
+
+func ephemeralUDP(t *testing.T) int {
+	t.Helper()
+	c, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := c.LocalAddr().(*net.UDPAddr).Port
+	_ = c.Close()
+	return port
+}
+
+func askStatus(t *testing.T, srv *Server) protocol.StatusReply {
+	t.Helper()
+	addr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: srv.status.Addr().Port}
+	c, err := net.DialUDP("udp4", nil, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if _, err := c.Write(protocol.MarshalStatusQuery()); err != nil {
+		t.Fatal(err)
+	}
+	_ = c.SetReadDeadline(time.Now().Add(3 * time.Second))
+	buf := make([]byte, 1500)
+	n, err := c.Read(buf)
+	if err != nil {
+		t.Fatalf("no status reply from the SMB server: %v", err)
+	}
+	reply, err := protocol.ParseStatusReply(buf[:n])
+	if err != nil {
+		t.Fatalf("status reply did not parse: %v", err)
+	}
+	return reply
+}
+
+func TestSMBAnswersStatusAndSaysItServesSMB(t *testing.T) {
+	srv := startSMBWithStatus(t, t.TempDir(), false)
+	reply := askStatus(t, srv)
+
+	if reply.State != protocol.StateReady {
+		t.Fatalf("state = %v, want ready", reply.State)
+	}
+	if reply.Flags&protocol.FlagServesSMB == 0 {
+		t.Fatal("the SMB flag is not set, so a launcher cannot tell what this is")
+	}
+	if reply.Flags&protocol.FlagReadOnly != 0 {
+		t.Fatal("read-only flag set on a writable server")
+	}
+	if reply.Name == "" {
+		t.Fatal("no server name")
+	}
+}
+
+func TestSMBStatusReportsReadOnly(t *testing.T) {
+	srv := startSMBWithStatus(t, t.TempDir(), true)
+	if reply := askStatus(t, srv); reply.Flags&protocol.FlagReadOnly == 0 {
+		t.Fatal("read-only server did not report it")
+	}
+}
+
+func TestSMBStatusGoesBusyWhileAConsoleIsConnected(t *testing.T) {
+	// SMB has no idle state a server can observe -- a console holds the
+	// connection open across a whole game load -- so a live connection is the
+	// honest answer to "is something happening", and it is the one that
+	// matters for "do not cut power".
+	srv := startSMBWithStatus(t, t.TempDir(), false)
+	if reply := askStatus(t, srv); reply.State != protocol.StateReady {
+		t.Fatalf("state = %v before any connection, want ready", reply.State)
+	}
+
+	c, err := net.Dial("tcp", srv.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		reply := askStatus(t, srv)
+		if reply.State == protocol.StateBusy && reply.Sessions >= 1 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("status never reported busy while a connection was open")
+}
+
+func TestSMBStatusDegradesWhenTheShareVanishes(t *testing.T) {
+	// The ordinary hardware failure on a router: someone pulls the USB stick.
+	// Reporting ready would send them hunting the network for a storage fault.
+	root := filepath.Join(t.TempDir(), "games")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	srv := startSMBWithStatus(t, root, false)
+	if reply := askStatus(t, srv); reply.State != protocol.StateReady {
+		t.Fatalf("state = %v before removal, want ready", reply.State)
+	}
+	if err := os.Remove(root); err != nil {
+		t.Skipf("cannot remove the share root here: %v", err)
+	}
+	if reply := askStatus(t, srv); reply.State != protocol.StateDegraded {
+		t.Fatalf("state = %v after the share vanished, want degraded", reply.State)
+	}
+}
+
+func TestSMBStartsEvenWhenTheStatusPortIsTaken(t *testing.T) {
+	// The standard status port is UDPFS's discovery port, so on a board
+	// already running Edge's udpfs it is legitimately occupied. Refusing to
+	// serve SMB over a diagnostic would be the wrong trade.
+	port := ephemeralUDP(t)
+	squatter, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port})
+	if err != nil {
+		t.Skipf("could not occupy a port to test with: %v", err)
+	}
+	defer squatter.Close()
+
+	r, err := filesystem.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := New(Config{
+		Shares: []Share{{Name: "games", Root: r}}, Bind: "127.0.0.1", Port: 0,
+		StatusPort: port, Log: edgelog.New(discardWriter{}, "text", true, false),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.Listen(); err != nil {
+		t.Fatalf("SMB refused to start because the status port was taken: %v", err)
+	}
+	defer srv.Close()
+	if srv.status != nil {
+		t.Fatal("status listener claims to have bound an occupied port")
+	}
+	// And SMB itself must still be serving.
+	if srv.Addr() == nil {
+		t.Fatal("SMB did not bind")
+	}
+}
+
+func TestStatusCanBeDisabled(t *testing.T) {
+	r, err := filesystem.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := New(Config{
+		Shares: []Share{{Name: "games", Root: r}}, Bind: "127.0.0.1", Port: 0,
+		StatusPort: 0, Log: edgelog.New(discardWriter{}, "text", true, false),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.Listen(); err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	if srv.status != nil {
+		t.Fatal("StatusPort 0 should disable the listener entirely")
+	}
+}

--- a/native/ps2servers-edge/internal/statuslistener/listener.go
+++ b/native/ps2servers-edge/internal/statuslistener/listener.go
@@ -1,0 +1,108 @@
+// Package statuslistener answers router status queries for a server that has
+// no UDP socket of its own.
+//
+// UDPFS handles these inline, because the query arrives on the discovery
+// socket it already owns. SMB is TCP and UDPBD listens on its own port, so
+// without this they answer nothing -- and a router serving SMB is exactly the
+// case the status protocol was asked for: the launcher goes dark on the one
+// service the board exists to provide.
+//
+// See docs/ROUTER-STATUS.md for the wire format.
+package statuslistener
+
+import (
+	"net"
+	"time"
+
+	edgelog "github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/protocol"
+)
+
+// State is what the server reports when asked. Called per query, so it must be
+// cheap and safe to call from another goroutine.
+type State func() protocol.StatusReply
+
+// Listener answers status queries on one UDP port.
+type Listener struct {
+	conn  *net.UDPConn
+	state State
+	log   *edgelog.Logger
+	done  chan struct{}
+}
+
+// Start binds the port and begins answering.
+//
+// A bind failure is returned rather than swallowed, but callers are expected
+// to treat it as non-fatal: the standard status port is the UDPFS discovery
+// port, so on a box already running Edge's udpfs the address is legitimately
+// taken. Refusing to start SMB because a status listener could not bind would
+// take the actual service down over a diagnostic one.
+func Start(bind string, port int, state State, log *edgelog.Logger) (*Listener, error) {
+	ip := net.ParseIP(bind)
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: ip, Port: port})
+	if err != nil {
+		return nil, err
+	}
+	l := &Listener{conn: conn, state: state, log: log, done: make(chan struct{})}
+	go l.serve()
+	return l, nil
+}
+
+// Addr reports the bound address.
+func (l *Listener) Addr() *net.UDPAddr {
+	if l == nil || l.conn == nil {
+		return nil
+	}
+	return l.conn.LocalAddr().(*net.UDPAddr)
+}
+
+// Close stops the listener. Safe on a nil receiver, so a caller that treated a
+// bind failure as non-fatal can defer Close unconditionally.
+func (l *Listener) Close() error {
+	if l == nil || l.conn == nil {
+		return nil
+	}
+	select {
+	case <-l.done:
+	default:
+		close(l.done)
+	}
+	return l.conn.Close()
+}
+
+func (l *Listener) serve() {
+	// Small: a status query is ten bytes, and anything larger is not one.
+	// Sizing this to the protocol rather than to a datagram means a flood
+	// cannot make the server allocate.
+	buf := make([]byte, 64)
+	for {
+		n, peer, err := l.conn.ReadFromUDP(buf)
+		if err != nil {
+			select {
+			case <-l.done:
+				return
+			default:
+			}
+			// A read error on a UDP socket is usually one bad datagram, not a
+			// dead socket -- on Windows an ICMP port-unreachable from a peer
+			// that has gone away surfaces here. Keep serving.
+			continue
+		}
+		if !protocol.IsStatusQuery(buf[:n]) {
+			continue
+		}
+		reply := l.state()
+		if _, err := l.conn.WriteToUDP(reply.Marshal(), peer); err != nil && l.log != nil {
+			l.log.Debug("status reply failed", map[string]any{
+				"peer": peer.String(), "error": err.Error()})
+		}
+	}
+}
+
+// Uptime is a convenience for building a reply's uptime field.
+func Uptime(started time.Time) uint32 {
+	if started.IsZero() {
+		return 0
+	}
+	return uint32(time.Since(started).Seconds())
+}

--- a/native/ps2servers-edge/internal/udpbd/server.go
+++ b/native/ps2servers-edge/internal/udpbd/server.go
@@ -8,8 +8,11 @@ import (
 	"net"
 	"os"
 	"sync"
+	"time"
 
 	edgelog "github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/protocol"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/statuslistener"
 )
 
 // Config describes one UDPBD service.
@@ -19,6 +22,11 @@ type Config struct {
 	Port     int
 	ReadOnly bool
 	Log      *edgelog.Logger
+	// StatusPort answers router status queries. Zero disables it; negative
+	// means the standard port, which is UDPFS's discovery port -- legitimately
+	// taken on a box already running that server, so a bind failure is logged
+	// and ignored rather than taking UDPBD down over a diagnostic.
+	StatusPort int
 }
 
 // device is an image file addressed as fixed-size sectors.
@@ -107,6 +115,9 @@ type Server struct {
 
 	totalRead  int64
 	totalWrite int64
+
+	started time.Time
+	status  *statuslistener.Listener
 }
 
 func New(cfg Config) (*Server, error) {
@@ -130,7 +141,7 @@ func New(cfg Config) (*Server, error) {
 		dev.close()
 		return nil, fmt.Errorf("image is smaller than one %d-byte sector", SectorSize)
 	}
-	return &Server{cfg: cfg, dev: dev, seen: make(map[string]bool)}, nil
+	return &Server{cfg: cfg, dev: dev, seen: make(map[string]bool), started: time.Now()}, nil
 }
 
 // Listen binds the UDPBD port.
@@ -155,7 +166,46 @@ func (s *Server) Addr() *net.UDPAddr {
 	return s.conn.LocalAddr().(*net.UDPAddr)
 }
 
+// statusReply reports what this server is doing, for the router status
+// protocol. See docs/ROUTER-STATUS.md.
+func (s *Server) statusReply() protocol.StatusReply {
+	flags := protocol.FlagServesUDPBD
+	if s.dev != nil && s.dev.readOnly {
+		flags |= protocol.FlagReadOnly
+	}
+
+	state := protocol.StateReady
+	if s.dev == nil || s.dev.file == nil {
+		state = protocol.StateDegraded
+	} else if _, err := os.Stat(s.dev.path); err != nil {
+		// The image went away -- an unmounted USB stick, most likely, which is
+		// the ordinary failure on this hardware.
+		state = protocol.StateDegraded
+	}
+
+	s.mu.Lock()
+	peers := len(s.seen)
+	// left > 0 is a write with bytes still outstanding. There is no separate
+	// "active" flag: a completed write leaves left at zero.
+	writing := s.write.left > 0
+	s.mu.Unlock()
+	if state == protocol.StateReady && writing {
+		// Only a write in flight counts as busy. That is the case worth
+		// warning about: cutting power mid-write is what costs a save.
+		state = protocol.StateBusy
+	}
+
+	return protocol.StatusReply{
+		State:    state,
+		Flags:    flags,
+		Sessions: uint16(peers),
+		Uptime:   statuslistener.Uptime(s.started),
+		Name:     "PS2 Servers Edge",
+	}
+}
+
 func (s *Server) Close() error {
+	_ = s.status.Close()
 	if s.conn != nil {
 		err := s.conn.Close()
 		s.dev.close()
@@ -176,6 +226,20 @@ func (s *Server) Serve(ctx context.Context) error {
 	if s.dev.readOnly {
 		mode = "read-only"
 	}
+	if s.cfg.StatusPort != 0 {
+		port := s.cfg.StatusPort
+		if port < 0 {
+			port = int(protocol.DefaultPort)
+		}
+		if sl, err := statuslistener.Start(s.cfg.Bind, port, s.statusReply, s.cfg.Log); err != nil {
+			s.cfg.Log.Warn("UDPBD status channel unavailable", map[string]any{
+				"port": port, "error": err.Error()})
+		} else {
+			s.status = sl
+			s.cfg.Log.Info("UDPBD status channel", map[string]any{"addr": sl.Addr().String()})
+		}
+	}
+
 	s.cfg.Log.Info("UDPBD listening", map[string]any{
 		"image":   s.dev.path,
 		"mode":    mode,

--- a/packaging/openwrt/files/ps2servers-edge.config
+++ b/packaging/openwrt/files/ps2servers-edge.config
@@ -17,3 +17,37 @@ config udpfs 'main'
         option compression_cache_size '32'
         option metrics '0'
         option metrics_period '1m'
+
+# SMB is what OPL's network game list and POPSTARTER use. Edge could not serve
+# it at all before, so a router had to run the host's Samba -- which modern
+# distributions ship with SMBv1 disabled, and which OPL cannot talk to.
+#
+# Off by default: enabling it binds a port and exposes a share with no
+# password, which should be a decision rather than a side effect of upgrading.
+config smb 'smb'
+        option enabled '0'
+        # NAME=PATH, repeatable by separating with spaces.
+        option share 'games=/mnt/sda1/PS2'
+        option bind '0.0.0.0'
+        # 1111, not 445: binding below 1024 needs root and this runs as
+        # ps2edge. Set OPL's "SMB Port" to match.
+        option port '1111'
+        option read_only '1'
+        # Answers router status queries so a launcher can tell whether the box
+        # is ready. -1 is the standard discovery port; it is skipped
+        # automatically when udpfs above already owns that address.
+        option status_port '-1'
+        option log_format 'text'
+        option verbose '0'
+
+# UDPBD serves ONE disk image as a network hard drive, unlike udpfs and smb
+# which serve a directory.
+config udpbd 'udpbd'
+        option enabled '0'
+        option image ''
+        option bind '0.0.0.0'
+        option port '48301'
+        option read_only '1'
+        option status_port '-1'
+        option log_format 'text'
+        option verbose '0'

--- a/packaging/openwrt/files/ps2servers-edge.config
+++ b/packaging/openwrt/files/ps2servers-edge.config
@@ -33,10 +33,14 @@ config smb 'smb'
         # ps2edge. Set OPL's "SMB Port" to match.
         option port '1111'
         option read_only '1'
-        # Answers router status queries so a launcher can tell whether the box
-        # is ready. -1 is the standard discovery port; it is skipped
-        # automatically when udpfs above already owns that address.
-        option status_port '-1'
+        # Router status: 0 is off, -1 is the standard discovery port.
+        #
+        # Off by default because that port is udpfs's, and udpfs above already
+        # owns it. Leaving both at -1 would make whichever procd happened to
+        # start first the one that answers -- a launcher would get a different
+        # service's status across a reboot, for no visible reason. Set -1 here
+        # when smb is the only service enabled on this board.
+        option status_port '0'
         option log_format 'text'
         option verbose '0'
 
@@ -48,6 +52,9 @@ config udpbd 'udpbd'
         option bind '0.0.0.0'
         option port '48301'
         option read_only '1'
-        option status_port '-1'
+        # See the note on status_port in the smb section: off by default so it
+        # cannot race udpfs for the same socket. Set -1 when udpbd is the only
+        # service enabled on this board.
+        option status_port '0'
         option log_format 'text'
         option verbose '0'

--- a/packaging/openwrt/files/ps2servers-edge.init
+++ b/packaging/openwrt/files/ps2servers-edge.init
@@ -12,8 +12,32 @@ append_bool_flag() {
         [ "$value" -eq 1 ] && procd_append_param command "$flag"
 }
 
+# Shared supervision and hardening, applied to every instance so the three
+# services cannot drift apart in how they are run.
+common_params() {
+        procd_set_param user ps2edge
+        procd_set_param group ps2edge
+        procd_set_param respawn 10 5 0
+        procd_set_param stdout 1
+        procd_set_param stderr 1
+        procd_set_param limits nofile="256 256"
+}
+
+# One procd instance per enabled service, rather than a single command.
+#
+# Edge is a subcommand per process, so a board can serve udpfs and smb at once
+# and procd restarts them independently. This used to start udpfs and nothing
+# else, which meant the binary grew an smb subcommand its own package could not
+# launch: serving SMB required sshing in to run it by hand, and it did not
+# survive a reboot.
 start_service() {
         config_load ps2servers-edge
+        start_udpfs
+        start_smb
+        start_udpbd
+}
+
+start_udpfs() {
         config_get_bool enabled main enabled 0
         [ "$enabled" -eq 1 ] || return 0
 
@@ -30,7 +54,7 @@ start_service() {
         config_get compression_cache_size main compression_cache_size 32
         config_get metrics_period main metrics_period 1m
 
-        procd_open_instance
+        procd_open_instance udpfs
         procd_set_param command "$PROG" udpfs \
                 --root "$root" \
                 --bind "$bind" \
@@ -74,12 +98,78 @@ start_service() {
                 procd_append_param command --metrics
                 procd_append_param command --metrics-period "$metrics_period"
         fi
-        procd_set_param user ps2edge
-        procd_set_param group ps2edge
-        procd_set_param respawn 10 5 0
-        procd_set_param stdout 1
-        procd_set_param stderr 1
-        procd_set_param limits nofile="256 256"
+        common_params
+        procd_close_instance
+}
+
+start_smb() {
+        config_get_bool enabled smb enabled 0
+        [ "$enabled" -eq 1 ] || return 0
+
+        config_get share smb share
+        config_get bind smb bind 0.0.0.0
+        config_get port smb port 1111
+        config_get status_port smb status_port -1
+        config_get log_format smb log_format text
+
+        # Refused rather than started empty. The server exits immediately with
+        # no share, and procd would respawn it every five seconds forever; one
+        # line in the log beats a restart loop nobody can read.
+        if [ -z "$share" ]; then
+                echo "ps2servers-edge: smb is enabled but no share is configured" >&2
+                return 0
+        fi
+
+        procd_open_instance smb
+        procd_set_param command "$PROG" smb \
+                --bind "$bind" \
+                --port "$port" \
+                --status-port "$status_port" \
+                --log-format "$log_format"
+        # Space-separated NAME=PATH pairs, each passed as its own --share.
+        # Deliberately unquoted so the shell splits it, which is also why a
+        # share path containing a space cannot be configured this way.
+        for entry in $share; do
+                procd_append_param command --share "$entry"
+        done
+        # Read-only by default here, unlike the binary. A router share is
+        # frequently an entire attached disk and this server has no password,
+        # so writes are opt-in on this platform.
+        config_get_bool read_only smb read_only 1
+        [ "$read_only" -eq 1 ] && procd_append_param command --read-only
+        append_bool_flag smb verbose --verbose
+
+        common_params
+        procd_close_instance
+}
+
+start_udpbd() {
+        config_get_bool enabled udpbd enabled 0
+        [ "$enabled" -eq 1 ] || return 0
+
+        config_get image udpbd image
+        config_get bind udpbd bind 0.0.0.0
+        config_get port udpbd port 48301
+        config_get status_port udpbd status_port -1
+        config_get log_format udpbd log_format text
+
+        if [ -z "$image" ]; then
+                echo "ps2servers-edge: udpbd is enabled but no image is configured" >&2
+                return 0
+        fi
+
+        procd_open_instance udpbd
+        procd_set_param command "$PROG" udpbd \
+                --image "$image" \
+                --bind "$bind" \
+                --port "$port" \
+                --status-port "$status_port" \
+                --log-format "$log_format"
+        config_get_bool read_only udpbd read_only 1
+        [ "$read_only" -eq 1 ] && procd_append_param command --read-only
+        append_bool_flag udpbd verbose --verbose
+
+        common_params
         procd_close_instance
 }
 

--- a/packaging/systemd/README.md
+++ b/packaging/systemd/README.md
@@ -5,12 +5,27 @@ Two units here, and which one you want depends on whether you need SMB.
 | unit | build | serves |
 |---|---|---|
 | `ps2servers@.service` | the normal Linux download | **SMBv1**, UDPFS, UDPBD |
-| `ps2servers-edge.service` | the Go Edge build | UDPFS, UDPBD only |
+| `ps2servers-edge@.service` | the Go Edge build | **SMBv1**, UDPFS, UDPBD |
+| `ps2servers-edge.service` | the Go Edge build | UDPFS only (predates the others) |
 
-**Edge has no SMB.** If a console needs SMB — OPL's network game list, or
-POPSTARTER — Edge cannot serve it and `ps2servers@smbv1` is the unit you want.
-Edge is for routers and other small boxes where a Python runtime is not
-practical.
+**Edge now serves SMB too**, as of the `smb` subcommand. Use
+`ps2servers-edge@smb` on a router or other small box where a Python runtime is
+not practical, and `ps2servers@smbv1` on a normal machine. The older
+`ps2servers-edge.service` runs udpfs only and is left alone for anyone already
+using it.
+
+```sh
+sudo install -m 0644 packaging/systemd/ps2servers-edge@.service /etc/systemd/system/
+sudo install -m 0644 packaging/systemd/ps2servers-edge-smb.env /etc/default/ps2servers-edge-smb
+sudo systemctl enable --now ps2servers-edge@smb
+```
+
+The instance name is the Edge subcommand, so `ps2servers-edge@udpfs` and
+`ps2servers-edge@udpbd` work the same way, each reading its own
+`/etc/default/ps2servers-edge-<subcommand>`. Several can run at once.
+
+Edge's SMB defaults to **port 1111**, not 445, for the same reason as the
+Python one: below 1024 needs root and these units run as `ps2edge`.
 
 ## Any server, on a normal Linux box (`ps2servers@.service`)
 

--- a/packaging/systemd/ps2servers-edge-smb.env
+++ b/packaging/systemd/ps2servers-edge-smb.env
@@ -1,0 +1,15 @@
+# /etc/default/ps2servers-edge-smb
+#
+# Flags for `ps2servers-edge smb`. Split on whitespace by systemd, so no value
+# here may contain a space.
+#
+# Port 1111, not 445: binding below 1024 needs root or CAP_NET_BIND_SERVICE and
+# this unit runs as ps2edge. Set OPL's "SMB Port" to match.
+#
+# --status-port -1 uses the standard discovery port so a launcher can ask
+# whether this box is ready. It is skipped automatically when Edge's udpfs is
+# already running and owns that address.
+PS2EDGE_ARGS=--share games=/srv/ps2 --port 1111 --status-port -1
+
+# The share path must also be covered by ReadWritePaths= in the unit, or writes
+# fail silently under ProtectSystem=strict. Add --read-only to refuse writes.

--- a/packaging/systemd/ps2servers-edge-smb.env
+++ b/packaging/systemd/ps2servers-edge-smb.env
@@ -6,10 +6,15 @@
 # Port 1111, not 445: binding below 1024 needs root or CAP_NET_BIND_SERVICE and
 # this unit runs as ps2edge. Set OPL's "SMB Port" to match.
 #
-# --status-port -1 uses the standard discovery port so a launcher can ask
-# whether this box is ready. It is skipped automatically when Edge's udpfs is
-# already running and owns that address.
-PS2EDGE_ARGS=--share games=/srv/ps2 --port 1111 --status-port -1
+# --status-port 0 is off; -1 is the standard discovery port, which answers a
+# launcher asking whether this box is ready.
+#
+# Off by default because that port belongs to udpfs. If ps2servers-edge@udpfs
+# also runs, leaving both at -1 would make whichever systemd started first the
+# one that answers -- a launcher would get a different service's status across
+# a reboot, for no visible reason. Set -1 when this is the only Edge service on
+# the machine.
+PS2EDGE_ARGS=--share games=/srv/ps2 --port 1111 --status-port 0
 
 # The share path must also be covered by ReadWritePaths= in the unit, or writes
 # fail silently under ProtectSystem=strict. Add --read-only to refuse writes.

--- a/packaging/systemd/ps2servers-edge-udpbd.env
+++ b/packaging/systemd/ps2servers-edge-udpbd.env
@@ -1,0 +1,10 @@
+# /etc/default/ps2servers-edge-udpbd
+#
+# Flags for `ps2servers-edge udpbd`. Split on whitespace by systemd, so no
+# value here may contain a space.
+#
+# UDPBD serves ONE disk image, not a directory -- unlike udpfs and smb.
+PS2EDGE_ARGS=--image /srv/ps2/ps2.img --port 48301 --status-port -1
+
+# The image must be under ReadWritePaths= in the unit, or writes fail silently
+# under ProtectSystem=strict. Add --read-only to refuse writes.

--- a/packaging/systemd/ps2servers-edge-udpbd.env
+++ b/packaging/systemd/ps2servers-edge-udpbd.env
@@ -4,7 +4,11 @@
 # value here may contain a space.
 #
 # UDPBD serves ONE disk image, not a directory -- unlike udpfs and smb.
-PS2EDGE_ARGS=--image /srv/ps2/ps2.img --port 48301 --status-port -1
+#
+# --status-port 0 is off; -1 is the standard discovery port. Off by default so
+# it cannot race udpfs for the same socket -- see the note in
+# ps2servers-edge-smb.env. Set -1 when this is the only Edge service here.
+PS2EDGE_ARGS=--image /srv/ps2/ps2.img --port 48301 --status-port 0
 
 # The image must be under ReadWritePaths= in the unit, or writes fail silently
 # under ProtectSystem=strict. Add --read-only to refuse writes.

--- a/packaging/systemd/ps2servers-edge-udpfs.env
+++ b/packaging/systemd/ps2servers-edge-udpfs.env
@@ -1,0 +1,9 @@
+# /etc/default/ps2servers-edge-udpfs
+#
+# Flags for `ps2servers-edge udpfs` when run via the ps2servers-edge@ template.
+# The older ps2servers-edge.service uses /etc/default/ps2servers-edge instead
+# and takes individual PS2EDGE_* variables; this file is one argument list.
+PS2EDGE_ARGS=--root /srv/ps2 --port 62966 --protocol-mode auto
+
+# The root must also be covered by ReadWritePaths= in the unit. Add --read-only
+# to refuse writes.

--- a/packaging/systemd/ps2servers-edge@.service
+++ b/packaging/systemd/ps2servers-edge@.service
@@ -1,0 +1,63 @@
+[Unit]
+# A template: %i is the Edge subcommand -- udpfs, udpbd or smb.
+#   systemctl enable --now ps2servers-edge@smb
+#
+# ps2servers-edge.service alongside this one runs udpfs only, and predates the
+# other subcommands existing. It still works and is left alone; this is the way
+# to run smb or udpbd, or several at once.
+Description=PS2 Servers Edge (%i)
+Documentation=https://github.com/NathanNeurotic/PS2-Servers/blob/main/packaging/systemd/README.md
+After=network-online.target local-fs.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ps2edge
+Group=ps2edge
+
+# Per-instance, so each service keeps its own share, image and ports:
+#   /etc/default/ps2servers-edge-smb
+#
+# Required, not optional: every subcommand refuses to start without arguments
+# -- udpfs needs --root, smb a --share, udpbd an --image -- so a missing file
+# would become an exit every 5s under Restart=on-failure. One clear "failed to
+# load environment files" beats a restart loop.
+EnvironmentFile=/etc/default/ps2servers-edge-%i
+
+# $PS2EDGE_ARGS is unbraced on purpose: systemd splits an unbraced variable on
+# whitespace into separate arguments and does not split ${VAR}. The cost is
+# that a path containing a space cannot be passed this way.
+ExecStart=/usr/local/bin/ps2servers-edge %i $PS2EDGE_ARGS
+
+Restart=on-failure
+RestartSec=5s
+TimeoutStopSec=15s
+
+ProtectSystem=strict
+# The `-` makes a missing path non-fatal; without it a directory that does not
+# exist fails at mount-namespace setup, before ExecStart, and Restart loops it.
+#
+# THIS MUST COVER THE PATH IN THE ENV FILE. ProtectSystem=strict re-opens only
+# what is listed here, so serving /mnt/games while this says /srv/ps2 gives a
+# share the console can read and never write -- and only saving fails, which
+# reads as a network fault rather than a permissions one. A `systemctl edit`
+# override ADDS to this list rather than replacing it.
+ReadWritePaths=-/srv/ps2
+ProtectHome=read-only
+
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+RestrictSUIDSGID=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictAddressFamilies=AF_INET AF_UNIX
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/test_edge_flag_exposure.py
+++ b/tests/test_edge_flag_exposure.py
@@ -93,6 +93,26 @@ def _udpfs_flags():
     return {"--" + name for name in found}
 
 
+def _section(text, name):
+    """One `config <type> '<name>'` block, without the sections after it.
+
+    These checks are about the udpfs service specifically -- FLAG_TO_UCI maps
+    udpfs flags -- so they must not scan the whole file. Edge later gained smb
+    and udpbd sections whose options map to those subcommands' flags instead;
+    scanning globally reported every one of them as an orphan.
+    tests/test_edge_service_modes.py covers those.
+    """
+    lines = text.splitlines()
+    out, inside = [], False
+    for line in lines:
+        if line.startswith("config "):
+            inside = line.rstrip().endswith("'%s'" % name)
+            continue
+        if inside:
+            out.append(line)
+    return "\n".join(out)
+
+
 class UdpfsFlagsAreReachableFromOpenWrt(unittest.TestCase):
     def setUp(self):
         self.flags = _udpfs_flags()
@@ -121,7 +141,8 @@ class UdpfsFlagsAreReachableFromOpenWrt(unittest.TestCase):
             % ", ".join(stale)))
 
     def test_mapped_options_are_in_the_shipped_config(self):
-        declared = set(re.findall(r"(?m)^\s*option\s+([a-z0-9_]+)\s+'", self.config))
+        declared = set(re.findall(
+            r"(?m)^\s*option\s+([a-z0-9_]+)\s+'", _section(self.config, "main")))
         missing = sorted(
             "%s (for %s)" % (option, flag)
             for flag, option in FLAG_TO_UCI.items() if option not in declared)
@@ -160,7 +181,8 @@ class UdpfsFlagsAreReachableFromOpenWrt(unittest.TestCase):
 
     def test_config_has_no_orphan_options(self):
         """Every shipped option must correspond to a flag the binary accepts."""
-        declared = set(re.findall(r"(?m)^\s*option\s+([a-z0-9_]+)\s+'", self.config))
+        declared = set(re.findall(
+            r"(?m)^\s*option\s+([a-z0-9_]+)\s+'", _section(self.config, "main")))
         known = set(FLAG_TO_UCI.values()) | {"enabled"}
         orphans = sorted(declared - known)
         self.assertEqual(orphans, [], (
@@ -189,9 +211,9 @@ class UdpfsFlagsAreDocumented(unittest.TestCase):
     def test_openwrt_doc_config_block_matches_the_shipped_file(self):
         """The doc quotes the config verbatim; a drifted quote teaches a wrong key."""
         shipped = set(re.findall(
-            r"(?m)^\s*option\s+([a-z0-9_]+)\s+'", _read(UCI_CONFIG)))
+            r"(?m)^\s*option\s+([a-z0-9_]+)\s+'", _section(_read(UCI_CONFIG), "main")))
         documented = set(re.findall(
-            r"(?m)^\s*option\s+([a-z0-9_]+)\s+'", _read(OPENWRT_DOC)))
+            r"(?m)^\s*option\s+([a-z0-9_]+)\s+'", _section(_read(OPENWRT_DOC), "main")))
         self.assertEqual(shipped, documented, (
             "the config block in docs/OPENWRT.md has drifted from the file the "
             "package actually installs: only in the file %s; only in the doc %s"

--- a/tests/test_edge_flag_exposure.py
+++ b/tests/test_edge_flag_exposure.py
@@ -100,7 +100,11 @@ def _section(text, name):
     udpfs flags -- so they must not scan the whole file. Edge later gained smb
     and udpbd sections whose options map to those subcommands' flags instead;
     scanning globally reported every one of them as an orphan.
-    tests/test_edge_service_modes.py covers those.
+
+    The equivalent orphan check for those sections lives in
+    tests/test_edge_service_modes.py (NewSectionOptionsMapToRealFlags), which
+    resolves each option against the flags its own run function declares and
+    against the init script that must read it.
     """
     lines = text.splitlines()
     out, inside = [], False

--- a/tests/test_edge_service_modes.py
+++ b/tests/test_edge_service_modes.py
@@ -1,0 +1,173 @@
+"""Edge's packaging must be able to start every server the binary has.
+
+This exists because it once could not. The binary grew an `smb` subcommand and
+the OpenWrt init still hardcoded `udpfs`, so serving SMB -- the whole reason a
+router user wanted Edge -- meant sshing in to run it by hand, and it did not
+survive a reboot. Nothing failed; the capability simply was not reachable.
+
+That class of gap is invisible to every other test in the tree: the Go tests
+prove the server works, the packaging tests prove the files ship, and neither
+notices that no shipped file ever invokes it.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import unittest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_OPENWRT = os.path.join(_ROOT, "packaging", "openwrt", "files")
+_SYSTEMD = os.path.join(_ROOT, "packaging", "systemd")
+_MAIN_GO = os.path.join(_ROOT, "native", "ps2servers-edge", "cmd",
+                        "ps2servers-edge", "main.go")
+
+
+def _read(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def edge_subcommands():
+    """The subcommands main.go actually dispatches, read from the source.
+
+    Derived rather than hardcoded, so adding a fourth server to Edge fails
+    these tests until its packaging exists -- which is the point.
+    """
+    source = _read(_MAIN_GO)
+    # Both comparison forms: udpbd and smb dispatch on ==, while udpfs is the
+    # fallthrough and is written as `os.Args[1] != "udpfs"`. Matching only ==
+    # silently omits it, which would leave the one server that has always
+    # shipped unchecked.
+    found = set(re.findall(r'os\.Args\[1\] [!=]= "([a-z0-9]+)"', source))
+    # --version and version go through the same shape but are not servers.
+    return found - {"version", "--version"}
+
+
+class EveryServerIsLaunchable(unittest.TestCase):
+    def test_main_go_dispatches_the_expected_set(self):
+        # A guard on the guard: if this changes, the tests below are checking
+        # the wrong list and should be looked at rather than silently passing.
+        self.assertEqual(edge_subcommands(), {"udpfs", "udpbd", "smb"},
+                         "Edge's subcommands changed; update the packaging too")
+
+    def test_openwrt_init_starts_each_one(self):
+        init = _read(os.path.join(_OPENWRT, "ps2servers-edge.init"))
+
+        # start_service is procd's entry point, so a start_<cmd> function that
+        # nothing calls is exactly the original bug wearing a disguise: the
+        # command appears in the file and is never reached. An earlier version
+        # of this test checked only that the string was present, and a mutation
+        # deleting the call from start_service sailed past it.
+        match = re.search(r"^start_service\(\)\s*\{(.*?)^\}", init,
+                          re.MULTILINE | re.DOTALL)
+        self.assertIsNotNone(match, "no start_service() in the init script")
+        body = match.group(1)
+
+        for cmd in sorted(edge_subcommands()):
+            with self.subTest(subcommand=cmd):
+                self.assertRegex(
+                    init, r'procd_set_param command "\$PROG" ' + cmd + r'\b',
+                    f"the OpenWrt init never launches `{cmd}`, so the package "
+                    "ships a server it cannot start")
+                # re.MULTILINE explicitly: assertRegex does not apply it, so a
+                # `^` anchor would only ever match the start of the file.
+                self.assertIsNotNone(
+                    re.search(r"^start_" + cmd + r"\(\)\s*\{", init, re.MULTILINE),
+                    f"no start_{cmd}() function")
+                self.assertIsNotNone(
+                    re.search(r"\bstart_" + cmd + r"\b", body),
+                    f"start_service() never calls start_{cmd}, so `{cmd}` is "
+                    "defined but unreachable -- the package still cannot start it")
+
+    def test_openwrt_config_has_a_section_per_service(self):
+        config = _read(os.path.join(_OPENWRT, "ps2servers-edge.config"))
+        sections = set(re.findall(r"^config\s+(\w+)", config, re.MULTILINE))
+        for cmd in sorted(edge_subcommands()):
+            with self.subTest(subcommand=cmd):
+                self.assertIn(cmd, sections,
+                              f"no UCI section for {cmd}; it could be started "
+                              "but not configured")
+
+    def test_each_instance_is_named(self):
+        # procd needs distinct instance names or the later ones replace the
+        # earlier: a single unnamed instance would mean enabling smb silently
+        # stopped udpfs.
+        init = _read(os.path.join(_OPENWRT, "ps2servers-edge.init"))
+        names = re.findall(r"procd_open_instance\s+(\w+)", init)
+        self.assertEqual(len(names), len(edge_subcommands()),
+                         "every instance must be named, or they overwrite each other")
+        self.assertEqual(len(names), len(set(names)), f"duplicate instance names: {names}")
+
+    def test_every_instance_runs_unprivileged(self):
+        init = _read(os.path.join(_OPENWRT, "ps2servers-edge.init"))
+        opens = init.count("procd_open_instance")
+        # common_params applies the hardening; each instance must call it, or
+        # one of them quietly runs as root.
+        self.assertEqual(init.count("common_params"), opens + 1,
+                         "an instance is not applying common_params, so it may "
+                         "run without the user/limits the others have")
+
+    def test_systemd_template_covers_each_one(self):
+        env_files = os.listdir(_SYSTEMD)
+        for cmd in sorted(edge_subcommands()):
+            with self.subTest(subcommand=cmd):
+                self.assertIn(f"ps2servers-edge-{cmd}.env", env_files,
+                              f"no env sample for ps2servers-edge@{cmd}; the "
+                              "unit requires one and the instance would fail "
+                              "before starting")
+
+    def test_systemd_template_splits_its_arguments(self):
+        unit = _read(os.path.join(_SYSTEMD, "ps2servers-edge@.service"))
+        exec_line = [l for l in unit.splitlines() if l.startswith("ExecStart=")]
+        self.assertEqual(len(exec_line), 1)
+        # Unbraced: systemd splits $VAR on whitespace and does not split ${VAR}.
+        self.assertTrue(exec_line[0].endswith("%i $PS2EDGE_ARGS"),
+                        f"ExecStart must end with the exact unbraced variable: {exec_line[0]}")
+
+    def test_readwritepaths_tolerates_a_missing_directory(self):
+        unit = _read(os.path.join(_SYSTEMD, "ps2servers-edge@.service"))
+        for line in unit.splitlines():
+            if line.startswith("ReadWritePaths="):
+                value = line.split("=", 1)[1].strip()
+                self.assertTrue(value.startswith("-"),
+                                f"ReadWritePaths={value} is fatal if the path is "
+                                "missing; prefix with - to tolerate it")
+
+
+class InitScriptIsValidShell(unittest.TestCase):
+    def test_posix_sh_parses_it(self):
+        init = os.path.join(_OPENWRT, "ps2servers-edge.init")
+        for shell in ("sh", "dash", "bash"):
+            try:
+                result = subprocess.run([shell, "-n", init],
+                                        capture_output=True, text=True, timeout=60)
+            except (FileNotFoundError, OSError):
+                continue
+            self.assertEqual(result.returncode, 0,
+                             f"{shell} -n rejected the init script:\n{result.stderr}")
+            return
+        self.skipTest("no POSIX shell available to check syntax")
+
+
+class StatusIsOfferedByEveryServer(unittest.TestCase):
+    """The router status handshake was requested for a board serving SMB.
+
+    It only ever answered on UDPFS, so the one service the request was about
+    reported nothing.
+    """
+
+    def test_smb_and_udpbd_accept_a_status_port(self):
+        source = _read(_MAIN_GO)
+        self.assertEqual(source.count('fs.Int("status-port"'), 2,
+                         "smb and udpbd should each expose --status-port")
+
+    def test_openwrt_config_exposes_it(self):
+        config = _read(os.path.join(_OPENWRT, "ps2servers-edge.config"))
+        self.assertGreaterEqual(
+            config.count("option status_port"), 2,
+            "the smb and udpbd sections should each expose status_port")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_edge_service_modes.py
+++ b/tests/test_edge_service_modes.py
@@ -228,13 +228,17 @@ class ShippedStatusPortsDoNotRace(unittest.TestCase):
     def test_systemd_env_files_ship_no_claimant(self):
         # udpfs owns the port implicitly by serving discovery on it, so no
         # Edge env file should claim it by default.
+        # Go's flag package accepts -flag=v, --flag=v, -flag v and --flag v, so
+        # a literal "--status-port -1" check would pass on three spellings that
+        # claim the port just as effectively.
+        claims = re.compile(r"--?status-port[=\s]+-1\b")
         for name in ("smb", "udpbd"):
             path = os.path.join(_SYSTEMD, f"ps2servers-edge-{name}.env")
-            args = [l for l in _read(path).splitlines()
-                    if l.startswith("PS2EDGE_ARGS=")]
+            args = [line for line in _read(path).splitlines()
+                    if line.startswith("PS2EDGE_ARGS=")]
             self.assertEqual(len(args), 1)
-            self.assertNotIn(
-                "--status-port -1", args[0],
+            self.assertNotRegex(
+                args[0], claims,
                 f"ps2servers-edge-{name}.env claims the shared status port by "
                 "default, which races ps2servers-edge@udpfs")
 

--- a/tests/test_edge_service_modes.py
+++ b/tests/test_edge_service_modes.py
@@ -135,6 +135,110 @@ class EveryServerIsLaunchable(unittest.TestCase):
                                 "missing; prefix with - to tolerate it")
 
 
+class NewSectionOptionsMapToRealFlags(unittest.TestCase):
+    """Every smb/udpbd UCI option must correspond to a flag its server accepts.
+
+    The same check test_edge_flag_exposure applies to udpfs. Without it an
+    option can be shipped, documented and set, and do nothing -- which is
+    exactly the bug that once made udpfs's `read_only` decorative.
+
+    Flags are read from main.go rather than by running the binary, so this
+    needs no Go toolchain and still fails when a flag is renamed.
+    """
+
+    @staticmethod
+    def _flags_of(func_name):
+        source = _read(_MAIN_GO)
+        start = source.find(f"func {func_name}(")
+        if start < 0:
+            return set()
+        # To the next top-level func, which is where this one ends.
+        end = source.find("\nfunc ", start + 1)
+        body = source[start:end if end > 0 else len(source)]
+        # Two shapes: fs.String("name", ...) puts the name first, while
+        # fs.Var(&value, "name", ...) puts the value first. Matching only the
+        # first misses every repeatable flag -- --share among them, which is
+        # the one option smb cannot run without.
+        return set(re.findall(r'fs\.\w+\(\s*(?:&\w+,\s*)?"([a-z0-9-]+)"', body))
+
+    @staticmethod
+    def _section_options(config, section_name):
+        options, inside = set(), False
+        for line in config.splitlines():
+            if line.startswith("config "):
+                inside = line.rstrip().endswith(f"'{section_name}'")
+                continue
+            if inside:
+                m = re.match(r"\s*option\s+([a-z0-9_]+)\s+'", line)
+                if m:
+                    options.add(m.group(1))
+        return options
+
+    def test_smb_and_udpbd_options_all_reach_a_flag(self):
+        config = _read(os.path.join(_OPENWRT, "ps2servers-edge.config"))
+        init = _read(os.path.join(_OPENWRT, "ps2servers-edge.init"))
+
+        for section, func in (("smb", "runSMB"), ("udpbd", "runUDPBD")):
+            flags = self._flags_of(func)
+            self.assertTrue(flags, f"no flags parsed out of {func}")
+            for option in sorted(self._section_options(config, section)):
+                if option == "enabled":
+                    continue  # consumed by the init script, not the binary
+                with self.subTest(section=section, option=option):
+                    flag = option.replace("_", "-")
+                    self.assertIn(
+                        flag, flags,
+                        f"{section}.{option} does not map to a --{flag} flag on "
+                        f"{func}, so setting it does nothing")
+                    # And the init must actually read it, or it is decorative
+                    # even though the flag exists.
+                    #
+                    # Two spellings count, as in test_edge_flag_exposure:
+                    # scalars go through config_get, booleans through the
+                    # append_bool_flag helper. Matching only the first reports
+                    # every boolean as unread, which is the opposite of true.
+                    direct = (r"config_get(?:_bool)?\s+\w+\s+" + section +
+                              r"\s+" + re.escape(option) + r"\b")
+                    helper = (r"append_bool_flag\s+" + section + r"\s+" +
+                              re.escape(option) + r"\b")
+                    self.assertTrue(
+                        re.search(direct, init) or re.search(helper, init),
+                        f"the init never reads {section}.{option}, so setting "
+                        "it would be decorative")
+
+
+class ShippedStatusPortsDoNotRace(unittest.TestCase):
+    """Only one service may claim the shared status socket by default.
+
+    -1 resolves to UDPFS's discovery port in every subcommand, and bind
+    failures are deliberately non-fatal, so shipping -1 for several services
+    would make whichever started first the one that answers -- a launcher would
+    get a different service's status across a reboot, for no visible reason.
+    """
+
+    def test_openwrt_ships_at_most_one_claimant(self):
+        config = _read(os.path.join(_OPENWRT, "ps2servers-edge.config"))
+        claiming = re.findall(r"^\s*option\s+status_port\s+'(-?\d+)'",
+                              config, re.MULTILINE)
+        self.assertLessEqual(
+            [c for c in claiming].count("-1"), 1,
+            "more than one shipped section claims the standard status port; "
+            "which one answers would depend on procd start order")
+
+    def test_systemd_env_files_ship_no_claimant(self):
+        # udpfs owns the port implicitly by serving discovery on it, so no
+        # Edge env file should claim it by default.
+        for name in ("smb", "udpbd"):
+            path = os.path.join(_SYSTEMD, f"ps2servers-edge-{name}.env")
+            args = [l for l in _read(path).splitlines()
+                    if l.startswith("PS2EDGE_ARGS=")]
+            self.assertEqual(len(args), 1)
+            self.assertNotIn(
+                "--status-port -1", args[0],
+                f"ps2servers-edge-{name}.env claims the shared status port by "
+                "default, which races ps2servers-edge@udpfs")
+
+
 class InitScriptIsValidShell(unittest.TestCase):
     def test_posix_sh_parses_it(self):
         init = os.path.join(_OPENWRT, "ps2servers-edge.init")


### PR DESCRIPTION
Two gaps between *implemented* and *usable*, both found by asking what a router user could actually do with what shipped in #146.

## The package could not start the server it shipped

`ps2servers-edge.init` hardcoded `udpfs`, and the systemd unit's `ExecStart` did the same. So the `smb` subcommand added last commit was reachable only by sshing in and running it by hand — and it didn't survive a reboot.

procd now opens **one named instance per enabled service**, so a board can serve udpfs and smb at once and they restart independently. systemd gets a `ps2servers-edge@.service` template alongside the existing unit, which is left alone for anyone already using it.

```
config smb 'smb'
        option enabled '1'
        option share 'games=/mnt/sda1/PS2'
        option port '1111'
```

## The status handshake didn't cover the service it was requested for

It was asked for so a launcher could tell whether an internal router was ready — and it answered on UDPFS only. A board serving SMB, *which is the case that prompted the request*, went dark on the one protocol it existed to provide.

SMB and UDPBD now answer too, via a shared `internal/statuslistener` (neither owns a UDP socket the way udpfs does). A bind failure there is **logged and ignored, not fatal**: the standard status port is UDPFS's discovery port, legitimately taken on a board already running that server, and refusing to serve SMB over a diagnostic would be the wrong trade.

`busy` means different things per protocol, and each is the honest reading rather than a forced abstraction:
- **UDPBD** — busy only with a write in flight, the case worth warning about before cutting power.
- **SMB** — busy whenever a connection is open, because SMB has no idle state a server can observe; OPL holds one connection across a whole game load.

## Verified against a real process

Not a fake: the Go SMB server answered a status query from the **Python** client over real UDP.

```
{'version': 1, 'state': 1, 'state_name': 'ready', 'flags': 4,
 'sessions': 0, 'uptime': 1, 'name': 'PS2 Servers Edge'}
```

## Two existing tests failed on this, and were right to

`test_edge_flag_exposure` scanned the whole UCI file while only knowing udpfs's flags, so the new options read as orphans and the documented config block as drifted. Both are now scoped to the udpfs section, with the new sections covered by `test_edge_service_modes` and documented in `docs/OPENWRT.md`.

That new test derives Edge's subcommands **from main.go** rather than hardcoding them, so adding a fourth server fails until its packaging exists. Its first version only checked the command appeared somewhere in the init — which a mutation deleting the call from `start_service` sailed straight past, the original bug wearing a disguise. It now requires `start_<cmd>` to exist *and* be reached from `start_service`, and that mutation fails it.

Binary 3.31 → 3.34 MB mipsle. 313 Python tests, all Go packages under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate SMB and UDPBD services alongside UDPFS, including OpenWrt procd instance support.
  * Added optional router-status reporting for SMB and UDPBD with a configurable status port (including an “off” mode).
* **Documentation**
  * Added OpenWrt SMB/UDPBD configuration guidance, including status-port coordination to prevent conflicts.
  * Updated systemd instructions and added per-service environment and template unit files.
* **Tests**
  * Added/expanded automated checks to validate server status behavior and keep OpenWrt/systemd/CLI settings aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->