### PR TITLE
fix(udpbd): the RDMA read test was flaky because loopback has no wire

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -49,7 +49,11 @@ jobs:
       - name: Test and vet Edge
         working-directory: native/ps2servers-edge
         run: |
-          go test -race ./... -count=1
+          # -count=2, not 1. Both bypass the test cache, but a socket test that
+          # only fails when the process is warm passes the first run and fails
+          # the second -- which is exactly how the udpbd RDMA flake survived in
+          # main for a week while CI stayed green. Costs about 8 seconds.
+          go test -race ./... -count=2
           go vet ./...
       - name: Test Python protocol negotiation and launcher compatibility
         run: |

--- a/native/ps2servers-edge/internal/udpbd/udpbd_test.go
+++ b/native/ps2servers-edge/internal/udpbd/udpbd_test.go
@@ -3,6 +3,7 @@ package udpbd
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"math/rand"
 	"net"
 	"os"
@@ -137,6 +138,34 @@ func freePort(t *testing.T) int {
 	return c.LocalAddr().(*net.UDPAddr).Port
 }
 
+// clientReadBuffer sizes the test client's receive buffer for the largest burst
+// it asks for -- a 512-sector READ is 256 KiB, which handleRead sends as ~180
+// datagrams back to back with no pacing, because that is what the console
+// expects and what the Python reference does.
+//
+// Nothing throttles that on loopback. There is no 100 Mbit link between the two
+// sockets to spread the burst out the way a real console's wire does, so the
+// send loop can outrun the receiving goroutine by more than the OS default
+// buffer holds (64 KiB on Windows, ~208 KiB on Linux -- both under 256 KiB).
+// The kernel then drops the tail, and since UDPBD has no retransmission those
+// packets never arrive: the test blocked until its deadline and failed with an
+// i/o timeout after ~66 KiB, which read like a server bug and is not one.
+//
+// This is not leniency. A console has its own buffering in the SMAP driver and
+// re-requests what it misses; the strict reassembler here does neither, so it
+// has to be given the room the burst actually needs.
+const clientReadBuffer = 1 << 20
+
+// packetDeadline bounds the wait for ONE datagram. The connection used to carry
+// a single absolute 5s deadline covering everything after the dial, so a slow
+// early read spent budget the last read needed, and the failure named whichever
+// read happened to be holding the clock rather than whatever actually stalled.
+const packetDeadline = 3 * time.Second
+
+// readAttempts bounds the re-requesting in readSectors. Three, because one
+// stall is the host's buffer policy and three in a row is the server.
+const readAttempts = 3
+
 func dialServer(t *testing.T, addr *net.UDPAddr) *net.UDPConn {
 	t.Helper()
 	c, err := net.DialUDP("udp4", nil, addr)
@@ -144,8 +173,20 @@ func dialServer(t *testing.T, addr *net.UDPAddr) *net.UDPConn {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { c.Close() })
-	_ = c.SetDeadline(time.Now().Add(5 * time.Second))
+	if err := c.SetReadBuffer(clientReadBuffer); err != nil {
+		t.Fatalf("could not size the receive buffer to %d bytes: %v",
+			clientReadBuffer, err)
+	}
+	_ = c.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	_ = c.SetReadDeadline(time.Now().Add(packetDeadline))
 	return c
+}
+
+// readPacket reads one datagram, giving it its own deadline.
+func readPacket(t *testing.T, c *net.UDPConn, buf []byte) (int, error) {
+	t.Helper()
+	_ = c.SetReadDeadline(time.Now().Add(packetDeadline))
+	return c.Read(buf)
 }
 
 func sectorReq(cmd, cmdid uint8, sector uint32, count uint16) []byte {
@@ -162,7 +203,7 @@ func TestInfoReportsSectorGeometry(t *testing.T) {
 		t.Fatal(err)
 	}
 	buf := make([]byte, 2048)
-	n, err := c.Read(buf)
+	n, err := readPacket(t, c, buf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,29 +222,68 @@ func TestInfoReportsSectorGeometry(t *testing.T) {
 // readSectors reassembles an RDMA stream, the way a console does.
 func readSectors(t *testing.T, c *net.UDPConn, cmdid uint8, sector uint32, count uint16) []byte {
 	t.Helper()
-	if _, err := c.Write(sectorReq(CmdRead, cmdid, sector, count)); err != nil {
-		t.Fatal(err)
-	}
 	want := int(count) * SectorSize
-	out := make([]byte, 0, want)
 	buf := make([]byte, 2048)
-	for len(out) < want {
-		n, err := c.Read(buf)
-		if err != nil {
-			t.Fatalf("read sectors %d+%d: %v (got %d/%d bytes)", sector, count, err, len(out), want)
+
+	// Re-request a stream that stalls, which is what a console does: UDPBD has
+	// no retransmission, so a lost RDMA packet is only ever recovered by asking
+	// again. Sizing the receive buffer is not enough on its own to make that
+	// impossible -- Linux caps SO_RCVBUF at net.core.rmem_max (212992 by
+	// default, under the 256 KiB a 512-sector read delivers), so how much of
+	// the ask survives is the host's policy, not ours.
+	//
+	// This does not soften what the test checks. Every byte still has to match
+	// the image, and a server that truncates or stops answering fails all the
+	// attempts rather than one.
+	for attempt := 1; ; attempt++ {
+		if _, err := c.Write(sectorReq(CmdRead, cmdid, sector, count)); err != nil {
+			t.Fatal(err)
 		}
-		cmd, gotID, _ := unpackHeader(buf[:n])
-		if cmd != CmdReadRDMA || gotID != cmdid {
-			t.Fatalf("unexpected reply cmd=0x%02x cmdid=%d", cmd, gotID)
+		out := make([]byte, 0, want)
+		stalled := false
+		for len(out) < want {
+			// Per packet, not per transfer: 180 datagrams sharing one deadline
+			// made the timeout depend on how many had already arrived.
+			n, err := readPacket(t, c, buf)
+			if err != nil {
+				if errors.Is(err, os.ErrDeadlineExceeded) && attempt < readAttempts {
+					stalled = true
+					break
+				}
+				t.Fatalf("read sectors %d+%d after %d attempt(s): %v (got %d/%d bytes)",
+					sector, count, attempt, err, len(out), want)
+			}
+			cmd, gotID, _ := unpackHeader(buf[:n])
+			if cmd != CmdReadRDMA || gotID != cmdid {
+				t.Fatalf("unexpected reply cmd=0x%02x cmdid=%d", cmd, gotID)
+			}
+			shift, blocks := unpackBlockType(buf[:n], 2)
+			size := int(blocks) * (1 << (shift + 2))
+			if n < 6+size {
+				t.Fatalf("RDMA payload %d shorter than its block_type %d", n-6, size)
+			}
+			out = append(out, buf[6:6+size]...)
 		}
-		shift, blocks := unpackBlockType(buf[:n], 2)
-		size := int(blocks) * (1 << (shift + 2))
-		if n < 6+size {
-			t.Fatalf("RDMA payload %d shorter than its block_type %d", n-6, size)
+		if !stalled {
+			return out[:want]
 		}
-		out = append(out, buf[6:6+size]...)
+		// Late packets from the abandoned burst are still queued, and appending
+		// them to the retry would splice two streams into one wrong answer.
+		drain(t, c)
 	}
-	return out[:want]
+}
+
+// drain discards whatever is already queued, so an abandoned transfer cannot
+// leak into the next one.
+func drain(t *testing.T, c *net.UDPConn) {
+	t.Helper()
+	buf := make([]byte, 2048)
+	for {
+		_ = c.SetReadDeadline(time.Now().Add(150 * time.Millisecond))
+		if _, err := c.Read(buf); err != nil {
+			return
+		}
+	}
 }
 
 // TestReadsMatchTheImageAcrossBlockRegimes covers each branch of the optimizer,
@@ -244,7 +324,7 @@ func TestWriteLandsInTheImage(t *testing.T) {
 		t.Fatal(err)
 	}
 	buf := make([]byte, 2048)
-	n, err := c.Read(buf)
+	n, err := readPacket(t, c, buf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +401,7 @@ func TestReadOnlyImageReportsWriteFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	buf := make([]byte, 2048)
-	n, err := c.Read(buf)
+	n, err := readPacket(t, c, buf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -378,7 +458,7 @@ func TestMalformedDatagramsDoNotKillTheServer(t *testing.T) {
 	if _, err := c.Write(append(packHeader(CmdInfo, 0, 0), make([]byte, 6)...)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := c.Read(buf); err != nil {
+	if _, err := readPacket(t, c, buf); err != nil {
 		t.Fatalf("server died on malformed input: %v", err)
 	}
 }


### PR DESCRIPTION
`TestReadsMatchTheImageAcrossBlockRegimes` passed under `-count=1` and failed on the second and third runs with an i/o timeout after ~66 KiB of a 256 KiB read. Noted in #147, never diagnosed. It looked like a server bug or a race — **it is neither, and the server is not changed here.**

## What was actually happening

`handleRead` sends a 512-sector READ as ~180 datagrams back to back with no pacing. That is correct: it is what the console expects and what the hardware-validated Python server does.

On a real setup the 100 Mbit link spreads that burst out. **On loopback nothing does**, so the send loop outruns the receiving goroutine by more than the OS default receive buffer holds — 64 KiB on Windows, ~208 KiB on Linux, both under the 256 KiB in flight. The kernel drops the tail, and UDPBD has no retransmission, so those packets never arrive and the test blocked until its deadline.

The `67680 bytes` in the failure is the buffer filling up, not an off-by-one.

```
before:  FAIL 2 of 3 runs, 10.5s   (5.01s deadline, "got 67680/262144 bytes")
after:   ok   20 of 20 runs, 0.77s
```

## The fix — harness only

**Size the client's receive buffer** for the largest burst it asks for. This cannot be the whole answer: Linux caps `SO_RCVBUF` at `net.core.rmem_max` (212992 by default), so how much of the ask survives is the host's policy, not ours.

**Re-request a stalled stream**, which is what a console does — asking again is the only recovery UDPBD has. Bounded at three attempts: one stall is the host's buffer, three in a row is the server. Late packets from the abandoned burst are drained first, or they would splice into the retry and produce a wrong answer that still had the right length.

This does not soften what the test checks. Every byte still has to match the image, and a server that truncates or stops answering fails all three attempts rather than one.

**Deadlines are now per packet.** The connection carried one absolute 5s deadline covering everything after the dial, so a slow early read spent the budget the last read needed, and the failure named whichever read happened to be holding the clock rather than whatever actually stalled.

## Verifying the retry isn't dead code

Per the "check that tests catch what they claim" rule, I forced the failure mode rather than trusting that the path works: shrinking `clientReadBuffer` to 8 KiB makes the loss certain, and the test still completes byte-exact through the retry (first run 3.17s — one stall plus recovery — then 0.02s). Restored to `1 << 20` afterwards.

## CI runs `-count=2` now

Both `-count=1` and `-count=2` bypass the test cache, but only the second catches a test that passes cold and fails warm — which is exactly how this survived in `main` for a week behind a green check.

I checked this was safe before proposing it: the whole Edge suite is clean under `-race -count=2`, and it costs about 8 seconds.

## Testing

- `-count=20` on the previously flaky test: green
- `internal/udpbd -count=3 -race`: green
- Full Edge suite `-race -count=1` and `-race -count=2`: all 7 packages green
- `go vet ./...`: clean; the edited file is `gofmt`-clean (the `gofmt -l` hits on a Windows checkout are CRLF, and flag untouched files too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
