### PR TITLE
fix(gui): stop offering SMBv2/SMBv3, which serve no files

### DIFF
--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -137,12 +137,19 @@ def _smbv1_argv(v):
     return _smb_argv(v, "1")
 
 
-def _smbv2_argv(v):
-    return _smb_argv(v, "2")
-
-
-def _smbv3_argv(v):
-    return _smb_argv(v, "3")
+# There is deliberately no SMBv2/SMBv3 entry here. The server answers those
+# dialects far enough to negotiate, authenticate and connect, and then serves
+# nothing: SMB2 READ returns zero bytes, CREATE ignores the requested path, and
+# QUERY_DIRECTORY is not implemented at all, so a share cannot even be listed.
+# Offering the modes on that meant a user picked SMBv2, connected successfully,
+# and saw an empty folder with no error to explain it -- and an SMB2 WRITE
+# reported success without writing, which tells a client a save committed when
+# nothing did.
+#
+# The work to make them real is a rooted path guard and NTLMv2 credential
+# checking (both written, see smb2_server/) plus a QUERY_DIRECTORY that packs
+# many entries per response. When the server can serve a file, add the entries
+# back -- tests/test_netinfo_and_smb.py enforces that order.
 
 
 # How the protocol mode is offered, and what each choice puts on the wire.
@@ -297,58 +304,6 @@ SMBV1 = ServerDef(
     _build_argv=_smbv1_argv,
 )
 
-SMBV2 = ServerDef(
-    key="smbv2",
-    label="SMBv2 server",
-    blurb="Share a games folder over SMB2 for modern clients and supported OPL builds.",
-    runtime="python",
-    default_port=1025,
-    share_hint="games",
-    module_file=_repo("smbv1_server", "smbserver_opl.py"),
-    module_dir=_repo("smbv1_server"),
-    fields=[
-        Field("games_folder", "Games folder", "folder", required=True,
-              help="Folder of PS2 games/apps to share over SMB2."),
-        Field("port", "Port", "port", default=1025, advanced=False,
-              help="TCP port (default 1025). Ports below 1025 require Administrator."),
-        Field("read_only", "Read-only", "bool", default=False, advanced=True,
-              help="No saves / no VMC writes."),
-        Field("take_445", "Take port 445 (admin)", "bool", default=False,
-              advanced=True, windows_only=True,
-              help="Bind standard port 445 by pausing Windows file sharing. Needs admin."),
-        Field("bind", "Bind address", "text", default="", advanced=True,
-              help="Interface to bind (blank = all)."),
-        Field("verbose", "Verbose logging", "bool", default=False, advanced=True),
-    ],
-    _build_argv=_smbv2_argv,
-)
-
-SMBV3 = ServerDef(
-    key="smbv3",
-    label="SMBv3 server",
-    blurb="Share a games folder over SMB3 with modern authentication and encryption support.",
-    runtime="python",
-    default_port=1025,
-    share_hint="games",
-    module_file=_repo("smbv1_server", "smbserver_opl.py"),
-    module_dir=_repo("smbv1_server"),
-    fields=[
-        Field("games_folder", "Games folder", "folder", required=True,
-              help="Folder of PS2 games/apps to share over SMB3."),
-        Field("port", "Port", "port", default=1025, advanced=False,
-              help="TCP port (default 1025). Ports below 1025 require Administrator."),
-        Field("read_only", "Read-only", "bool", default=False, advanced=True,
-              help="No saves / no VMC writes."),
-        Field("take_445", "Take port 445 (admin)", "bool", default=False,
-              advanced=True, windows_only=True,
-              help="Bind standard port 445 by pausing Windows file sharing. Needs admin."),
-        Field("bind", "Bind address", "text", default="", advanced=True,
-              help="Interface to bind (blank = all)."),
-        Field("verbose", "Verbose logging", "bool", default=False, advanced=True),
-    ],
-    _build_argv=_smbv3_argv,
-)
-
 UDPFS = ServerDef(
     key="udpfs",
     label="UDPFS server",
@@ -412,4 +367,4 @@ UDPBD = ServerDef(
     _build_argv=_udpbd_argv,
 )
 
-REGISTRY = {s.key: s for s in (SMBV1, SMBV2, SMBV3, UDPFS, UDPBD)}
+REGISTRY = {s.key: s for s in (SMBV1, UDPFS, UDPBD)}

--- a/ps2servers.py
+++ b/ps2servers.py
@@ -21,7 +21,7 @@ def _normalize_headless_alias(argv):
     args = list(argv)
     if args and args[0] == "serve":
         if len(args) < 2:
-            print("error: serve requires udpfs, udpbd, smbv1, smbv2, or smbv3", file=sys.stderr)
+            print("error: serve requires udpfs, udpbd, or smbv1", file=sys.stderr)
             return None
         return ["--serve", args[1], *args[2:]]
     return args

--- a/smbv1_server/smbserver_opl.py
+++ b/smbv1_server/smbserver_opl.py
@@ -1021,7 +1021,8 @@ def main(argv=None):
     ap.add_argument("--take-445", action="store_true",
                     help="bind the standard port 445 by pausing Windows LanmanServer (admin; reversible)")
     ap.add_argument("--smb-version", type=int, choices=[1, 2, 3], default=1,
-                    help="SMB protocol version (1=SMBv1, 2=SMBv2, 3=SMBv3)")
+                    help="SMB protocol version (1=SMBv1; 2 and 3 are INCOMPLETE "
+                         "-- they negotiate and connect but serve no files)")
     ap.add_argument("-v", "--verbose", action="store_true")
     args = ap.parse_args(argv)
     VERBOSE = args.verbose
@@ -1036,6 +1037,18 @@ def main(argv=None):
         shares[name] = Share(name, path)
     if not shares:
         ap.error("at least one --share NAME=PATH is required")
+
+    # The SMB2/SMB3 handlers negotiate, authenticate and accept a tree connect,
+    # then serve nothing: READ returns zero bytes, CREATE ignores the path it was
+    # given, WRITE reports success without writing, and QUERY_DIRECTORY is absent
+    # so the share cannot be listed. A client sees an empty folder and no error.
+    # The flag stays because it is how the real implementation gets developed and
+    # tested, but it must never look finished to whoever runs it.
+    if args.smb_version != 1:
+        print("WARNING: --smb-version %d is INCOMPLETE. The server will negotiate "
+              "SMB%d and accept a connection, but it serves no files: reads return "
+              "nothing and the share cannot be listed. Use --smb-version 1 to serve "
+              "a console." % (args.smb_version, args.smb_version), file=sys.stderr)
 
     server = SmbServer(shares, read_only=args.read_only, smb_version=args.smb_version)
 

--- a/tests/test_linux_parity.py
+++ b/tests/test_linux_parity.py
@@ -156,8 +156,7 @@ class WindowsOnlyFieldTests(unittest.TestCase):
         for server in servers.REGISTRY.values():
             for f in server.fields:
                 if f.windows_only:
-                    self.assertIn((server.key, f.key),
-                                  (("smbv1", "take_445"), ("smbv2", "take_445"), ("smbv3", "take_445")))
+                    self.assertIn((server.key, f.key), (("smbv1", "take_445"),))
 
 
 if __name__ == "__main__":

--- a/tests/test_netinfo_and_smb.py
+++ b/tests/test_netinfo_and_smb.py
@@ -1,4 +1,4 @@
-"""Tests for netinfo IP helpers, SMB2/3 registration, and port settings."""
+"""Tests for netinfo IP helpers, SMB mode registration, and port settings."""
 
 import os
 import sys
@@ -23,29 +23,83 @@ class NetInfoTests(unittest.TestCase):
         self.assertIn("Custom IP...", info)
 
 
-class ServerRegistryTests(unittest.TestCase):
-    def test_smb_servers_exist_and_default_to_1025(self):
-        for key in ("smbv1", "smbv2", "smbv3"):
-            self.assertIn(key, servers.REGISTRY)
-            server = servers.REGISTRY[key]
-            self.assertEqual(server.default_port, 1025)
-            port_field = next(f for f in server.fields if f.key == "port")
-            self.assertFalse(port_field.advanced, f"{key} port field should not be advanced hidden")
-            self.assertEqual(port_field.default, 1025)
+def _probe_values(server):
+    """Enough values to build any server's command line.
 
-    def test_smb_argv_version_flags(self):
-        v = {"games_folder": "C:/Games", "port": 1025}
-        argv1 = servers.REGISTRY["smbv1"]._build_argv(v)
-        argv2 = servers.REGISTRY["smbv2"]._build_argv(v)
-        argv3 = servers.REGISTRY["smbv3"]._build_argv(v)
-        self.assertIn("--smb-version", argv1)
-        self.assertEqual(argv1[argv1.index("--smb-version") + 1], "1")
-        self.assertIn("--smb-version", argv2)
-        self.assertEqual(argv2[argv2.index("--smb-version") + 1], "2")
-        self.assertIn("--smb-version", argv3)
-        self.assertEqual(argv3[argv3.index("--smb-version") + 1], "3")
+    Derived from the server's own fields rather than hard-coded, so a mode that
+    grows a new required field is still covered instead of raising here.
+    """
+    values = {}
+    for f in server.fields:
+        if f.kind in ("folder", "file"):
+            values[f.key] = "C:/Games"
+        elif f.kind == "port":
+            values[f.key] = f.default or 1025
+        elif f.kind == "bool":
+            values[f.key] = bool(f.default)
+        elif f.kind == "choice":
+            values[f.key] = f.default or (f.choices[0][0] if f.choices else "")
+        elif f.default:
+            values[f.key] = f.default
+    return values
+
+
+def _smb_dialect_of(server):
+    """The dialect a REGISTRY entry asks the server for, or None if it is not SMB."""
+    argv = server._build_argv(_probe_values(server))
+    if "--smb-version" not in argv:
+        return None
+    return int(argv[argv.index("--smb-version") + 1])
+
+
+class ServerRegistryTests(unittest.TestCase):
+    def test_smb_server_exists_and_defaults_to_1025(self):
+        self.assertIn("smbv1", servers.REGISTRY)
+        server = servers.REGISTRY["smbv1"]
+        self.assertEqual(server.default_port, 1025)
+        port_field = next(f for f in server.fields if f.key == "port")
+        self.assertFalse(port_field.advanced, "smbv1 port field should not be advanced hidden")
+        self.assertEqual(port_field.default, 1025)
+
+    def test_smb_argv_version_flag(self):
+        self.assertEqual(_smb_dialect_of(servers.REGISTRY["smbv1"]), 1)
+
+    def test_no_offered_mode_asks_for_a_dialect_that_cannot_serve_a_file(self):
+        """A mode in the REGISTRY is a mode a user can pick and expect to work.
+
+        SMB2/SMB3 currently negotiate, authenticate and accept a tree connect,
+        then serve nothing -- READ returns zero bytes and QUERY_DIRECTORY is not
+        implemented, so the share cannot even be listed. Offering that meant a
+        user connected successfully and saw an empty folder with no error.
+
+        This is not "SMB2 is banned". It is the ordering: the server has to be
+        able to serve a file before the launcher offers the mode. Implement
+        QUERY_DIRECTORY and a real READ, and this test goes green on its own --
+        no edit here, nothing to remember.
+        """
+        sys.path.insert(0, os.path.join(_ROOT, "smbv1_server"))
+        try:
+            import smbserver_opl
+        finally:
+            sys.path.pop(0)
+
+        SMB2_QUERY_DIRECTORY = 0x000E
+        can_list = SMB2_QUERY_DIRECTORY in smbserver_opl.SMB2_HANDLERS
+
+        for key, server in servers.REGISTRY.items():
+            dialect = _smb_dialect_of(server)
+            if dialect is None or dialect < 2:
+                continue
+            self.assertTrue(
+                can_list,
+                "{} offers SMB{}, but the server implements no QUERY_DIRECTORY, "
+                "so the share cannot be listed. Finish the SMB2 handlers before "
+                "putting the mode back in the REGISTRY.".format(key, dialect))
 
     def test_windows_setup_ports_for_smb(self):
+        # The SMBv2/SMBv3 keys stay mapped here even though no mode offers them:
+        # the firewall helper is keyed by name, and it is what the modes will
+        # need again once the server can serve them.
         for key in ("smbv1", "smbv2", "smbv3"):
             rules = windows_setup._server_ports(key, {"port": "1025"})
             self.assertEqual(rules[0][1], 1025)


### PR DESCRIPTION
#149 added SMBv2 and SMBv3 as pickable server modes on the same day it added the SMB2 handlers behind them. Those handlers negotiate, authenticate and accept a tree connect — and then serve nothing.

## What a user actually got

In [smbv1_server/smbserver_opl.py](https://github.com/NathanNeurotic/PS2-Servers/blob/main/smbv1_server/smbserver_opl.py):

| | |
|---|---|
| `h2_read` | `data = b""` — every read returns **zero bytes**, never touches disk |
| `h2_create` | ignores the filename it was given, returns a fixed `FileId` |
| `h2_write` | reports **success having written nothing** — a client believes a save committed |
| `SMB2_HANDLERS` | no `0x000E QUERY_DIRECTORY`, so the dispatcher answers `STATUS_NOT_IMPLEMENTED` and **the share cannot be listed** |

So picking SMBv2 connected successfully and showed an empty folder, with no error anywhere to explain why. That is worse than the mode not existing: it reads as *"my games are gone"*, not *"this isn't built yet"*.

## What this changes

The launcher stops offering the two modes. **This is not a decision that SMB2/3 is unwanted** — it is the ordering. The server has to be able to serve a file before the launcher sells the mode. (The groundwork for doing it properly — a rooted path guard and NTLMv2 credential checking — is in #151.)

The `--smb-version` flag stays on the server, because it is how the real implementation gets developed and tested. It now prints a warning saying exactly what does not work, and `--help` says INCOMPLETE:

```
WARNING: --smb-version 2 is INCOMPLETE. The server will negotiate SMB2 and
accept a connection, but it serves no files: reads return nothing and the
share cannot be listed. Use --smb-version 1 to serve a console.
```

Tabs before → after: `SMBv1 · SMBv2 · SMBv3 · UDPFS · UDPBD` → **`SMBv1 · UDPFS · UDPBD`**.

## The test enforces the ordering, not the outcome

Rather than a "SMB2 is banned" assertion someone has to remember to delete, the guard states the actual rule: **any REGISTRY entry asking for a dialect ≥ 2 must be backed by a server that implements QUERY_DIRECTORY.**

Re-adding the modes today fails it. Implementing the handlers turns it green on its own, with nothing in the test to edit. Verified in all three states rather than assumed:

```
as shipped (no SMB2 mode offered):             PASS
SMB2 mode re-added, QUERY_DIRECTORY missing:   FAIL  <- must be FAIL
SMB2 mode re-added, QUERY_DIRECTORY present:   PASS  <- must be PASS
```

## Notes

- The `smbv2`/`smbv3` keys stay mapped in `windows_setup` and `TAB_TITLES` — keyed lookups, inert while nothing offers those keys, and needed again when the modes come back.
- `ps2servers.py serve smbv2` now fails with `unknown server: smbv2` rather than starting a server that serves nothing.
- Edge is unaffected: its SMB is SMBv1 only, which is the only dialect OPL speaks.

## Testing

Full suite **323 tests, OK**. Verified the GUI builds the right tab set, `--list` reports the three real servers, and the CLI warning prints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
