### PR TITLE
fix(gui): wrap the terminal log, and let the whole window reflow

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -48,18 +48,73 @@ COLOR_RUNNING = "#2e9e44"
 COLOR_STOPPED = "#b0b0b0"
 COLOR_ERROR = "#d23c3c"
 
-APP_CONTENT_WIDTH = 1000
-APP_WINDOW_WIDTH = 1024
+APP_WINDOW_WIDTH = 1024     # preferred opening width; the window resizes freely
 APP_INITIAL_HEIGHT = 760
+APP_MIN_WIDTH = 780
 APP_MIN_HEIGHT = 420
+# The tab strip's right-hand tail: the notebook's right tabmargin and border, which
+# sit past the last tab and so are not included when the strip is measured, plus a
+# few pixels of slack so the last tab keeps its whole border at the minimum width.
+TAB_STRIP_TAIL = 18
 
-# Field help wraps at a fixed pixel width: the window is width-locked (resizable(False, True)
-# plus _enforce_fixed_width) and the scroll canvas pins its content to APP_CONTENT_WIDTH, so
-# there is no horizontal resize for a wraplength to track. The 220px reserve clears the widest
-# field label (161px) plus card padding and grid padx at either placement below.
-HELP_WRAPLENGTH = APP_CONTENT_WIDTH - 220
+# The window resizes in both directions and the scroll canvas hands its full width
+# to the content, so nothing may carry a hard-coded wraplength: every wrapping label
+# tracks the real width of a frame that resizes with the window (bind_wraplength).
+#
+# Card text measures against the NOTEBOOK, not the card: ttk unmaps unselected tabs,
+# so a card the user has not visited has no width yet, and asking it would feed each
+# label a made-up figure -- which the card then reports back as the width it needs,
+# widening the whole page. The notebook is always laid out. These reserves are the
+# padding chain between it and the text: notebook padding + tab border + the card's
+# grid padx + card padding + label padx, then the field label column for help text.
+CARD_TEXT_RESERVE = 72
+HELP_RESERVE = 190
 # Indent checkbox help past the indicator so it lines up under the label, not under the box.
 CHECK_HELP_INDENT = 27
+CHECK_HELP_RESERVE = CARD_TEXT_RESERVE + CHECK_HELP_INDENT
+# Never wrap narrower than this, however small the window gets: past this point the
+# text is unreadable anyway, and letting it clip is the honest failure -- the page
+# scrollbar and the window's own minsize are what keep it from happening.
+WRAP_MIN = 200
+# Ignore sub-8px width changes. Setting wraplength re-requests the label's size, so a
+# label that chases every pixel can trade requests with its container forever; a dead
+# band that big is below one character and settles immediately.
+WRAP_STEP = 8
+
+
+def bind_wraplength(widget, source, reserve=0, siblings=(), minimum=WRAP_MIN):
+    """Keep widget's wraplength tracking the real width of source.
+
+    reserve is fixed padding to hold back; siblings are widgets sharing the row,
+    whose measured width is held back too -- so the reserve follows the actual
+    font, theme and DPI rather than a number guessed at one screen size.
+    """
+    def update(_event=None):
+        try:
+            width = source.winfo_width()
+            if width <= 1:
+                # Not laid out yet. Leave the current wrap alone rather than wrap
+                # to a guess: the first <Configure> after the window is drawn is
+                # what sets the real value, and it always arrives.
+                return
+            for sibling in siblings:
+                width -= max(sibling.winfo_width(), sibling.winfo_reqwidth())
+            width = max(minimum, width - reserve)
+            current = int(widget.cget("wraplength") or 0)
+            if abs(current - width) >= WRAP_STEP:
+                widget.configure(wraplength=width)
+        except (tk.TclError, ValueError):
+            pass
+
+    try:
+        source.bind("<Configure>", update, add="+")
+        widget.after_idle(update)
+    except (tk.TclError, AttributeError):
+        # Nothing to track (a card built outside a real window, say). The label
+        # keeps its default wrap; text that does not resize is not worth an
+        # exception out of a widget constructor.
+        pass
+    return update
 
 PROJECT_URL = "https://www.psx-place.com/resources/windows-linux-mac-ps2-servers-smbv1-udpbd-udpfs-for-everyone.1728/"
 REPO_URL = "https://github.com/NathanNeurotic/PS2-Servers"
@@ -197,6 +252,15 @@ class ServerCard(ttk.LabelFrame):
         self._advanced_shown = False
         self._build()
 
+    def _wrap_source(self):
+        """The widget whose width the card's wrapping text follows.
+
+        The notebook, because it is always mapped (see CARD_TEXT_RESERVE). The
+        card itself is the fallback for anywhere a card is built outside one --
+        including a bare card in a test, which has no app at all.
+        """
+        return getattr(getattr(self, "app", None), "nb", None) or self
+
     # -- widget construction ---------------------------------------------- #
     def _build(self):
         self.configure(padding=(12, 10, 12, 12))
@@ -214,9 +278,9 @@ class ServerCard(ttk.LabelFrame):
             row += 1
 
         # header: blurb + status + start/stop
-        ttk.Label(self, text=self.server.blurb, wraplength=560,
-                  style="CardMuted.TLabel").grid(row=row, column=0, columnspan=3,
-                                                 sticky="w", padx=4, pady=(2, 6))
+        blurb = ttk.Label(self, text=self.server.blurb, style="CardMuted.TLabel")
+        blurb.grid(row=row, column=0, columnspan=3, sticky="w", padx=4, pady=(2, 6))
+        bind_wraplength(blurb, self._wrap_source(), reserve=CARD_TEXT_RESERVE)
         row += 1
 
         self.status = ttk.Label(self, text=DOT_RUNNING + " Stopped",
@@ -256,10 +320,10 @@ class ServerCard(ttk.LabelFrame):
                 arow = self._add_field(self.adv_frame, f, arow)
             row += 1
 
-        self.hint = ttk.Label(self, text="", style="CardHint.TLabel",
-                              wraplength=720)
+        self.hint = ttk.Label(self, text="", style="CardHint.TLabel")
         self.hint.grid(row=row, column=0, columnspan=3, sticky="w",
                        padx=4, pady=(4, 0))
+        bind_wraplength(self.hint, self._wrap_source(), reserve=CARD_TEXT_RESERVE)
 
     def _refresh_tab_dot(self, running):
         """Mark this server's tab up or down.
@@ -283,13 +347,13 @@ class ServerCard(ttk.LabelFrame):
         except tk.TclError:
             pass
 
-    def _add_help(self, parent, text, row, column, indent):
+    def _add_help(self, parent, text, row, column, indent, reserve):
         # Own row, so help never overlaps the entry or Browse button. columnspan
         # reaches the card's last column (2) from wherever it starts.
-        ttk.Label(parent, text=text, style="CardHelp.TLabel", font=("", 8),
-                  wraplength=HELP_WRAPLENGTH).grid(
-            row=row, column=column, columnspan=3 - column, sticky="w",
-            padx=(indent, 4), pady=(0, 4))
+        label = ttk.Label(parent, text=text, style="CardHelp.TLabel", font=("", 8))
+        label.grid(row=row, column=column, columnspan=3 - column, sticky="w",
+                   padx=(indent, 4), pady=(0, 4))
+        bind_wraplength(label, self._wrap_source(), reserve=reserve)
         return row + 1
 
     def _add_field(self, parent, f, row):
@@ -301,7 +365,8 @@ class ServerCard(ttk.LabelFrame):
             self.vars[f.key] = var
             row += 1
             if f.help:
-                row = self._add_help(parent, f.help, row, 0, CHECK_HELP_INDENT)
+                row = self._add_help(parent, f.help, row, 0, CHECK_HELP_INDENT,
+                                     CHECK_HELP_RESERVE)
             return row
 
         ttk.Label(parent, text=f.label + ":", style="Card.TLabel").grid(
@@ -343,7 +408,7 @@ class ServerCard(ttk.LabelFrame):
         self.vars[f.key] = var
         row += 1
         if f.help:
-            row = self._add_help(parent, f.help, row, 1, 6)
+            row = self._add_help(parent, f.help, row, 1, 6, HELP_RESERVE)
         return row
 
     def _toggle_advanced(self):
@@ -515,6 +580,8 @@ class LauncherApp:
         self._update_tray_option_controls()
 
         self.root.after(150, self._drain_logs)
+        # Once the window is drawn, so the tab strip has a width to measure.
+        self.root.after(200, self._apply_tab_minimum_width)
         self.root.after(600, self._poll_status)
         if self.saved.get("pending_firewall_allow"):
             self.root.after(350, self._allow_pending)
@@ -541,66 +608,147 @@ class LauncherApp:
                 self.root.after(600, self._direct_link_reset_stale_unix)
 
     def _configure_window(self):
-        screen_height = self.root.winfo_screenheight()
+        screen_width = max(640, self.root.winfo_screenwidth())
+        screen_height = max(480, self.root.winfo_screenheight())
+        width = min(APP_WINDOW_WIDTH, max(APP_MIN_WIDTH, screen_width - 96))
         height = min(APP_INITIAL_HEIGHT, max(APP_MIN_HEIGHT, screen_height - 80))
-        self.root.geometry("{}x{}".format(APP_WINDOW_WIDTH, height))
-        self.root.minsize(APP_WINDOW_WIDTH, APP_MIN_HEIGHT)
-        self.root.maxsize(APP_WINDOW_WIDTH, max(APP_MIN_HEIGHT, screen_height))
-        self.root.resizable(False, True)
-        self.root.bind("<Configure>", self._enforce_fixed_width, add="+")
+        x = max(0, int((screen_width - width) / 2))
+        y = max(0, int((screen_height - height) / 3))
+        self.root.geometry("{}x{}+{}+{}".format(width, height, x, y))
+        # Free in both directions, with no maxsize: the content reflows to the
+        # width it is given, so there is nothing left for a width lock to protect.
+        # The minimum is what the button rows and field columns need, capped to the
+        # screen so a small display can still show the whole window.
+        self._min_height = min(APP_MIN_HEIGHT, screen_height - 40)
+        self.root.minsize(min(APP_MIN_WIDTH, screen_width - 40), self._min_height)
+        self.root.resizable(True, True)
 
-    def _enforce_fixed_width(self, event):
-        if str(event.widget) != str(self.root) or event.height <= 1:
+    def _tab_strip_width(self):
+        """How much width the tab row actually uses, measured rather than guessed.
+
+        ttk offers no query for it, so probe the row: identify() names an element
+        while x is over a tab and returns nothing past the last one. Binary search,
+        so it costs about ten calls instead of one per pixel. Returns 0 if the
+        notebook is not laid out or the probe finds no tab -- callers keep their
+        default rather than act on a measurement that did not happen.
+        """
+        nb = getattr(self, "nb", None)
+        if nb is None:
+            return 0
+        try:
+            width = nb.winfo_width()
+            if width <= 1:
+                return 0
+            # Start inside the first tab, past the notebook's own left tabmargin.
+            probe = 20
+            row = next((y for y in (10, 14, 18, 22, 6) if nb.identify(probe, y)),
+                       None)
+            if row is None:
+                return 0
+            if nb.identify(width - 2, row):
+                return width              # already filling the notebook, or clipped
+            low, high = probe, width - 2  # low is over a tab; high is past the last
+            while high - low > 2:
+                mid = (low + high) // 2
+                if nb.identify(mid, row):
+                    low = mid
+                else:
+                    high = mid
+            return high
+        except tk.TclError:
+            return 0
+
+    def _apply_tab_minimum_width(self):
+        """Never let the window shrink past its own tab strip.
+
+        The tabs are the one thing on the page that cannot reflow -- ttk neither
+        wraps nor scrolls them, so a window narrower than the strip simply hides
+        the last tab (ABOUT). Measuring beats a constant here: the strip's width
+        follows the theme's tab padding, the user's font and DPI, and how many
+        servers this build ships, none of which are known when writing a number.
+        """
+        strip = self._tab_strip_width()
+        if strip <= 0:
             return
-        if event.width == APP_WINDOW_WIDTH and self.root.state() != "zoomed":
-            return
-
-        def resize():
-            try:
-                height = self.root.winfo_height()
-                if height <= 1:
-                    height = event.height
-                height = min(max(APP_MIN_HEIGHT, height),
-                             self.root.winfo_screenheight())
-                if self.root.state() == "zoomed":
-                    self.root.state("normal")
-                self.root.geometry("{}x{}".format(APP_WINDOW_WIDTH, height))
-            except tk.TclError:
-                pass
-
-        self.root.after_idle(resize)
+        # Everything the window spends before the notebook starts -- page padding,
+        # window border, and the page scrollbar when it is out -- measured rather
+        # than added up from the padx values, which would miss the scrollbar and
+        # go stale the moment any of them changes.
+        chrome = max(0, self.root.winfo_width() - self.nb.winfo_width())
+        if not self._scrollbar.winfo_ismapped():
+            chrome += self._scrollbar.winfo_reqwidth()
+        screen_width = max(640, self.root.winfo_screenwidth())
+        needed = strip + TAB_STRIP_TAIL + chrome
+        minimum = min(max(APP_MIN_WIDTH, needed), screen_width - 40)
+        try:
+            self.root.minsize(minimum, self._min_height)
+            if self.root.winfo_width() < minimum:
+                self.root.geometry("{}x{}".format(minimum,
+                                                  self.root.winfo_height()))
+        except tk.TclError:
+            pass
 
     def _build_scroll_body(self):
         bg = self.root.cget("background")
-        canvas = tk.Canvas(self.root, width=APP_CONTENT_WIDTH, highlightthickness=0,
-                           bd=0, background=bg)
-        scrollbar = ttk.Scrollbar(self.root, orient="vertical", command=canvas.yview)
+        shell = ttk.Frame(self.root)
+        shell.pack(fill="both", expand=True)
+
+        canvas = tk.Canvas(shell, highlightthickness=0, bd=0, background=bg)
+        scrollbar = ttk.Scrollbar(shell, orient="vertical", command=canvas.yview)
         canvas.configure(yscrollcommand=scrollbar.set)
-        scrollbar.pack(side="right", fill="y")
         canvas.pack(side="left", fill="both", expand=True)
 
         body = ttk.Frame(canvas)
-        window = canvas.create_window((0, 0), window=body, anchor="nw",
-                                      width=APP_CONTENT_WIDTH)
+        window = canvas.create_window((0, 0), window=body, anchor="nw")
 
         def refresh_scroll_region(event=None):
-            height = max(1, body.winfo_reqheight())
-            current_width = str(canvas.itemcget(window, "width"))
-            current_height = str(canvas.itemcget(window, "height"))
-            if current_width != str(APP_CONTENT_WIDTH) or current_height != str(height):
-                canvas.itemconfigure(window, width=APP_CONTENT_WIDTH, height=height)
-                scrollregion = canvas.bbox("all")
-                if scrollregion:
-                    canvas.configure(scrollregion=scrollregion)
+            try:
+                width = max(1, canvas.winfo_width())
+                view = max(1, canvas.winfo_height())
+                content = max(1, body.winfo_reqheight())
+                # Hand the body the full viewport, not just what it asked for, so
+                # spare vertical space goes to the notebook (a taller TERMINAL)
+                # instead of sitting as dead grey under the page.
+                height = max(content, view)
+                if (str(canvas.itemcget(window, "width")) != str(width)
+                        or str(canvas.itemcget(window, "height")) != str(height)):
+                    canvas.itemconfigure(window, width=width, height=height)
+                canvas.configure(scrollregion=(0, 0, width, height))
+                self._sync_body_scrollbar(content, view)
+            except tk.TclError:
+                pass
 
         body.bind("<Configure>", refresh_scroll_region)
         canvas.bind("<Configure>", refresh_scroll_region)
+        self._scroll_shell = shell
         self._scroll_canvas = canvas
         self._scrollbar = scrollbar
         self._scroll_window = window
         self._bind_body_mousewheel(canvas)
         self._refresh_scroll_body = refresh_scroll_region
         return body
+
+    def _sync_body_scrollbar(self, content_height, view_height):
+        """Show the page scrollbar only when the page genuinely overflows.
+
+        A permanent bar on a page that fits is noise, and it eats width the text
+        could have used. Hiding it can only ever give the content MORE width, and
+        more width never makes the page taller, so this settles in one pass
+        instead of flickering between the two states.
+        """
+        bar, canvas = self._scrollbar, self._scroll_canvas
+        needed = content_height > view_height + 2
+        try:
+            shown = bool(bar.winfo_ismapped())
+            if needed and not shown:
+                # before=canvas: the canvas is packed fill+expand and would
+                # otherwise swallow the whole cavity, leaving the bar zero width.
+                bar.pack(side="right", fill="y", before=canvas)
+            elif not needed and shown:
+                bar.pack_forget()
+                canvas.yview_moveto(0)   # nothing left to scroll back with
+        except tk.TclError:
+            pass
 
     def _bind_body_mousewheel(self, canvas):
         def should_scroll_page(event):
@@ -649,7 +797,7 @@ class LauncherApp:
         # Always-visible version, so a tester can read it off the screen without
         # opening About. Right-aligned in the header's stretchy column.
         ttk.Label(header, text="PS2 Servers " + APP_VERSION_LABEL,
-                  style="TopStripHint.TLabel").grid(row=0, column=5, sticky="e",
+                  style="TopStripHint.TLabel").grid(row=0, column=4, sticky="e",
                                                     padx=(12, 0))
         self.ip_var = tk.StringVar(value=netinfo.best_lan_ip())
         # Editable, not readonly: detection leans on getaddrinfo(gethostname()),
@@ -670,11 +818,15 @@ class LauncherApp:
             row=0, column=2, sticky="w")
         ttk.Button(header, text="What's my IP?", command=self._show_whats_my_ip).grid(
             row=0, column=3, sticky="w", padx=(4, 0))
-        ttk.Label(header, text="Enter this in OPL where it asks for the PC/server IP. "
-                  "Pick from the list, or type your own if the right address "
-                  "isn't shown -- it saves as you type.",
-                  style="TopStripHint.TLabel", wraplength=420).grid(
-            row=0, column=4, sticky="w", padx=(12, 0))
+        # Its own full-width row rather than a fifth column on the controls row:
+        # four controls plus a paragraph cannot share one row at every window
+        # width, and a row of its own reflows to any width without squeezing them.
+        ip_hint = ttk.Label(header, text="Enter this in OPL where it asks for the "
+                            "PC/server IP. Pick from the list, or type your own if "
+                            "the right address isn't shown -- it saves as you type.",
+                            style="TopStripHint.TLabel")
+        ip_hint.grid(row=1, column=0, columnspan=5, sticky="w", pady=(6, 0))
+        bind_wraplength(ip_hint, header, reserve=24)
 
         # direct PS2-to-PC link: adapter setup + DHCP helper behind one checkbox.
         # Available on every desktop OS; the per-OS network plumbing differs, and
@@ -691,24 +843,32 @@ class LauncherApp:
             self._direct_check.grid(row=0, column=0, sticky="w")
             self._direct_status = ttk.Label(
                 direct, text=self._DIRECT_STATUS_OFF,
-                style="TopStripHint.TLabel", wraplength=640)
+                style="TopStripHint.TLabel")
             self._direct_status.grid(row=0, column=1, sticky="w", padx=(12, 0))
+            # Reserve the checkbox's measured width, so the status wraps against
+            # whatever the tick box actually takes at this font and DPI.
+            bind_wraplength(self._direct_status, direct, reserve=36,
+                            siblings=(self._direct_check,))
             if _direct_link_experimental():
                 osname = "macOS" if platform.system() == "Darwin" else "Linux"
-                ttk.Label(
-                    direct, style="TopStripHint.TLabel", wraplength=900,
+                experimental = ttk.Label(
+                    direct, style="TopStripHint.TLabel",
                     text="Experimental on {}: it sets up the port and needs your "
                          "password. If anything looks off, untick it and send the "
-                         "TERMINAL output.".format(osname)).grid(
-                    row=1, column=0, columnspan=2, sticky="w", pady=(4, 0))
+                         "TERMINAL output.".format(osname))
+                experimental.grid(row=1, column=0, columnspan=2, sticky="w",
+                                  pady=(4, 0))
+                bind_wraplength(experimental, direct, reserve=24)
         else:
             self.direct_link_var = None
             self._direct_check = None
             self._direct_status = None
 
-        # main tabs: one server per tab, plus a shared terminal tab
+        # main tabs: one server per tab, plus a shared terminal tab. expand=True so
+        # a taller window grows the tab body (mainly the TERMINAL log) instead of
+        # leaving empty page below it.
         self.nb = ttk.Notebook(parent)
-        self.nb.pack(fill="x", padx=16, pady=(0, 12))
+        self.nb.pack(fill="both", expand=True, padx=16, pady=(0, 12))
         self.server_tabs = {}
         self._init_tab_dots()
 
@@ -732,7 +892,13 @@ class LauncherApp:
         self.terminal_tab.rowconfigure(0, weight=1)
         self.terminal_tab.columnconfigure(0, weight=1)
         _p = theme.PALETTE
-        self.terminal = tk.Text(self.terminal_tab, height=16, wrap="none",
+        # wrap="word": a log line is read, not scrolled to. With no wrap, the long
+        # lines servers print (paths, commands, firewall rules) ran off the right
+        # edge with no horizontal bar to chase them, so the end of the line -- the
+        # part that says what went wrong -- was simply unreachable. Wrapping is the
+        # only setting here that can never hide text. height is a floor, not a size:
+        # the tab expands, so the log takes whatever the window has spare.
+        self.terminal = tk.Text(self.terminal_tab, height=10, wrap="word",
                                 state="disabled", background=_p["entry"],
                                 foreground=_p["text"], insertbackground=_p["accent"],
                                 selectbackground=_p["panel3"], selectforeground=_p["text"],
@@ -844,15 +1010,26 @@ class LauncherApp:
         text_frame.rowconfigure(0, weight=1)
         text_frame.columnconfigure(0, weight=1)
         _p = theme.PALETTE
-        text = tk.Text(text_frame, wrap="word", height=18, state="normal",
+        # height is a floor: the tab expands, so About uses the window it is given.
+        text = tk.Text(text_frame, wrap="word", height=10, state="normal",
                        background=_p["panel"], foreground=_p["text"],
                        insertbackground=_p["accent"], selectbackground=_p["panel3"],
                        selectforeground=_p["text"], borderwidth=0,
                        highlightthickness=0, padx=12, pady=10)
         scroll = ttk.Scrollbar(text_frame, orient="vertical", command=text.yview)
-        text.configure(yscrollcommand=scroll.set)
         text.grid(row=0, column=0, sticky="nsew")
         scroll.grid(row=0, column=1, sticky="ns")
+        # Out only while there is something to scroll. Unlike the TERMINAL -- where
+        # the bar is a standing sign that the log runs past the window -- About is a
+        # page of prose, and on a tall window the whole thing fits.
+        def sync(first, last):
+            scroll.set(first, last)
+            if float(first) <= 0.0 and float(last) >= 1.0:
+                scroll.grid_remove()
+            else:
+                scroll.grid()
+
+        text.configure(yscrollcommand=sync)
         text.insert("1.0", ABOUT_TEXT)
         text.config(state="disabled")
 

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -81,10 +81,11 @@ PS2 Servers runs the same three servers here as on Windows. A few things differ:
 
 
 def _apply_gui_review_fixes(gui):
-    """Apply the active launcher theme and a stable, responsive layout baseline.
+    """Apply the active launcher theme, the admin panel, and the styled tab bar.
 
-    This stays as a runtime shim so release-risk remains low, but it deliberately
-    avoids image stretching, fixed-width root geometry, and off-screen button rows.
+    This stays as a runtime shim so release-risk remains low. It no longer touches
+    window sizing or the scrolling body: those are gui.py's, and keeping a second
+    copy here only gave the two a way to disagree.
     """
     original_notebook = gui.ttk.Notebook
     original_launcher_init = gui.LauncherApp.__init__
@@ -202,7 +203,13 @@ def _apply_gui_review_fixes(gui):
         # page below. clam otherwise blends its own lighter fill onto the raised
         # selected tab (a washed-out, low-contrast box), so light/dark/bordercolor
         # are pinned per state to keep every tab exactly the colour asked for.
-        style.configure("Server.TNotebook.Tab", padding=(18, 9), font=("", 10, "bold"),
+        #
+        # 12px of horizontal padding, not 18: the tab strip is the one part of the
+        # page that cannot reflow, so its width sets how narrow the window is
+        # allowed to get (see gui._apply_tab_minimum_width). Six pixels a side
+        # across seven tabs is ~84px off that floor, and the tab labels already
+        # carry a space either side.
+        style.configure("Server.TNotebook.Tab", padding=(12, 9), font=("", 10, "bold"),
                         background=palette["panel"], foreground=palette["muted"],
                         borderwidth=1, bordercolor=palette["edge"],
                         lightcolor=palette["panel"], darkcolor=palette["panel"])
@@ -250,67 +257,9 @@ def _apply_gui_review_fixes(gui):
                                   ("active", palette["accent2"]),
                                   ("!active", palette["panel3"])])
 
-    def configure_window(self):
-        screen_width = max(640, self.root.winfo_screenwidth())
-        screen_height = max(480, self.root.winfo_screenheight())
-        width = min(1040, max(760, screen_width - 96))
-        height = min(780, max(520, screen_height - 96))
-        min_width = min(760, max(640, screen_width - 96))
-        min_height = min(480, max(420, screen_height - 96))
-        x = max(0, int((screen_width - width) / 2))
-        y = max(0, int((screen_height - height) / 3))
-        self.root.geometry("{}x{}+{}+{}".format(width, height, x, y))
-        self.root.minsize(min_width, min_height)
-        self.root.resizable(True, True)
-
-    def build_scroll_body(self):
-        bg = self.root.cget("background")
-        shell = gui.ttk.Frame(self.root)
-        shell.pack(fill="both", expand=True)
-
-        canvas = gui.tk.Canvas(shell, highlightthickness=0, bd=0, background=bg)
-        scrollbar = gui.ttk.Scrollbar(shell, orient="vertical", command=canvas.yview)
-        canvas.configure(yscrollcommand=scrollbar.set)
-        scrollbar.pack(side="right", fill="y")
-        canvas.pack(side="left", fill="both", expand=True)
-
-        body = gui.ttk.Frame(canvas)
-        window = canvas.create_window((0, 0), window=body, anchor="nw")
-
-        def refresh_scroll_region(event=None):
-            try:
-                width = max(1, canvas.winfo_width())
-                height = max(1, body.winfo_reqheight())
-                canvas.itemconfigure(window, width=width)
-                canvas.configure(scrollregion=(0, 0, width, height))
-            except gui.tk.TclError:
-                pass
-
-        body.bind("<Configure>", refresh_scroll_region)
-        canvas.bind("<Configure>", refresh_scroll_region)
-        self._scroll_shell = shell
-        self._scroll_canvas = canvas
-        self._scrollbar = scrollbar
-        self._scroll_window = window
-        self._bind_body_mousewheel(canvas)
-        self._refresh_scroll_body = refresh_scroll_region
-        return body
-
-    def set_wrap(widget, width):
-        try:
-            widget.configure(wraplength=max(220, int(width)))
-        except gui.tk.TclError:
-            pass
-
-    def bind_wrap(widget, offset=48):
-        def update(event=None):
-            try:
-                root_width = widget.winfo_toplevel().winfo_width()
-                set_wrap(widget, root_width - offset)
-            except gui.tk.TclError:
-                pass
-        widget.bind("<Configure>", update, add="+")
-        widget.after_idle(update)
+    # Window sizing and the scrolling body used to be overridden here as well.
+    # They are not any more: gui.py owns one responsive implementation, and a
+    # second copy in this shim was free to drift out of step with it.
 
     def add_admin_panel(self):
         if not gui.windows_setup.is_windows():
@@ -322,21 +271,26 @@ def _apply_gui_review_fixes(gui):
         is_admin = gui.elevate.is_admin()
         status_style = "AdminYes.TLabel" if is_admin else "AdminNo.TLabel"
         status_text = "Administrator: Yes" if is_admin else "Administrator: No"
-        gui.ttk.Label(frame, text=status_text, style=status_style,
-                      font=("", 9, "bold")).grid(row=0, column=0, sticky="w",
-                                                 padx=(0, 12), pady=(0, 4))
+        status = gui.ttk.Label(frame, text=status_text, style=status_style,
+                               font=("", 9, "bold"))
+        status.grid(row=0, column=0, sticky="w", padx=(0, 12), pady=(0, 4))
         note = gui.ttk.Label(
             frame,
             text="Normal launch stays non-admin. Elevate only for firewall changes or advanced port 445.",
             style="Admin.TLabel")
         note.grid(row=0, column=1, sticky="ew", pady=(0, 4))
-        bind_wrap(note, offset=360)
         button = gui.ttk.Button(frame, text="Restart as administrator",
                                 style="Accent.TButton",
                                 command=lambda: restart_as_admin(self))
         button.grid(row=0, column=2, sticky="e", padx=(12, 0), pady=(0, 4))
         if is_admin or not gui.elevate.can_elevate():
             button.config(state="disabled")
+        # Wraps against the panel's real width, holding back the two widgets that
+        # share the row, so it reflows with the window like everything else.
+        # 48 = the frame's own padding either side, plus the padx on the status
+        # label and on the button. Miss one and the row asks for more width than
+        # the window has, which is how a panel ends up clipped at the minimum.
+        gui.bind_wraplength(note, frame, reserve=48, siblings=(status, button))
         self._ps2_admin_frame = frame
 
     def restart_as_admin(app):
@@ -377,18 +331,10 @@ def _apply_gui_review_fixes(gui):
             return super().add(child, **kwargs)
 
     def normalize_original_widgets(self):
-        try:
-            self.nb.pack_configure(fill="both", expand=True)
-        except (gui.tk.TclError, AttributeError):
-            pass
-
-        for card in getattr(self, "cards", {}).values():
-            for child in card.winfo_children():
-                if getattr(child, "winfo_class", lambda: "")() == "TLabel":
-                    text = str(child.cget("text"))
-                    if text:
-                        bind_wrap(child, offset=96)
-
+        # Card labels are no longer re-wrapped here: gui.py binds each one to the
+        # notebook's width as it builds it. Re-wrapping them against the root width
+        # fought that, and reached only the cards' direct children -- never the help
+        # text inside the advanced-fields frame.
         parent = content_parent(self)
         for child in parent.winfo_children():
             try:
@@ -423,8 +369,6 @@ def _apply_gui_review_fixes(gui):
         widget.config(state="disabled")
 
     gui.ttk.Notebook = StyledNotebook
-    gui.LauncherApp._configure_window = configure_window
-    gui.LauncherApp._build_scroll_body = build_scroll_body
     gui.LauncherApp._build = launcher_build
     gui.LauncherApp.__init__ = launcher_init
     gui.LauncherApp._append_log = append_log

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -86,7 +86,16 @@ def _apply_gui_review_fixes(gui):
     This stays as a runtime shim so release-risk remains low. It no longer touches
     window sizing or the scrolling body: those are gui.py's, and keeping a second
     copy here only gave the two a way to disagree.
+
+    Applied once per process. Every wrapper below captures the CURRENT attribute
+    and calls it, so a second application would wrap the wrappers -- two admin
+    panels, tab text padded twice, every log line written twice. The other three
+    patchers in this package guard themselves the same way (asset_skin,
+    full_skin_controls, __init__); this one was the exception.
     """
+    if getattr(gui, "_ps2_gui_review_fixes_patched", False):
+        return
+
     original_notebook = gui.ttk.Notebook
     original_launcher_init = gui.LauncherApp.__init__
     original_build = gui.LauncherApp._build
@@ -372,6 +381,7 @@ def _apply_gui_review_fixes(gui):
     gui.LauncherApp._build = launcher_build
     gui.LauncherApp.__init__ = launcher_init
     gui.LauncherApp._append_log = append_log
+    gui._ps2_gui_review_fixes_patched = True
 
 
 def _selfcheck():

--- a/tests/test_gui_layout.py
+++ b/tests/test_gui_layout.py
@@ -50,6 +50,8 @@ class LauncherLayout(unittest.TestCase):
             os.environ[var] = cls._scratch
 
         from launcher import config, main as launcher_main, tray
+        cls._saved_config_save = config.save
+        cls._saved_tray_available = tray.AVAILABLE
         config.save = lambda data: None
         tray.AVAILABLE = False              # no tray icon during the test
 
@@ -61,12 +63,34 @@ class LauncherLayout(unittest.TestCase):
         try:
             cls.root = tk.Tk()
         except tk.TclError:
+            cls._restore_env_and_stubs()
             raise unittest.SkipTest("no display")
         cls.app = gui.LauncherApp(cls.root)
         cls._settle()
         cls.app._apply_tab_minimum_width()  # normally fires 200ms after launch
         cls._settle()
         cls.min_width = cls.root.minsize()[0]
+
+    @classmethod
+    def _restore_env_and_stubs(cls):
+        for var, was in getattr(cls, "_saved_env", {}).items():
+            if was is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = was
+        scratch = getattr(cls, "_scratch", None)
+        if scratch:
+            import shutil
+            shutil.rmtree(scratch, ignore_errors=True)
+            cls._scratch = None
+        saved_config_save = getattr(cls, "_saved_config_save", None)
+        if saved_config_save is not None:
+            from launcher import config
+            config.save = saved_config_save
+        saved_tray = getattr(cls, "_saved_tray_available", None)
+        if saved_tray is not None:
+            from launcher import tray
+            tray.AVAILABLE = saved_tray
 
     @classmethod
     def tearDownClass(cls):
@@ -81,15 +105,7 @@ class LauncherLayout(unittest.TestCase):
         if root is not None:
             root.destroy()
 
-        for var, was in getattr(cls, "_saved_env", {}).items():
-            if was is None:
-                os.environ.pop(var, None)
-            else:
-                os.environ[var] = was
-        scratch = getattr(cls, "_scratch", None)
-        if scratch:
-            import shutil
-            shutil.rmtree(scratch, ignore_errors=True)
+        cls._restore_env_and_stubs()
 
     # The module patch _apply_gui_review_fixes applies is deliberately NOT undone:
     # it is idempotent (launcher/main.py guards it) and it is what the real app

--- a/tests/test_gui_layout.py
+++ b/tests/test_gui_layout.py
@@ -38,8 +38,14 @@ class LauncherLayout(unittest.TestCase):
             raise unittest.SkipTest("no tkinter")
 
         # Point the settings file at a scratch dir and stub the write, so a test
-        # run cannot touch (or create) the user's real launcher.json.
+        # run cannot touch (or create) the user's real launcher.json. Both the
+        # variables and the directory are put back in tearDownClass: this runs in
+        # the same process as every other test, and a config path left pointing
+        # at a temp dir is the kind of thing that makes an unrelated test pass
+        # for the wrong reason.
         cls._scratch = tempfile.mkdtemp(prefix="ps2-layout-")
+        cls._saved_env = {v: os.environ.get(v)
+                          for v in ("APPDATA", "XDG_CONFIG_HOME")}
         for var in ("APPDATA", "XDG_CONFIG_HOME"):
             os.environ[var] = cls._scratch
 
@@ -74,6 +80,21 @@ class LauncherLayout(unittest.TestCase):
         root = getattr(cls, "root", None)
         if root is not None:
             root.destroy()
+
+        for var, was in getattr(cls, "_saved_env", {}).items():
+            if was is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = was
+        scratch = getattr(cls, "_scratch", None)
+        if scratch:
+            import shutil
+            shutil.rmtree(scratch, ignore_errors=True)
+
+    # The module patch _apply_gui_review_fixes applies is deliberately NOT undone:
+    # it is idempotent (launcher/main.py guards it) and it is what the real app
+    # runs, so a later GUI test that expects the launcher as users get it should
+    # find it already in place rather than having to know to re-apply it.
 
     @classmethod
     def _settle(cls, rounds=6):

--- a/tests/test_gui_layout.py
+++ b/tests/test_gui_layout.py
@@ -1,0 +1,193 @@
+"""The launcher window must reflow, and the TERMINAL must never scroll sideways.
+
+Three things this locks down, all of them things a user reported as "text is cut
+off" rather than as a layout bug:
+
+  * The terminal wraps. It used to be wrap="none" with no horizontal scrollbar,
+    so the end of a long line -- the path, the port, the reason a server exited --
+    was simply unreachable.
+  * Nothing carries a hard-coded wraplength. The window resizes in both
+    directions now, so any fixed number is wrong at every other size.
+  * The page scrollbar appears only when the page really does not fit, and the
+    window cannot be dragged narrower than its own tab strip.
+
+Needs a real, mapped window: widths do not exist until Tk has laid one out. The
+test skips where there is no display, and where the window manager refuses the
+geometry it asks for (a tiling WM), because then nothing it measures is about
+this code.
+
+Run:  python -m unittest tests.test_gui_layout -v
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+class LauncherLayout(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import tkinter as tk
+        except ImportError:
+            raise unittest.SkipTest("no tkinter")
+
+        # Point the settings file at a scratch dir and stub the write, so a test
+        # run cannot touch (or create) the user's real launcher.json.
+        cls._scratch = tempfile.mkdtemp(prefix="ps2-layout-")
+        for var in ("APPDATA", "XDG_CONFIG_HOME"):
+            os.environ[var] = cls._scratch
+
+        from launcher import config, main as launcher_main, tray
+        config.save = lambda data: None
+        tray.AVAILABLE = False              # no tray icon during the test
+
+        from launcher import gui
+        launcher_main._apply_gui_review_fixes(gui)
+        cls.gui = gui
+        cls.tk = tk
+
+        try:
+            cls.root = tk.Tk()
+        except tk.TclError:
+            raise unittest.SkipTest("no display")
+        cls.app = gui.LauncherApp(cls.root)
+        cls._settle()
+        cls.app._apply_tab_minimum_width()  # normally fires 200ms after launch
+        cls._settle()
+        cls.min_width = cls.root.minsize()[0]
+
+    @classmethod
+    def tearDownClass(cls):
+        app = getattr(cls, "app", None)
+        if app is not None:
+            app._shutting_down = True
+            try:
+                app.status_poller.stop()
+            except Exception:
+                pass
+        root = getattr(cls, "root", None)
+        if root is not None:
+            root.destroy()
+
+    @classmethod
+    def _settle(cls, rounds=6):
+        for _ in range(rounds):
+            cls.root.update_idletasks()
+            cls.root.update()
+
+    def resize(self, width, height):
+        """Ask for a size, then report what we actually got."""
+        self.root.geometry("{}x{}".format(width, height))
+        self._settle()
+        got = (self.root.winfo_width(), self.root.winfo_height())
+        if abs(got[0] - width) > 8 or abs(got[1] - height) > 8:
+            self.skipTest("window manager did not honour the requested geometry")
+        return got
+
+    def wrapping_labels(self, widget, found=None):
+        found = [] if found is None else found
+        for child in widget.winfo_children():
+            if (child.winfo_class() == "TLabel"
+                    and int(child.cget("wraplength") or 0)):
+                found.append(child)
+            self.wrapping_labels(child, found)
+        return found
+
+    # -- the terminal ----------------------------------------------------- #
+    def test_terminal_wraps_and_never_scrolls_sideways(self):
+        self.assertEqual(str(self.app.terminal.cget("wrap")), "word")
+        self.assertFalse(str(self.app.terminal.cget("xscrollcommand")),
+                         "a horizontal scrollbar means lines can hide off-screen")
+
+    def test_a_long_unbroken_path_still_wraps(self):
+        self.resize(self.min_width, 700)
+        self.app.nb.select(self.app.terminal_tab)
+        self.app._append_log("setup", "C:\\a_single_token_with_no_spaces_in_it_at_"
+                                      "all_of_the_kind_a_server_prints_when_it_"
+                                      "reports_which_file_it_is_serving.iso\n")
+        self._settle()
+        shown = int(self.app.terminal.count("1.0", "end", "displaylines")[0])
+        self.assertGreater(shown, 1, "a word longer than the line must break")
+
+    def test_terminal_grows_with_the_window(self):
+        self.app.nb.select(self.app.terminal_tab)
+        self.resize(1024, 640)
+        short = self.app.terminal.winfo_height()
+        self.resize(1024, 1000)
+        self.assertGreater(self.app.terminal.winfo_height(), short + 50,
+                           "spare height should go to the log, not to dead page")
+
+    # -- reflow ------------------------------------------------------------ #
+    def test_wrapping_text_follows_the_window_width(self):
+        key = next(iter(self.app.cards))
+        labels = self.wrapping_labels(self.app.cards[key])
+        self.assertTrue(labels, "the cards should have wrapping text to check")
+        self.resize(1400, 900)
+        wide = [int(w.cget("wraplength")) for w in labels]
+        self.resize(self.min_width, 900)
+        narrow = [int(w.cget("wraplength")) for w in labels]
+        for before, after in zip(wide, narrow):
+            self.assertLess(after, before)
+
+    def test_a_tab_never_opened_still_wraps_to_the_window(self):
+        """ttk unmaps unselected tabs, so those cards have no width of their own.
+
+        Wrapping them against their own (unknown) width fed each label a made-up
+        number, which the card then reported back as the width it needed --
+        widening the whole page for a tab nobody had looked at.
+        """
+        self.resize(self.min_width, 900)
+        limit = self.app.nb.winfo_width()
+        for key, card in self.app.cards.items():
+            for label in self.wrapping_labels(card):
+                self.assertLessEqual(int(label.cget("wraplength")), limit,
+                                     "{} wraps wider than the window".format(key))
+
+    def test_the_page_never_needs_more_width_than_it_has(self):
+        for width in (self.min_width, 1024, 1400):
+            with self.subTest(width=width):
+                self.resize(width, 900)
+                canvas = self.app._scroll_canvas
+                item = int(float(canvas.itemcget(self.app._scroll_window, "width")))
+                self.assertEqual(item, canvas.winfo_width(),
+                                 "the body must be exactly as wide as the canvas")
+                self.assertLessEqual(self.app.nb.winfo_reqwidth(),
+                                     self.app.nb.winfo_width() + 2,
+                                     "the notebook wants more width than it has")
+
+    def test_the_window_cannot_shrink_past_its_own_tab_strip(self):
+        strip = self.app._tab_strip_width()
+        if strip <= 0:
+            self.skipTest("tab strip could not be measured on this theme")
+        self.assertGreaterEqual(self.min_width, strip,
+                                "a narrower window would hide the last tab")
+
+    # -- scrollbars -------------------------------------------------------- #
+    def test_the_page_scrollbar_is_out_only_when_the_page_overflows(self):
+        for width, height in ((1024, 460), (1024, 1000), (self.min_width, 700)):
+            with self.subTest(size=(width, height)):
+                self.resize(width, height)
+                overflows = (self.app.content.winfo_reqheight()
+                             > self.app._scroll_canvas.winfo_height() + 2)
+                self.assertEqual(bool(self.app._scrollbar.winfo_ismapped()),
+                                 overflows)
+
+    def test_the_page_scrollbar_settles_instead_of_flickering(self):
+        # Hiding the bar hands the content more width, and more width never makes
+        # the page taller -- so the decision must hold, not oscillate.
+        self.resize(1024, 1000)
+        states = []
+        for _ in range(6):
+            self._settle(2)
+            states.append(bool(self.app._scrollbar.winfo_ismapped()))
+        self.assertEqual(len(set(states)), 1, "scrollbar flip-flopped: %s" % states)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The TERMINAL log could not show the end of a long line, and the window could not be resized. Both are fixed, and the page reflows into whatever width it is given.

## The terminal wraps

It was `wrap="none"` **with no horizontal scrollbar at all** — so the end of every long line (the path being served, the port, the reason a server exited) was simply unreachable. It wraps on words now. A path with no spaces in it still breaks, verified with a 400-character token.

## The window reflows

It was `resizable(False, True)` plus a `<Configure>` handler that snapped any width change back to 1024 and undid maximising. It resizes freely now, with no `maxsize`.

Every wrapping label carried a hard-coded pixel count — 420, 560, 640, 720, 900, 780 — each of them wrong at any other size. They now follow the real width of a frame that resizes, through one `bind_wraplength` helper that can also hold back the *measured* width of widgets sharing the row, so the reserve follows the actual font, theme and DPI rather than a number guessed at one screen size.

Card text measures against the **notebook**, not the card. ttk unmaps unselected tabs, so a card the user has not visited has no width of its own; asking it fed each label a made-up figure, which the card then reported back as the width it needed — widening the whole page for a tab nobody had opened.

## Fewer scrollbars

They should be the terminal's alone, so:

- The page scrollbar is out only when the page genuinely does not fit. Hiding it can only ever hand the content *more* width, and more width never makes the page taller, so the decision settles in one pass instead of flickering — there is a test for that.
- About's bar does the same. TERMINAL keeps its bar permanently, where it is a standing sign that the log runs past the window.
- The notebook expands, so spare height grows the log (465px → 582px in the test) instead of leaving dead page under it.

## The tab strip sets the floor

The tabs are the one part of the page that cannot reflow — ttk neither wraps nor scrolls them, so a window narrower than the strip just hides ABOUT. Rather than guess a constant, `_apply_tab_minimum_width` measures the strip (binary-searching `identify()`) and raises the window minimum to fit it. That tracks the theme's tab padding, the user's font and DPI, and how many servers the build ships.

Trimming tab padding from 18px to 12px a side takes the measured floor from **848 → 782**. Measuring the strips at that floor turned up two overflows the wider minimum had been hiding, both fixed here: the admin panel asked for 744px in a 734px page (a wrap reserve that missed one `padx`), and the last tab lost 1px of its border.

At 782px every strip fits: admin 719, header 736, notebook 735, footer 687, in a 736px page.

## One implementation, not two

`main.py` was overriding `_configure_window` and `_build_scroll_body` with a *second, different* layout, and re-wrapping card labels against the root width — which fought the card-level wrapping and reached only each card's direct children, never the help text inside the advanced-fields frame. Those overrides are gone. `main.py` keeps the theme, admin panel, styled tabs and log appender; `gui.py` owns the layout.

## Testing

New `tests/test_gui_layout.py` — 9 tests over a real window: the terminal wraps and has no horizontal scroll, a long unbroken token breaks, wrapping text follows the window width, an unvisited tab still wraps to the window, the page never needs more width than it has, the window cannot shrink past its tab strip, and the page scrollbar appears exactly when it should and does not flicker. It skips cleanly with no display, and where a window manager refuses the geometry it asks for.

Full suite: 331 tests pass. Verified visually at 782, 900, 1024, 1100 and 1400 wide, and maximised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows can now be freely resized with responsive text wrapping and layouts.
  * Terminal, About, card, and help content adapts to available space.
  * Scrollbars appear only when content exceeds the visible area.
  * Tabs remain fully visible, and the interface expands smoothly with larger windows.

* **Bug Fixes**
  * Prevented clipped tabs, unnecessary horizontal scrolling, and scrollbar flickering.
  * Improved wrapping for long paths and narrow window sizes.

* **Tests**
  * Added coverage for responsive sizing, wrapping, scrolling, and minimum window dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->