### PR TITLE
fix(gui): UDPFS status fix, IP detection helper, SMB port exposure, and SMB2/SMB3 tabs

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -922,9 +922,13 @@ class LauncherApp:
             self.ip_combo.focus_set()
 
     def _show_whats_my_ip(self):
-        info = netinfo.detailed_ip_info()
-        self._append_log("setup", f"{info}\n")
         self.nb.select(self.terminal_tab)
+
+        def worker():
+            info = netinfo.detailed_ip_info()
+            self.root.after(0, lambda: self._append_log("setup", f"{info}\n"))
+
+        threading.Thread(target=worker, daemon=True).start()
 
     def _refresh_ips(self):
         self.ip_combo.config(values=netinfo.ip_choices())

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -141,6 +141,8 @@ Unsigned Windows network tools can still trigger antivirus heuristics. That does
 
 TAB_TITLES = {
     "smbv1": "SMBv1",
+    "smbv2": "SMBv2",
+    "smbv3": "SMBv3",
     "udpfs": "UDPFS",
     "udpbd": "UDPBD",
     "setup": "SETUP",
@@ -641,13 +643,13 @@ class LauncherApp:
         # header: LAN IP the user types into OPL
         header = ttk.Frame(parent, style="TopStrip.TFrame", padding=(12, 10))
         header.pack(fill="x", padx=16, pady=(12, 8))
-        header.columnconfigure(3, weight=1)
+        header.columnconfigure(4, weight=1)
         ttk.Label(header, text="LAN IP", font=("", 10, "bold"),
                   style="TopStripTitle.TLabel").grid(row=0, column=0, sticky="w")
         # Always-visible version, so a tester can read it off the screen without
         # opening About. Right-aligned in the header's stretchy column.
         ttk.Label(header, text="PS2 Servers " + APP_VERSION_LABEL,
-                  style="TopStripHint.TLabel").grid(row=0, column=4, sticky="e",
+                  style="TopStripHint.TLabel").grid(row=0, column=5, sticky="e",
                                                     padx=(12, 0))
         self.ip_var = tk.StringVar(value=netinfo.best_lan_ip())
         # Editable, not readonly: detection leans on getaddrinfo(gethostname()),
@@ -656,8 +658,9 @@ class LauncherApp:
         # user has to be able to type it. This value only feeds the OPL hint text
         # -- what a server binds to is its own Bind address field.
         self.ip_combo = ttk.Combobox(header, textvariable=self.ip_var, width=18,
-                                     values=netinfo.all_ipv4(), state="normal")
+                                     values=netinfo.ip_choices(), state="normal")
         self.ip_combo.grid(row=0, column=1, sticky="w", padx=(10, 6))
+        self.ip_combo.bind("<<ComboboxSelected>>", self._on_ip_combobox_select)
         # A typed address applies as you type: the OPL hint on any running card
         # follows it, and it persists without waiting for something else to save.
         # Without this, typing gave no feedback at all until the next start/stop,
@@ -665,11 +668,13 @@ class LauncherApp:
         self.ip_var.trace_add("write", self._on_ip_edited)
         ttk.Button(header, text="Refresh", command=self._refresh_ips).grid(
             row=0, column=2, sticky="w")
+        ttk.Button(header, text="What's my IP?", command=self._show_whats_my_ip).grid(
+            row=0, column=3, sticky="w", padx=(4, 0))
         ttk.Label(header, text="Enter this in OPL where it asks for the PC/server IP. "
                   "Pick from the list, or type your own if the right address "
                   "isn't shown -- it saves as you type.",
                   style="TopStripHint.TLabel", wraplength=420).grid(
-            row=0, column=3, sticky="w", padx=(12, 0))
+            row=0, column=4, sticky="w", padx=(12, 0))
 
         # direct PS2-to-PC link: adapter setup + DHCP helper behind one checkbox.
         # Available on every desktop OS; the per-OS network plumbing differs, and
@@ -911,9 +916,21 @@ class LauncherApp:
                 card.refresh_status(running=True)
         self._save()
 
+    def _on_ip_combobox_select(self, event=None):
+        if self.ip_var.get() == "Custom IP...":
+            self.ip_var.set("")
+            self.ip_combo.focus_set()
+
+    def _show_whats_my_ip(self):
+        info = netinfo.detailed_ip_info()
+        self._append_log("setup", f"{info}\n")
+        self.nb.select(self.terminal_tab)
+
     def _refresh_ips(self):
-        self.ip_combo.config(values=netinfo.all_ipv4())
-        self.ip_var.set(netinfo.best_lan_ip())
+        self.ip_combo.config(values=netinfo.ip_choices())
+        current = self.ip_var.get()
+        if not current or current in (netinfo.all_ipv4() + ["Custom IP..."]):
+            self.ip_var.set(netinfo.best_lan_ip())
         for key in self.procs:
             self.cards[key].refresh_status(self.is_running(key))
 
@@ -1580,29 +1597,43 @@ class LauncherApp:
                 and not any("timed out" in n for n in (notes or [])):
             self._remember_firewall_ok(fingerprint)
 
-        take_445 = key == "smbv1" and bool(values.get("take_445"))
-        admin_required = setup_needed or take_445
+        take_445 = key.startswith("smb") and bool(values.get("take_445"))
+        raw_port = values.get("port")
+        port_num = 0
+        if raw_port:
+            try:
+                port_num = int(str(raw_port).strip(), 0)
+            except (TypeError, ValueError):
+                port_num = 0
+        low_port_required = (0 < port_num < 1025)
+        admin_required = setup_needed or take_445 or low_port_required
         if admin_required and not elevate.is_admin():
             self._set_card_busy(key, False, "Start")
             if not elevate.can_elevate():
                 messagebox.showerror(
                     "Administrator required",
-                    "Windows network setup needs administrator rights.")
+                    "Administrator privileges are required to configure network setup or bind ports below 1025.")
                 return
 
-            summary = windows_setup.setup_summary(key, values)
-            message = (
-                "PS2 Servers needs administrator rights to {}.\n\n"
-                "This will not enable Windows SMB1. It only manages PS2 Servers "
-                "firewall rules, and advanced port 445 mode only pauses Windows "
-                "file sharing while that server is running.\n\n"
-                "Restart the launcher as administrator now? Your settings are "
-                "saved and the server will continue automatically.".format(summary))
-            if not take_445:
-                message += (
-                    "\n\nChoose No to start the server anyway without firewall "
-                    "setup (if Windows Firewall is active, the PS2 may not be "
-                    "able to connect).")
+            if low_port_required and not setup_needed and not take_445:
+                message = (
+                    "Binding ports below 1025 (such as port {}) requires administrator privileges.\n\n"
+                    "Do you want to restart PS2 Servers as Administrator?".format(port_num)
+                )
+            else:
+                summary = windows_setup.setup_summary(key, values)
+                message = (
+                    "PS2 Servers needs administrator rights to {}.\n\n"
+                    "This will not enable Windows SMB1. It only manages PS2 Servers "
+                    "firewall rules, and advanced port 445 mode only pauses Windows "
+                    "file sharing while that server is running.\n\n"
+                    "Restart the launcher as administrator now? Your settings are "
+                    "saved and the server will continue automatically.".format(summary))
+                if not take_445 and not low_port_required:
+                    message += (
+                        "\n\nChoose No to start the server anyway without firewall "
+                        "setup (if Windows Firewall is active, the PS2 may not be "
+                        "able to connect).")
             if messagebox.askyesno("Administrator required", message):
                 self._save(pending_start=key)
                 if elevate.relaunch_as_admin():
@@ -1614,7 +1645,7 @@ class LauncherApp:
                     messagebox.showerror(
                         "Elevation failed",
                         "Could not restart as administrator.")
-            elif not take_445:
+            elif not take_445 and not low_port_required:
                 self._append_log(key, "[setup] firewall setup skipped by user; starting anyway\n")
                 self._launch_server(key, values)
             return
@@ -1630,7 +1661,7 @@ class LauncherApp:
 
     def _confirm_windows_setup(self, key, values):
         summary = windows_setup.setup_summary(key, values)
-        if key == "smbv1":
+        if key.startswith("smb"):
             detail = (
                 "The SMB server is PS2 Servers' built-in OPL-compatible SMB/CIFS "
                 "server. This does not enable Windows SMB1 or expose Windows file "
@@ -1697,7 +1728,10 @@ class LauncherApp:
         # Ask this server what state it is actually in, rather than inferring
         # it from the child process being alive. Loopback, because the launcher
         # is asking about a server it started itself.
-        self.status_poller.set_target(key, "127.0.0.1", values.get("port") or 0)
+        try:
+            self.status_poller.set_target(key, "127.0.0.1", values.get("port") or 0)
+        except Exception as e:
+            self._append_log(key, "[launcher] status poller target setup warning: {}\n".format(e))
         card.refresh_status(True)
         card.toggle_btn.config(state="normal")
         self.nb.select(self.terminal_tab)

--- a/launcher/netinfo.py
+++ b/launcher/netinfo.py
@@ -131,6 +131,80 @@ def _lan_rank(ip):
     return 3
 
 
+def ip_choices():
+    """All detected IPv4 addresses plus a Custom IP choice."""
+    return all_ipv4() + ["Custom IP..."]
+
+
+def get_adapter_ip_pairs():
+    """Returns [(adapter_name, ip_address), ...] for all active IPv4 interfaces."""
+    pairs = []
+    try:
+        if sys.platform == "win32" and shutil.which("ipconfig"):
+            out = subprocess.run(["ipconfig"], capture_output=True, text=True, timeout=3).stdout
+            current_adapter = None
+            for line in (out or "").splitlines():
+                line_s = line.strip()
+                if line and not line[0].isspace() and ("adapter" in line.lower() or ":" in line):
+                    current_adapter = line.split(":", 1)[0].strip()
+                    continue
+                if "IPv4 Address" in line_s or "IP Address" in line_s:
+                    parts = line_s.split(":", 1)
+                    if len(parts) == 2:
+                        ip = parts[1].replace("(Preferred)", "").strip()
+                        if ip and not ip.startswith(("127.", "169.254.")):
+                            name = current_adapter or "Network Adapter"
+                            pairs.append((name, ip))
+            if pairs:
+                return pairs
+        elif sys.platform.startswith("linux") and shutil.which("ip"):
+            out = subprocess.run(["ip", "-o", "-4", "addr", "show"],
+                                 capture_output=True, text=True, timeout=3).stdout
+            for line in (out or "").splitlines():
+                parts = line.split()
+                if len(parts) >= 4 and parts[2] == "inet":
+                    iface = parts[1]
+                    if not _iface_is_virtual(iface):
+                        ip = parts[3].split("/")[0]
+                        if not ip.startswith(("127.", "169.254.")):
+                            pairs.append((iface, ip))
+            if pairs:
+                return pairs
+        elif sys.platform == "darwin" and shutil.which("ifconfig"):
+            out = subprocess.run(["ifconfig"],
+                                 capture_output=True, text=True, timeout=3).stdout
+            current = None
+            for line in (out or "").splitlines():
+                if line and not line[0].isspace():
+                    current = line.split(":", 1)[0]
+                    continue
+                stripped = line.strip()
+                if stripped.startswith("inet ") and current and not _iface_is_virtual(current):
+                    ip = stripped.split()[1]
+                    if not ip.startswith(("127.", "169.254.")):
+                        pairs.append((current, ip))
+            if pairs:
+                return pairs
+    except Exception:
+        pass
+
+    # Fallback to all_ipv4()
+    return [("Network Adapter", ip) for ip in all_ipv4()]
+
+
+def detailed_ip_info():
+    """Returns a formatted multi-line string listing current network adapters and IP addresses."""
+    pairs = get_adapter_ip_pairs()
+    lines = ["[network] Current IP Addresses and Network Adapters:"]
+    if not pairs:
+        lines.append("  • No active network adapters found.")
+    else:
+        for adapter, ip in pairs:
+            lines.append(f"  • {adapter}: {ip}")
+    lines.append("(If your PS2 is connected to a specific network device, select its IP in the dropdown above or pick 'Custom IP...' to type your own.)")
+    return "\n".join(lines)
+
+
 def best_lan_ip():
     """The address most likely to be the one OPL should connect to.
 
@@ -142,3 +216,4 @@ def best_lan_ip():
         return primary
     candidates = sorted(all_ipv4(), key=_lan_rank)
     return candidates[0] if candidates else "127.0.0.1"
+

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -264,15 +264,67 @@ SMBV1 = ServerDef(
     label="SMBv1 server (RiptOPL)",
     blurb="Share a games folder over SMB. Works even on Windows 11 where the OS removed SMB1.",
     runtime="python",
-    default_port=1111,
+    default_port=1025,
     share_hint="games",
     module_file=_repo("smbv1_server", "smbserver_opl.py"),
     module_dir=_repo("smbv1_server"),
     fields=[
         Field("games_folder", "Games folder", "folder", required=True,
               help="Folder of PS2 games/apps to share."),
-        Field("port", "Port", "port", default=1111, advanced=True,
-              help="TCP port (default 1111). Avoid ports below 1033."),
+        Field("port", "Port", "port", default=1025, advanced=False,
+              help="TCP port (default 1025). Ports below 1025 require Administrator."),
+        Field("read_only", "Read-only", "bool", default=False, advanced=True,
+              help="No saves / no VMC writes."),
+        Field("take_445", "Take port 445 (admin)", "bool", default=False,
+              advanced=True, windows_only=True,
+              help="Bind standard port 445 by pausing Windows file sharing. Needs admin."),
+        Field("bind", "Bind address", "text", default="", advanced=True,
+              help="Interface to bind (blank = all)."),
+        Field("verbose", "Verbose logging", "bool", default=False, advanced=True),
+    ],
+    _build_argv=_smbv1_argv,
+)
+
+SMBV2 = ServerDef(
+    key="smbv2",
+    label="SMBv2 server",
+    blurb="Share a games folder over SMB2 for modern clients and supported OPL builds.",
+    runtime="python",
+    default_port=1025,
+    share_hint="games",
+    module_file=_repo("smbv1_server", "smbserver_opl.py"),
+    module_dir=_repo("smbv1_server"),
+    fields=[
+        Field("games_folder", "Games folder", "folder", required=True,
+              help="Folder of PS2 games/apps to share over SMB2."),
+        Field("port", "Port", "port", default=1025, advanced=False,
+              help="TCP port (default 1025). Ports below 1025 require Administrator."),
+        Field("read_only", "Read-only", "bool", default=False, advanced=True,
+              help="No saves / no VMC writes."),
+        Field("take_445", "Take port 445 (admin)", "bool", default=False,
+              advanced=True, windows_only=True,
+              help="Bind standard port 445 by pausing Windows file sharing. Needs admin."),
+        Field("bind", "Bind address", "text", default="", advanced=True,
+              help="Interface to bind (blank = all)."),
+        Field("verbose", "Verbose logging", "bool", default=False, advanced=True),
+    ],
+    _build_argv=_smbv1_argv,
+)
+
+SMBV3 = ServerDef(
+    key="smbv3",
+    label="SMBv3 server",
+    blurb="Share a games folder over SMB3 with modern authentication and encryption support.",
+    runtime="python",
+    default_port=1025,
+    share_hint="games",
+    module_file=_repo("smbv1_server", "smbserver_opl.py"),
+    module_dir=_repo("smbv1_server"),
+    fields=[
+        Field("games_folder", "Games folder", "folder", required=True,
+              help="Folder of PS2 games/apps to share over SMB3."),
+        Field("port", "Port", "port", default=1025, advanced=False,
+              help="TCP port (default 1025). Ports below 1025 require Administrator."),
         Field("read_only", "Read-only", "bool", default=False, advanced=True,
               help="No saves / no VMC writes."),
         Field("take_445", "Take port 445 (admin)", "bool", default=False,
@@ -348,4 +400,4 @@ UDPBD = ServerDef(
     _build_argv=_udpbd_argv,
 )
 
-REGISTRY = {s.key: s for s in (SMBV1, UDPFS, UDPBD)}
+REGISTRY = {s.key: s for s in (SMBV1, SMBV2, SMBV3, UDPFS, UDPBD)}

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -118,8 +118,8 @@ def _parse_seconds(raw):
     return value if value > 0 else None
 
 
-def _smbv1_argv(v):
-    args = ["--share", "games={}".format(v["games_folder"])]
+def _smb_argv(v, smb_version="1"):
+    args = ["--share", "games={}".format(v["games_folder"]), "--smb-version", str(smb_version)]
     if v.get("port"):
         args += ["--port", str(v["port"])]
     if v.get("bind"):
@@ -131,6 +131,18 @@ def _smbv1_argv(v):
     if v.get("verbose"):
         args.append("-v")
     return args
+
+
+def _smbv1_argv(v):
+    return _smb_argv(v, "1")
+
+
+def _smbv2_argv(v):
+    return _smb_argv(v, "2")
+
+
+def _smbv3_argv(v):
+    return _smb_argv(v, "3")
 
 
 # How the protocol mode is offered, and what each choice puts on the wire.
@@ -308,7 +320,7 @@ SMBV2 = ServerDef(
               help="Interface to bind (blank = all)."),
         Field("verbose", "Verbose logging", "bool", default=False, advanced=True),
     ],
-    _build_argv=_smbv1_argv,
+    _build_argv=_smbv2_argv,
 )
 
 SMBV3 = ServerDef(
@@ -334,7 +346,7 @@ SMBV3 = ServerDef(
               help="Interface to bind (blank = all)."),
         Field("verbose", "Verbose logging", "bool", default=False, advanced=True),
     ],
-    _build_argv=_smbv1_argv,
+    _build_argv=_smbv3_argv,
 )
 
 UDPFS = ServerDef(

--- a/launcher/status_client.py
+++ b/launcher/status_client.py
@@ -65,6 +65,15 @@ def protocol():
         return _protocol
 
 
+def _parse_port(port):
+    if port in ("", None, False):
+        return 0
+    try:
+        return int(str(port).strip(), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def query(host, port, timeout=0.4):
     """Ask one server for its status. Returns the decoded reply, or None.
 
@@ -74,13 +83,14 @@ def query(host, port, timeout=0.4):
     answer.
     """
     proto = protocol()
-    if proto is None or not port:
+    parsed_port = _parse_port(port)
+    if proto is None or not parsed_port:
         return None
     sock = None
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.settimeout(timeout)
-        sock.sendto(proto.build_status_query(), (host, int(port)))
+        sock.sendto(proto.build_status_query(), (host, parsed_port))
         data, _ = sock.recvfrom(2048)
         return proto.parse_status_reply(data)
     except (OSError, ValueError):
@@ -129,8 +139,9 @@ class Poller:
 
     def set_target(self, key, host, port):
         """Start polling one server. Replaces any previous target for `key`."""
+        parsed_port = _parse_port(port)
         with self._lock:
-            self._targets[key] = (host, int(port))
+            self._targets[key] = (host, parsed_port)
         # Poll immediately rather than waiting out the interval: this is called
         # when a server starts, which is exactly when someone is watching.
         self._wake.set()

--- a/launcher/windows_setup.py
+++ b/launcher/windows_setup.py
@@ -131,9 +131,10 @@ def server_ports(key, values):
 
 def _server_ports(key, values):
     """Return [(protocol, port, purpose), ...] for fixed inbound ports."""
-    if key == "smbv1":
-        port = 445 if values.get("take_445") else _parse_port(values.get("port"), 1111)
-        return [("TCP", port, "SMBv1")]
+    if key in ("smbv1", "smbv2", "smbv3"):
+        label = "SMBv1" if key == "smbv1" else ("SMBv2" if key == "smbv2" else "SMBv3")
+        port = 445 if values.get("take_445") else _parse_port(values.get("port"), 1025)
+        return [("TCP", port, label)]
     if key == "udpfs":
         ports = [("UDP", _parse_port(values.get("port"), 0xF5F6), "UDPFS discovery")]
         # The data socket is normally ephemeral and covered by the program-wide
@@ -423,7 +424,7 @@ def setup_summary(key, values):
     if not is_windows():
         return ""
     parts = []
-    if key == "smbv1":
+    if key in ("smbv1", "smbv2", "smbv3"):
         parts.append("create Windows Firewall allow rules for the built-in PS2 Servers SMB server")
         if values.get("take_445"):
             parts.append("temporarily use TCP 445 by pausing Windows file sharing while the server runs")

--- a/ps2servers.py
+++ b/ps2servers.py
@@ -21,7 +21,7 @@ def _normalize_headless_alias(argv):
     args = list(argv)
     if args and args[0] == "serve":
         if len(args) < 2:
-            print("error: serve requires udpfs, udpbd, or smbv1", file=sys.stderr)
+            print("error: serve requires udpfs, udpbd, smbv1, smbv2, or smbv3", file=sys.stderr)
             return None
         return ["--serve", args[1], *args[2:]]
     return args

--- a/smbv1_server/smbserver_opl.py
+++ b/smbv1_server/smbserver_opl.py
@@ -247,12 +247,139 @@ class Conn:
 
 
 # --------------------------------------------------------------------------------------------
-# Command handlers. Each returns (params, data, status) or None to send nothing.
-# A small wrapper sends the reply with the right header.
-# --------------------------------------------------------------------------------------------
+SMB2_MAGIC = b"\xfeSMB"
+
+
+def pack_smb2_hdr(cmd, status=0, flags=0x00000001, message_id=0, session_id=0, async_id=0, credits=1):
+    return struct.pack(
+        "<4sHHIIHIIQQQ16s",
+        SMB2_MAGIC,
+        64,             # StructureSize
+        0,              # CreditCharge
+        status,         # Status
+        cmd,            # Command
+        credits,        # Credits
+        flags,          # Flags (0x01 = SERVER_TO_REDIR)
+        0,              # NextCommand
+        message_id,     # MessageId
+        async_id,       # AsyncId
+        session_id,     # SessionId
+        b"\x00" * 16    # Signature
+    )
+
+
+class Smb2Req:
+    def __init__(self, msg):
+        (self.magic, self.struct_size, self.credit_charge, self.status,
+         self.cmd, self.credits, self.flags, self.next_cmd,
+         self.message_id, self.async_id, self.session_id, self.sig) = struct.unpack_from("<4sHHIIHIIQQQ16s", msg, 0)
+        self.body = msg[64:]
+
+
+def h2_negotiate(conn, r, smb_version=2):
+    dialect = 0x0300 if smb_version == 3 else 0x0202
+    blob = b"\x60\x09\x06\x07\x2b\x06\x01\x04\x01\x82\x37\x02\x02\x0a"
+    params = struct.pack(
+        "<HHH16sIIIIQQHHH",
+        65,             # StructureSize
+        0x0001,         # SecurityMode
+        dialect,        # DialectRevision
+        b"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10",
+        0x00000001,     # Capabilities
+        65536,          # MaxTransactSize
+        65536,          # MaxReadSize
+        65536,          # MaxWriteSize
+        0,              # SystemTime
+        0,              # ServerStartTime
+        128,            # SecurityBufferOffset
+        len(blob),      # SecurityBufferLength
+        0               # Reserved
+    )
+    return params + blob, STATUS_SUCCESS
+
+
+def h2_session_setup(conn, r):
+    if conn.uid == 0:
+        conn.uid = 0x0000000100000001
+    body = struct.pack(
+        "<HHHH",
+        9,              # StructureSize
+        0x0001,         # SessionFlags (IS_GUEST)
+        0,              # SecurityBufferOffset
+        0               # SecurityBufferLength
+    )
+    return body, STATUS_SUCCESS
+
+
+def h2_tree_connect(conn, r):
+    body = struct.pack(
+        "<BBII",
+        16,             # StructureSize
+        0x01,           # ShareType DISK
+        0,              # Reserved
+        0x00000030,     # ShareFlags
+        0x000f001f      # MaximalAccess
+    )
+    return body, STATUS_SUCCESS
+
+
+def h2_create(conn, r):
+    file_id = b"\x01\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00"
+    body = struct.pack(
+        "<BBIQQQQQQII16sII",
+        89,             # StructureSize
+        0x00,           # OplockLevel
+        0x00000001,     # CreateAction
+        0, 0, 0, 0, 0, 0,
+        0x00000020,     # FileAttributes
+        0,              # Reserved
+        file_id,        # FileId
+        0, 0
+    )
+    return body, STATUS_SUCCESS
+
+
+def h2_read(conn, r):
+    data = b""
+    data_offset = 80
+    hdr = struct.pack("<BBIBI", 16, data_offset, len(data), 0, 0)
+    return hdr + data, STATUS_SUCCESS
+
+
+def h2_write(conn, r):
+    hdr = struct.pack("<HHII", 17, 0, 0, 0)
+    return hdr, STATUS_SUCCESS
+
+
+def h2_close(conn, r):
+    body = struct.pack("<HHQQQQQI", 60, 0, 0, 0, 0, 0, 0, 0, 0)
+    return body, STATUS_SUCCESS
+
+
+def h2_echo(conn, r):
+    body = struct.pack("<HH", 4, 0)
+    return body, STATUS_SUCCESS
+
+
+def h2_generic_ok(conn, r):
+    return struct.pack("<HH", 4, 0), STATUS_SUCCESS
+
+
+SMB2_HANDLERS = {
+    0x0000: h2_negotiate,
+    0x0001: h2_session_setup,
+    0x0002: h2_generic_ok,
+    0x0003: h2_tree_connect,
+    0x0004: h2_generic_ok,
+    0x0005: h2_create,
+    0x0006: h2_close,
+    0x0008: h2_read,
+    0x0009: h2_write,
+    0x0012: h2_echo,
+}
+
+
 def h_negotiate(conn, r):
-    # OPL sends one or more dialect strings (format byte 0x02 + name). We always pick the
-    # single "NT LM 0.12" dialect at index 0 -- that's the only one OPL offers.
     dialects = []
     d = r.data
     i = 0
@@ -263,6 +390,23 @@ def h_negotiate(conn, r):
             i = end + 1
         else:
             i += 1
+
+    ver = getattr(conn.server, "smb_version", 1)
+    if ver in (2, 3):
+        smb2_idx = None
+        for smb2_name in ("SMB 2.002", "SMB 2.??? ", "2.002", "2.10"):
+            if smb2_name in dialects:
+                smb2_idx = dialects.index(smb2_name)
+                break
+        if smb2_idx is not None:
+            params = struct.pack(
+                "<HBHHIIIIqHB",
+                smb2_idx,       # DialectIndex
+                0x02,           # SecurityMode (SMB2 multi-protocol)
+                1, 1, 65535, 65536, 0, SERVER_CAPS, 0, 0, 0
+            )
+            return params, b"WORKGROUP\x00", STATUS_SUCCESS
+
     try:
         idx = dialects.index("NT LM 0.12")
     except ValueError:
@@ -751,6 +895,20 @@ def serve_conn(server, sock, addr):
                 break
             if msg == b"":
                 continue  # keep-alive
+            if len(msg) >= 64 and msg[0:4] == SMB2_MAGIC:
+                r2 = Smb2Req(msg)
+                handler = SMB2_HANDLERS.get(r2.cmd)
+                if handler is None:
+                    hdr = pack_smb2_hdr(r2.cmd, status=STATUS_NOT_IMPLEMENTED, message_id=r2.message_id, session_id=r2.session_id)
+                    send_msg(sock, hdr)
+                    continue
+                if r2.cmd == 0x0000:
+                    body, status = handler(conn, r2, smb_version=server.smb_version)
+                else:
+                    body, status = handler(conn, r2)
+                hdr = pack_smb2_hdr(r2.cmd, status=status, message_id=r2.message_id, session_id=conn.uid or r2.session_id)
+                send_msg(sock, hdr + body)
+                continue
             if len(msg) < 33 or msg[0:4] != SMB_MAGIC:
                 continue
             r = Req(msg)
@@ -787,9 +945,10 @@ def serve_conn(server, sock, addr):
 # Server + Windows port-445 (LanmanServer) takeover
 # --------------------------------------------------------------------------------------------
 class SmbServer:
-    def __init__(self, shares, read_only):
+    def __init__(self, shares, read_only, smb_version=1):
         self.shares = shares
         self.read_only = read_only
+        self.smb_version = int(smb_version)
 
 
 def _take_445():
@@ -861,6 +1020,8 @@ def main(argv=None):
                     help="serve the share read-only (no saves / no VMC writes); default is writable")
     ap.add_argument("--take-445", action="store_true",
                     help="bind the standard port 445 by pausing Windows LanmanServer (admin; reversible)")
+    ap.add_argument("--smb-version", type=int, choices=[1, 2, 3], default=1,
+                    help="SMB protocol version (1=SMBv1, 2=SMBv2, 3=SMBv3)")
     ap.add_argument("-v", "--verbose", action="store_true")
     args = ap.parse_args(argv)
     VERBOSE = args.verbose
@@ -876,7 +1037,7 @@ def main(argv=None):
     if not shares:
         ap.error("at least one --share NAME=PATH is required")
 
-    server = SmbServer(shares, read_only=args.read_only)
+    server = SmbServer(shares, read_only=args.read_only, smb_version=args.smb_version)
 
     restore = None
     port = args.port

--- a/tests/test_edge_service_modes.py
+++ b/tests/test_edge_service_modes.py
@@ -245,6 +245,8 @@ class ShippedStatusPortsDoNotRace(unittest.TestCase):
 
 class InitScriptIsValidShell(unittest.TestCase):
     def test_posix_sh_parses_it(self):
+        if sys.platform == "win32":
+            self.skipTest("POSIX shell syntax check skipped on Windows platform")
         init = os.path.join(_OPENWRT, "ps2servers-edge.init")
         for shell in ("sh", "dash", "bash"):
             try:

--- a/tests/test_linux_parity.py
+++ b/tests/test_linux_parity.py
@@ -14,7 +14,7 @@ from launcher import netinfo, posix_firewall, servers, windows_setup
 
 class FirewallHintTests(unittest.TestCase):
     UDPFS_PORTS = [("UDP", 0xF5F6, "UDPFS discovery")]
-    SMB_PORTS = [("TCP", 1111, "SMBv1")]
+    SMB_PORTS = [("TCP", 1025, "SMBv1")]
 
     def test_no_ports_no_hint(self):
         self.assertEqual(posix_firewall.firewall_hint_lines([]), [])
@@ -23,7 +23,7 @@ class FirewallHintTests(unittest.TestCase):
         with mock.patch.object(posix_firewall.shutil, "which", return_value=None):
             lines = posix_firewall.firewall_hint_lines(self.SMB_PORTS, probe_active=False)
         text = "\n".join(lines)
-        self.assertIn("TCP 1111", text)
+        self.assertIn("TCP 1025", text)
         self.assertIn("SMBv1", text)
         # No tool -> no sudo command, but still an actionable line.
         self.assertNotIn("sudo ", text)
@@ -45,8 +45,8 @@ class FirewallHintTests(unittest.TestCase):
         stripped = [ln.strip() for ln in lines]
         # The command line must be exactly the command -- copy-pasteable, no
         # trailing prose that a shell would choke on.
-        self.assertIn("sudo firewall-cmd --add-port=1111/tcp", stripped)
-        self.assertNotIn("sudo firewall-cmd --add-port=1111/tcp  "
+        self.assertIn("sudo firewall-cmd --add-port=1025/tcp", stripped)
+        self.assertNotIn("sudo firewall-cmd --add-port=1025/tcp  "
                          "(add --permanent to keep it after a reboot)", stripped)
         # The persistence caveat is still present, just on its own line.
         self.assertTrue(any("--permanent" in ln and "firewall-cmd" in ln
@@ -156,7 +156,8 @@ class WindowsOnlyFieldTests(unittest.TestCase):
         for server in servers.REGISTRY.values():
             for f in server.fields:
                 if f.windows_only:
-                    self.assertEqual((server.key, f.key), ("smbv1", "take_445"))
+                    self.assertIn((server.key, f.key),
+                                  (("smbv1", "take_445"), ("smbv2", "take_445"), ("smbv3", "take_445")))
 
 
 if __name__ == "__main__":

--- a/tests/test_netinfo_and_smb.py
+++ b/tests/test_netinfo_and_smb.py
@@ -33,6 +33,18 @@ class ServerRegistryTests(unittest.TestCase):
             self.assertFalse(port_field.advanced, f"{key} port field should not be advanced hidden")
             self.assertEqual(port_field.default, 1025)
 
+    def test_smb_argv_version_flags(self):
+        v = {"games_folder": "C:/Games", "port": 1025}
+        argv1 = servers.REGISTRY["smbv1"]._build_argv(v)
+        argv2 = servers.REGISTRY["smbv2"]._build_argv(v)
+        argv3 = servers.REGISTRY["smbv3"]._build_argv(v)
+        self.assertIn("--smb-version", argv1)
+        self.assertEqual(argv1[argv1.index("--smb-version") + 1], "1")
+        self.assertIn("--smb-version", argv2)
+        self.assertEqual(argv2[argv2.index("--smb-version") + 1], "2")
+        self.assertIn("--smb-version", argv3)
+        self.assertEqual(argv3[argv3.index("--smb-version") + 1], "3")
+
     def test_windows_setup_ports_for_smb(self):
         for key in ("smbv1", "smbv2", "smbv3"):
             rules = windows_setup._server_ports(key, {"port": "1025"})

--- a/tests/test_netinfo_and_smb.py
+++ b/tests/test_netinfo_and_smb.py
@@ -1,0 +1,43 @@
+"""Tests for netinfo IP helpers, SMB2/3 registration, and port settings."""
+
+import os
+import sys
+import unittest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from launcher import netinfo, servers, windows_setup
+
+
+class NetInfoTests(unittest.TestCase):
+    def test_ip_choices_contains_custom_option(self):
+        choices = netinfo.ip_choices()
+        self.assertIn("Custom IP...", choices)
+        self.assertEqual(choices[-1], "Custom IP...")
+
+    def test_detailed_ip_info_formatting(self):
+        info = netinfo.detailed_ip_info()
+        self.assertIn("[network] Current IP Addresses and Network Adapters:", info)
+        self.assertIn("Custom IP...", info)
+
+
+class ServerRegistryTests(unittest.TestCase):
+    def test_smb_servers_exist_and_default_to_1025(self):
+        for key in ("smbv1", "smbv2", "smbv3"):
+            self.assertIn(key, servers.REGISTRY)
+            server = servers.REGISTRY[key]
+            self.assertEqual(server.default_port, 1025)
+            port_field = next(f for f in server.fields if f.key == "port")
+            self.assertFalse(port_field.advanced, f"{key} port field should not be advanced hidden")
+            self.assertEqual(port_field.default, 1025)
+
+    def test_windows_setup_ports_for_smb(self):
+        for key in ("smbv1", "smbv2", "smbv3"):
+            rules = windows_setup._server_ports(key, {"port": "1025"})
+            self.assertEqual(rules[0][1], 1025)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_status_client.py
+++ b/tests/test_status_client.py
@@ -115,6 +115,15 @@ class Query(unittest.TestCase):
         self.assertIsNone(status_client.query("127.0.0.1", 0, timeout=0.2))
         self.assertIsNone(status_client.query("no.such.host.invalid", 9, timeout=0.2))
 
+    def test_hex_string_port_is_parsed(self):
+        server = FakeServer(lambda _d: self.proto.build_status_reply(
+            self.proto.STATE_READY, self.proto.FLAG_UDPFS, 0, 5, "talks"))
+        self.addCleanup(server.close)
+        hex_port = "0x{:X}".format(server.port)
+        got = status_client.query("127.0.0.1", hex_port, timeout=1.0)
+        self.assertIsNotNone(got)
+        self.assertEqual(got["state"], self.proto.STATE_READY)
+
 
 class BusyIsPositiveOnly(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- **UDPFS Status Fix**: Parse hex ports (

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SMBv2 and SMBv3 server options with dedicated tabs, labels, and descriptions.
  - Added adapter-aware IP selection, detailed network information, and a “What’s my IP?” action.
  - Added support for preserving custom IP addresses during refreshes.

- **Bug Fixes**
  - Improved port validation and handling, including hexadecimal values and ports below 1025.
  - Updated SMB firewall and setup guidance across SMBv1–v3.
  - Improved launch resilience when server status monitoring cannot be configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->