### PR TITLE
feat(smb2): a real SMB2/SMB3 server, and the modes back on top of it

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -49,6 +49,13 @@ SUPPORT_FILES = [
     # packaged build imports fine in source mode and fails at runtime, which is
     # exactly the failure tests/test_packaging_data_files.py exists to catch.
     "udpfs_server/router_status.py",
+    # smb2_server.py imports all four of these at load. _server_entry_points
+    # only sees the entry point itself, so a sibling module missing here is a
+    # packaged build whose SMBv2/SMBv3 modes die on ImportError at start.
+    "smb2_server/smb2_wire.py",
+    "smb2_server/smb2_spnego.py",
+    "smb2_server/smb2_auth.py",
+    "smb2_server/smb2_paths.py",
 ]
 
 

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -153,6 +153,8 @@ def _smb2_argv(v, smb_version):
         args += ["--bind", str(v["bind"])]
     if v.get("read_only"):
         args.append("--read-only")
+    if v.get("take_445"):
+        args.append("--take-445")
     # A password is required unless the user deliberately ticks the open box.
     # The server refuses to start with neither, rather than defaulting to open.
     user = (v.get("username") or "").strip()

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -137,19 +137,69 @@ def _smbv1_argv(v):
     return _smb_argv(v, "1")
 
 
-# There is deliberately no SMBv2/SMBv3 entry here. The server answers those
-# dialects far enough to negotiate, authenticate and connect, and then serves
-# nothing: SMB2 READ returns zero bytes, CREATE ignores the requested path, and
-# QUERY_DIRECTORY is not implemented at all, so a share cannot even be listed.
-# Offering the modes on that meant a user picked SMBv2, connected successfully,
-# and saw an empty folder with no error to explain it -- and an SMB2 WRITE
-# reported success without writing, which tells a client a save committed when
-# nothing did.
+# SMBv2 and SMBv3 run smb2_server/, not the SMBv1 server with a flag. They were
+# briefly offered on top of stub handlers that connected and then served nothing;
+# tests/test_netinfo_and_smb.py now refuses to let a mode be offered before the
+# server behind it can list a share, which is the rule that was missing.
 #
-# The work to make them real is a rooted path guard and NTLMv2 credential
-# checking (both written, see smb2_server/) plus a QUERY_DIRECTORY that packs
-# many entries per response. When the server can serve a file, add the entries
-# back -- tests/test_netinfo_and_smb.py enforces that order.
+# One implementation, two modes: SMB3 is the same protocol at a higher dialect,
+# so the ceiling is a flag rather than a second server to keep in step.
+def _smb2_argv(v, smb_version):
+    args = ["--share", "games={}".format(v["games_folder"]),
+            "--smb-version", str(smb_version)]
+    if v.get("port"):
+        args += ["--port", str(v["port"])]
+    if v.get("bind"):
+        args += ["--bind", str(v["bind"])]
+    if v.get("read_only"):
+        args.append("--read-only")
+    # A password is required unless the user deliberately ticks the open box.
+    # The server refuses to start with neither, rather than defaulting to open.
+    user = (v.get("username") or "").strip()
+    password = v.get("password") or ""
+    if v.get("open_share"):
+        args.append("--open")
+    elif user and password:
+        args += ["--user", "{}:{}".format(user, password)]
+    if v.get("verbose"):
+        args.append("-v")
+    return args
+
+
+def _smbv2_argv(v):
+    return _smb2_argv(v, "2")
+
+
+def _smbv3_argv(v):
+    return _smb2_argv(v, "3")
+
+
+_SMB2_FIELDS = [
+    Field("games_folder", "Games folder", "folder", required=True,
+          help="Folder to share. Browsable from a modern PC, unlike SMBv1."),
+    Field("port", "Port", "port", default=1445, advanced=False,
+          help="TCP port (default 1445). Windows itself can only connect on "
+               "445 -- use the advanced option below for that."),
+    Field("username", "Username", "text", default="ps2",
+          help="The name to enter on the client. SMB2/SMB3 clients require a "
+               "login; there is no guest mode as in SMBv1."),
+    Field("password", "Password", "text", default="",
+          help="Required unless 'No password' is ticked below. Anyone who can "
+               "reach the port can try to guess it, so make it a long one."),
+    Field("open_share", "No password (anyone on the network can read it)",
+          "bool", default=False, advanced=True,
+          help="Serve without a login at all. Only for a network you trust "
+               "completely -- every device on it gets the share."),
+    Field("read_only", "Read-only", "bool", default=False, advanced=True,
+          help="No saves / no VMC writes."),
+    Field("take_445", "Take port 445 (admin)", "bool", default=False,
+          advanced=True, windows_only=True,
+          help="Bind standard port 445 by pausing Windows file sharing. Needs "
+               "admin, and is what Windows Explorer needs to connect at all."),
+    Field("bind", "Bind address", "text", default="", advanced=True,
+          help="Interface to bind (blank = all)."),
+    Field("verbose", "Verbose logging", "bool", default=False, advanced=True),
+]
 
 
 # How the protocol mode is offered, and what each choice puts on the wire.
@@ -304,6 +354,34 @@ SMBV1 = ServerDef(
     _build_argv=_smbv1_argv,
 )
 
+SMBV2 = ServerDef(
+    key="smbv2",
+    label="SMBv2 server",
+    blurb="Share a games folder over SMB2, which modern Windows can browse "
+          "without re-enabling SMB1. Needs a username and password.",
+    runtime="python",
+    default_port=1445,
+    share_hint="games",
+    module_file=_repo("smb2_server", "smb2_server.py"),
+    module_dir=_repo("smb2_server"),
+    fields=_SMB2_FIELDS,
+    _build_argv=_smbv2_argv,
+)
+
+SMBV3 = ServerDef(
+    key="smbv3",
+    label="SMBv3 server",
+    blurb="The same server negotiating up to SMB 3.0.2. Pick this unless a "
+          "client refuses it and needs SMB2.",
+    runtime="python",
+    default_port=1445,
+    share_hint="games",
+    module_file=_repo("smb2_server", "smb2_server.py"),
+    module_dir=_repo("smb2_server"),
+    fields=_SMB2_FIELDS,
+    _build_argv=_smbv3_argv,
+)
+
 UDPFS = ServerDef(
     key="udpfs",
     label="UDPFS server",
@@ -367,4 +445,4 @@ UDPBD = ServerDef(
     _build_argv=_udpbd_argv,
 )
 
-REGISTRY = {s.key: s for s in (SMBV1, UDPFS, UDPBD)}
+REGISTRY = {s.key: s for s in (SMBV1, SMBV2, SMBV3, UDPFS, UDPBD)}

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -137,12 +137,19 @@ def _smbv1_argv(v):
     return _smb_argv(v, "1")
 
 
-def _smbv2_argv(v):
-    return _smb_argv(v, "2")
-
-
-def _smbv3_argv(v):
-    return _smb_argv(v, "3")
+# There is deliberately no SMBv2/SMBv3 entry here. The server answers those
+# dialects far enough to negotiate, authenticate and connect, and then serves
+# nothing: SMB2 READ returns zero bytes, CREATE ignores the requested path, and
+# QUERY_DIRECTORY is not implemented at all, so a share cannot even be listed.
+# Offering the modes on that meant a user picked SMBv2, connected successfully,
+# and saw an empty folder with no error to explain it -- and an SMB2 WRITE
+# reported success without writing, which tells a client a save committed when
+# nothing did.
+#
+# The work to make them real is a rooted path guard and NTLMv2 credential
+# checking (both written, see smb2_server/) plus a QUERY_DIRECTORY that packs
+# many entries per response. When the server can serve a file, add the entries
+# back -- tests/test_netinfo_and_smb.py enforces that order.
 
 
 # How the protocol mode is offered, and what each choice puts on the wire.
@@ -297,58 +304,6 @@ SMBV1 = ServerDef(
     _build_argv=_smbv1_argv,
 )
 
-SMBV2 = ServerDef(
-    key="smbv2",
-    label="SMBv2 server",
-    blurb="Share a games folder over SMB2 for modern clients and supported OPL builds.",
-    runtime="python",
-    default_port=1025,
-    share_hint="games",
-    module_file=_repo("smbv1_server", "smbserver_opl.py"),
-    module_dir=_repo("smbv1_server"),
-    fields=[
-        Field("games_folder", "Games folder", "folder", required=True,
-              help="Folder of PS2 games/apps to share over SMB2."),
-        Field("port", "Port", "port", default=1025, advanced=False,
-              help="TCP port (default 1025). Ports below 1025 require Administrator."),
-        Field("read_only", "Read-only", "bool", default=False, advanced=True,
-              help="No saves / no VMC writes."),
-        Field("take_445", "Take port 445 (admin)", "bool", default=False,
-              advanced=True, windows_only=True,
-              help="Bind standard port 445 by pausing Windows file sharing. Needs admin."),
-        Field("bind", "Bind address", "text", default="", advanced=True,
-              help="Interface to bind (blank = all)."),
-        Field("verbose", "Verbose logging", "bool", default=False, advanced=True),
-    ],
-    _build_argv=_smbv2_argv,
-)
-
-SMBV3 = ServerDef(
-    key="smbv3",
-    label="SMBv3 server",
-    blurb="Share a games folder over SMB3 with modern authentication and encryption support.",
-    runtime="python",
-    default_port=1025,
-    share_hint="games",
-    module_file=_repo("smbv1_server", "smbserver_opl.py"),
-    module_dir=_repo("smbv1_server"),
-    fields=[
-        Field("games_folder", "Games folder", "folder", required=True,
-              help="Folder of PS2 games/apps to share over SMB3."),
-        Field("port", "Port", "port", default=1025, advanced=False,
-              help="TCP port (default 1025). Ports below 1025 require Administrator."),
-        Field("read_only", "Read-only", "bool", default=False, advanced=True,
-              help="No saves / no VMC writes."),
-        Field("take_445", "Take port 445 (admin)", "bool", default=False,
-              advanced=True, windows_only=True,
-              help="Bind standard port 445 by pausing Windows file sharing. Needs admin."),
-        Field("bind", "Bind address", "text", default="", advanced=True,
-              help="Interface to bind (blank = all)."),
-        Field("verbose", "Verbose logging", "bool", default=False, advanced=True),
-    ],
-    _build_argv=_smbv3_argv,
-)
-
 UDPFS = ServerDef(
     key="udpfs",
     label="UDPFS server",
@@ -412,4 +367,4 @@ UDPBD = ServerDef(
     _build_argv=_udpbd_argv,
 )
 
-REGISTRY = {s.key: s for s in (SMBV1, SMBV2, SMBV3, UDPFS, UDPBD)}
+REGISTRY = {s.key: s for s in (SMBV1, UDPFS, UDPBD)}

--- a/ps2servers.py
+++ b/ps2servers.py
@@ -21,7 +21,8 @@ def _normalize_headless_alias(argv):
     args = list(argv)
     if args and args[0] == "serve":
         if len(args) < 2:
-            print("error: serve requires udpfs, udpbd, or smbv1", file=sys.stderr)
+            print("error: serve requires udpfs, udpbd, smbv1, smbv2, or smbv3",
+                  file=sys.stderr)
             return None
         return ["--serve", args[1], *args[2:]]
     return args

--- a/ps2servers.py
+++ b/ps2servers.py
@@ -21,7 +21,7 @@ def _normalize_headless_alias(argv):
     args = list(argv)
     if args and args[0] == "serve":
         if len(args) < 2:
-            print("error: serve requires udpfs, udpbd, smbv1, smbv2, or smbv3", file=sys.stderr)
+            print("error: serve requires udpfs, udpbd, or smbv1", file=sys.stderr)
             return None
         return ["--serve", args[1], *args[2:]]
     return args

--- a/smb2_server/smb2_auth.py
+++ b/smb2_server/smb2_auth.py
@@ -1,0 +1,324 @@
+"""NTLMv2 credential checking for the SMB2/SMB3 server.
+
+Kept in its own module for the same reason as the path guard: this is where a
+mistake hands a stranger the share, and it should be readable and testable
+without a socket or a protocol in the way. Nothing here speaks SMB. It takes
+bytes that arrived in a SESSION_SETUP and answers one question -- do these
+credentials prove knowledge of the password -- with no I/O in between.
+
+The default is that a password is required. "Open" is a real mode, because a
+PS2 on a LAN behind a router is the normal deployment and the older SMBv1
+server here is guest-only, so refusing to offer it would just push people back
+to the weaker server. But it is reachable only through Authenticator.open(),
+never by passing an empty password or a falsy flag to the normal constructor.
+A misconfiguration should fail closed and lock the operator out, rather than
+open and let everyone in.
+
+MD4 is implemented here rather than taken from hashlib. NTLM's NT hash is
+MD4(UTF-16LE(password)), and OpenSSL 3 moved MD4 to the legacy provider, so
+hashlib.new("md4") raises ValueError on a normal modern Python -- confirmed on
+the Python this repo builds against:
+
+    >>> hashlib.new("md4")
+    ValueError: unsupported hash type md4
+
+It is not conditionally used when present. One implementation that the tests
+always exercise is worth more than a fast path that only runs on the machines
+where nobody is looking, and this runs once per session setup, where the cost
+is not measurable.
+
+MD4 and MD5 are both broken as collision-resistant hashes and neither is used
+here as one. NTLMv2 relies on them as HMAC keys and PRFs, which the published
+collision attacks do not reach. NTLMv2 is what an SMB client will offer, so it
+is what the server has to check; the protocol's real weaknesses -- an offline
+guess against a captured exchange, and no channel binding -- are properties of
+NTLM itself and are not fixable from this side. Hence the password advice in
+the docstring for Authenticator.
+"""
+
+import hmac
+import secrets
+import struct
+from hashlib import md5
+
+# NTLMv2 fixes the response header at 0x01 0x01 followed by six zero bytes.
+# A client that sends anything else is speaking NTLMv1 or is confused; either
+# way this server does not implement it, and guessing would be worse.
+_NTLMV2_HEADER = b"\x01\x01\x00\x00\x00\x00\x00\x00"
+
+# NTProofStr, the HMAC-MD5 that opens an NTLMv2 response.
+_PROOF_LEN = 16
+
+# Windows counts 100-nanosecond ticks from 1601-01-01. Only used to expose the
+# client's claimed time; see Authenticator.verify for why it is not enforced.
+_FILETIME_EPOCH_DELTA = 11644473600
+
+
+class AuthError(Exception):
+    """Raised when credentials are refused. Carries an NT status name.
+
+    The status travels with the error so the session-setup handler does not
+    have to work out which of LOGON_FAILURE / ACCESS_DENIED to send, and so the
+    reason is recorded once, where it was decided.
+
+    The `detail` is for the operator's log. It is deliberately never the thing
+    that goes on the wire: a client is told only STATUS_LOGON_FAILURE, so it
+    cannot learn from the reply whether it got the user name right.
+    """
+
+    def __init__(self, status, detail):
+        super().__init__(detail)
+        self.status = status
+        self.detail = detail
+
+
+def md4(data):
+    """MD4 as specified in RFC 1320.
+
+    Present because hashlib no longer provides it (see the module docstring).
+    Used only to derive the NT hash, which is what NTLM defines the password to
+    be; it is not relied on for collision resistance anywhere in this module.
+    """
+    a, b, c, d = 0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476
+    mask = 0xFFFFFFFF
+
+    def rol(x, n):
+        x &= mask
+        return ((x << n) | (x >> (32 - n))) & mask
+
+    # Pad to a multiple of 64 bytes: 0x80, zeros, then the length in bits as a
+    # little-endian 64-bit count. The length is of the *original* message.
+    bit_len = (len(data) * 8) & 0xFFFFFFFFFFFFFFFF
+    data = data + b"\x80"
+    data += b"\x00" * ((56 - len(data) % 64) % 64)
+    data += struct.pack("<Q", bit_len)
+
+    for offset in range(0, len(data), 64):
+        x = struct.unpack("<16I", data[offset:offset + 64])
+        aa, bb, cc, dd = a, b, c, d
+
+        # Round 1: F = (x AND y) OR (NOT x AND z)
+        for i in range(0, 16, 4):
+            a = rol(a + (((b & c) | (~b & d)) & mask) + x[i], 3)
+            d = rol(d + (((a & b) | (~a & c)) & mask) + x[i + 1], 7)
+            c = rol(c + (((d & a) | (~d & b)) & mask) + x[i + 2], 11)
+            b = rol(b + (((c & d) | (~c & a)) & mask) + x[i + 3], 19)
+
+        # Round 2: G = majority. Constant is the square root of 2, per RFC 1320.
+        for i in range(4):
+            a = rol(a + (((b & c) | (b & d) | (c & d)) & mask) + x[i] + 0x5A827999, 3)
+            d = rol(d + (((a & b) | (a & c) | (b & c)) & mask) + x[i + 4] + 0x5A827999, 5)
+            c = rol(c + (((d & a) | (d & b) | (a & b)) & mask) + x[i + 8] + 0x5A827999, 9)
+            b = rol(b + (((c & d) | (c & a) | (d & a)) & mask) + x[i + 12] + 0x5A827999, 13)
+
+        # Round 3: H = XOR. Constant is the square root of 3.
+        for i in (0, 2, 1, 3):
+            a = rol(a + ((b ^ c ^ d) & mask) + x[i] + 0x6ED9EBA1, 3)
+            d = rol(d + ((a ^ b ^ c) & mask) + x[i + 8] + 0x6ED9EBA1, 9)
+            c = rol(c + ((d ^ a ^ b) & mask) + x[i + 4] + 0x6ED9EBA1, 11)
+            b = rol(b + ((c ^ d ^ a) & mask) + x[i + 12] + 0x6ED9EBA1, 15)
+
+        a = (a + aa) & mask
+        b = (b + bb) & mask
+        c = (c + cc) & mask
+        d = (d + dd) & mask
+
+    return struct.pack("<4I", a, b, c, d)
+
+
+def nt_hash(password):
+    """The NT hash: MD4 of the password in UTF-16LE.
+
+    Note what this is not. It is unsalted and uncounted, so it is a password
+    equivalent -- anyone who reads it can authenticate without ever knowing the
+    password. Whatever stores these is as sensitive as a password file, which
+    is why Authenticator keeps them in memory only and the caller is expected
+    to hold the password, not a hash file.
+    """
+    return md4(password.encode("utf-16-le"))
+
+
+def ntowfv2(password, user, domain=""):
+    """NTOWFv2: the per-identity key everything else in NTLMv2 is derived from.
+
+    MS-NLMP defines this as HMAC_MD5(NT hash, UNICODE(Uppercase(User) + Domain))
+    -- the user name is uppercased, the domain is used exactly as given. Getting
+    that asymmetry backwards produces a key that is wrong for every password, so
+    it is pinned by a published test vector in the tests rather than by reading.
+
+    Uppercasing uses Python's str.upper, which is Unicode-aware and so can
+    disagree with Windows for exotic scripts. For the ASCII user names this
+    server is configured with, the two agree.
+    """
+    key = nt_hash(password)
+    identity = (user.upper() + domain).encode("utf-16-le")
+    return hmac.new(key, identity, md5).digest()
+
+
+def ntlmv2_proof(ntowf, server_challenge, blob):
+    """NTProofStr: HMAC-MD5 over the server challenge and the client's blob.
+
+    The blob is the client's own contribution -- its nonce, its timestamp, and
+    the target info it echoed back. Both sides feed the same bytes in, so the
+    proof only matches if the client held the password AND was answering this
+    server's challenge.
+    """
+    return hmac.new(ntowf, server_challenge + blob, md5).digest()
+
+
+def lmv2_response(ntowf, server_challenge, client_challenge):
+    """The LMv2 response: 16-byte HMAC followed by the 8-byte client nonce.
+
+    Provided for completeness because a client may send it alongside the NTv2
+    response. It is not accepted as proof on its own: it commits to nothing but
+    the two nonces, so it carries strictly less than the NTv2 response does.
+    """
+    mac = hmac.new(ntowf, server_challenge + client_challenge, md5).digest()
+    return mac + client_challenge
+
+
+def session_base_key(ntowf, proof):
+    """SessionBaseKey, the root of SMB2 signing and SMB3 encryption keys.
+
+    Returned from a successful verify so the session layer never recomputes it
+    from credentials, and so the key material has exactly one origin.
+    """
+    return hmac.new(ntowf, proof, md5).digest()
+
+
+def server_challenge():
+    """A fresh 8-byte challenge for one session setup.
+
+    secrets, not random: the module-level Mersenne Twister is predictable from
+    its own output, and a predictable challenge lets an attacker who once saw a
+    valid exchange precompute a reply. This is the only thing standing between
+    a replayed capture and a session, so it must come from the OS.
+    """
+    return secrets.token_bytes(8)
+
+
+def parse_ntlmv2_response(data):
+    """Split an NTv2 response into (proof, blob), or raise AuthError.
+
+    Structure is NTProofStr(16) followed by the blob, whose first 8 bytes are
+    the fixed NTLMv2 header. The header is checked because an NTLMv1 response
+    is 24 bytes with no header at all, and it should be refused as unsupported
+    rather than silently sliced into a proof and a nonsense blob.
+    """
+    if not isinstance(data, (bytes, bytearray)):
+        raise AuthError("STATUS_LOGON_FAILURE", "response is not bytes")
+    data = bytes(data)
+    if len(data) < _PROOF_LEN + len(_NTLMV2_HEADER):
+        raise AuthError("STATUS_LOGON_FAILURE",
+                        "response too short to be NTLMv2 (%d bytes)" % len(data))
+    proof, blob = data[:_PROOF_LEN], data[_PROOF_LEN:]
+    if blob[:len(_NTLMV2_HEADER)] != _NTLMV2_HEADER:
+        raise AuthError("STATUS_LOGON_FAILURE",
+                        "not an NTLMv2 response (bad blob header); NTLMv1 is not served")
+    return proof, blob
+
+
+def blob_timestamp(blob):
+    """The client's claimed time from an NTLMv2 blob, as a POSIX timestamp.
+
+    Exposed for logging only. See Authenticator.verify for why it is not used
+    to reject anything.
+    """
+    if len(blob) < 16:
+        return None
+    (filetime,) = struct.unpack("<Q", blob[8:16])
+    if filetime == 0:
+        return None
+    return filetime / 10_000_000.0 - _FILETIME_EPOCH_DELTA
+
+
+class Authenticator:
+    """Checks NTLMv2 credentials for a set of configured users.
+
+    Construct it with users to require a password. Use Authenticator.open() for
+    the no-password mode, which is separate precisely so that it cannot be
+    entered by accident -- an empty password dict raises rather than quietly
+    admitting everyone.
+
+    NTLM allows an offline guess against any exchange an attacker can capture,
+    and this server cannot prevent that. So the password matters more here than
+    it would behind a modern KDC: a long random one is fine, a dictionary word
+    is not.
+    """
+
+    def __init__(self, users, domain="WORKGROUP"):
+        if not users:
+            raise ValueError(
+                "no users configured; use Authenticator.open() if the share is "
+                "meant to need no password")
+        # Keyed by the casefolded name: SMB user names are case-insensitive, and
+        # matching exactly would let "Ripto" fail where "ripto" worked, which
+        # reads as a broken server rather than as a rejected login.
+        self._users = {u.casefold(): p for u, p in users.items()}
+        if len(self._users) != len(users):
+            raise ValueError("user names differ only by case")
+        self.domain = domain
+        self.is_open = False
+
+    @classmethod
+    def open(cls, domain="WORKGROUP"):
+        """The no-password mode, named so it cannot be reached by accident.
+
+        Every session setup succeeds. Callers that log should say so plainly at
+        startup; an operator who did not mean to do this should be able to tell
+        from the log, not from a stranger's file appearing in the share.
+        """
+        self = cls.__new__(cls)
+        self._users = {}
+        self.domain = domain
+        self.is_open = True
+        return self
+
+    def verify(self, user, response, challenge, domain=None):
+        """Check an NTLMv2 response. Returns the SessionBaseKey, or raises.
+
+        Returning the key rather than True means a caller cannot use a bare
+        truth value to decide the session is authenticated and then go and
+        derive keys from somewhere else.
+
+        In open mode it returns None, and that is not a rejection -- failure is
+        always an AuthError, never a falsy return. There is genuinely no key,
+        because nothing was proved and there is no shared secret to derive one
+        from, so a session authenticated this way cannot be signed or
+        encrypted. A caller must branch on is_open when deciding what to
+        negotiate, not on whether a key came back.
+
+        The blob carries a client timestamp, and it is deliberately not checked
+        for freshness. A PS2 has no battery-backed clock that survives being
+        unplugged, so a console will routinely present a time that is years out
+        and would fail any sane window. Replay is already answered by the
+        challenge: it is fresh per session setup and comes from the OS CSPRNG,
+        so a captured response is worthless against the next one.
+        """
+        if self.is_open:
+            return None
+
+        proof, blob = parse_ntlmv2_response(response)
+
+        password = self._users.get((user or "").casefold())
+        if password is None:
+            # Do the same work for an unknown user as for a known one, and fail
+            # with the same status. Returning early here would make "no such
+            # user" measurably faster than "wrong password", which turns the
+            # server into an oracle for which names are worth attacking.
+            expected = ntlmv2_proof(
+                ntowfv2(secrets.token_hex(32), user or "", domain or self.domain),
+                challenge, blob)
+            hmac.compare_digest(expected, proof)
+            raise AuthError("STATUS_LOGON_FAILURE", "unknown user %r" % (user,))
+
+        ntowf = ntowfv2(password, user, domain if domain is not None else self.domain)
+        expected = ntlmv2_proof(ntowf, challenge, blob)
+
+        # compare_digest, not ==. A byte-at-a-time comparison leaks how much of
+        # the proof was right through its timing, which is enough to recover it
+        # one byte at a time without ever knowing the password.
+        if not hmac.compare_digest(expected, proof):
+            raise AuthError("STATUS_LOGON_FAILURE", "bad password for %r" % (user,))
+
+        return session_base_key(ntowf, proof)

--- a/smb2_server/smb2_paths.py
+++ b/smb2_server/smb2_paths.py
@@ -1,0 +1,158 @@
+"""Rooted path resolution for the SMB2/SMB3 server.
+
+Kept in its own module because it is the one piece where a mistake hands a
+client a file the operator never meant to share, and it should be readable and
+testable without starting a server.
+
+This deliberately does NOT copy smbv1_server's resolver. That one resolves with
+os.path.abspath, which normalises ".." textually but does not follow symbolic
+links, so a symlink inside the share resolves to a path that still begins with
+the share root while opening a file outside it. Verified against the real code:
+
+    share/elsewhere -> /tmp/outside
+    resolve("elsewhere/secret.txt")
+      -> .../share/elsewhere/secret.txt   (accepted: starts with the root)
+      real path .../outside/secret.txt    (outside the share)
+
+That is not remotely exploitable on its own -- the SMBv1 server implements no
+command that creates a symlink, so a client cannot plant one -- but it means the
+declared root is not the actual boundary, and both the Edge server and the UDPFS
+path guard already refuse symlink escapes. The newer servers should not inherit
+the weaker rule.
+
+Resolution here is by real path: symlinks are followed first, then the result is
+required to lie under the real root. A symlink pointing outside is refused even
+though the operator created it, which is the same answer the rest of the project
+gives.
+"""
+
+import os
+
+
+class PathError(Exception):
+    """Raised when a client path cannot be served. Carries an NT status name.
+
+    The status travels with the error so a handler does not have to guess which
+    of ACCESS_DENIED / OBJECT_NAME_NOT_FOUND / OBJECT_PATH_SYNTAX_BAD to send
+    back, and so the reason is recorded once, where it was decided.
+    """
+
+    def __init__(self, status, detail):
+        super().__init__(detail)
+        self.status = status
+        self.detail = detail
+
+
+# Characters Windows forbids in a filename. A client that sends one is either
+# confused or probing; either way there is nothing on disk it can legitimately
+# name, so refusing is both correct and cheap.
+_ILLEGAL = set('<>:"|?*') | {chr(c) for c in range(32)}
+
+# NTFS alternate data streams. "file.txt:hidden" names a stream, not a file, and
+# on Windows opening it succeeds -- so leaving this to the filesystem would let a
+# client read or write bytes that never appear in a directory listing.
+_STREAM_SEPARATOR = ":"
+
+MAX_COMPONENT = 255
+MAX_PATH_CHARS = 4096
+
+
+class Share:
+    """One shared directory, and the only way a client path becomes a real one."""
+
+    def __init__(self, name, root, read_only=False):
+        self.name = name
+        # realpath, not abspath: the root itself may be reached through a
+        # symlink (/home/user/games -> /mnt/disk2/games is ordinary), and if the
+        # root is not already resolved then every containment test below is
+        # comparing against the wrong string.
+        self.root = os.path.realpath(root)
+        self.read_only = read_only
+
+    def __repr__(self):
+        return "Share(%r, %r, read_only=%r)" % (self.name, self.root, self.read_only)
+
+    def resolve(self, client_path, must_exist=False):
+        """Map a client path to a real local path inside this share.
+
+        Raises PathError rather than returning None, so a caller cannot forget
+        to check and end up passing None to open().
+        """
+        if client_path is None:
+            client_path = ""
+        if len(client_path) > MAX_PATH_CHARS:
+            raise PathError("STATUS_OBJECT_NAME_INVALID", "path too long")
+
+        # SMB uses backslashes; accept forward slashes too because clients and
+        # test harnesses are inconsistent about it.
+        normalised = client_path.replace("\\", "/")
+
+        # A UNC path names a different server, so it is refused rather than
+        # served. Without this it is not rejected but quietly *reinterpreted*:
+        # the empty leading components fall out of the loop below and
+        # \\server\share\x becomes the share-relative server\share\x. That stays
+        # inside the root, so nothing leaks -- but answering a question the
+        # client did not ask is how a client ends up trusting the wrong file.
+        if normalised.startswith("//"):
+            raise PathError("STATUS_OBJECT_PATH_SYNTAX_BAD",
+                            "UNC paths name another server and are not served")
+
+        components = []
+        for part in normalised.split("/"):
+            if part in ("", "."):
+                continue
+            if part == "..":
+                # Refused outright rather than popped. Popping would silently
+                # accept "a/../../b" as "b" whenever the arithmetic happened to
+                # land back inside the root, which makes the guard depend on
+                # counting rather than on a rule.
+                raise PathError("STATUS_OBJECT_PATH_SYNTAX_BAD",
+                                "parent traversal is not served")
+            if len(part) > MAX_COMPONENT:
+                raise PathError("STATUS_OBJECT_NAME_INVALID", "name component too long")
+            if _STREAM_SEPARATOR in part:
+                raise PathError("STATUS_OBJECT_NAME_INVALID",
+                                "alternate data streams are not served")
+            if any(ch in _ILLEGAL for ch in part):
+                raise PathError("STATUS_OBJECT_NAME_INVALID",
+                                "illegal character in name")
+            components.append(part)
+
+        candidate = os.path.join(self.root, *components) if components else self.root
+
+        # The containment test is done on the REAL path. For a path that does
+        # not exist yet -- a file about to be created -- realpath still resolves
+        # the directories above it, which is the part that could be a symlink
+        # out of the share.
+        real = os.path.realpath(candidate)
+        if not self._inside(real):
+            raise PathError("STATUS_ACCESS_DENIED",
+                            "path resolves outside the share")
+
+        if must_exist and not os.path.exists(real):
+            raise PathError("STATUS_OBJECT_NAME_NOT_FOUND", "no such file or directory")
+        return real
+
+    def _inside(self, real):
+        """True if a resolved path is the share root or beneath it.
+
+        os.path.commonpath rather than a startswith on root + sep, because
+        startswith accepts a sibling whose name merely begins with the root's:
+        with a root of /srv/games, the string test lets /srv/games-private
+        through. commonpath compares whole components.
+        """
+        if real == self.root:
+            return True
+        try:
+            return os.path.commonpath([real, self.root]) == self.root
+        except ValueError:
+            # Raised when the paths are on different drives on Windows, which
+            # is conclusively outside the share.
+            return False
+
+    def relative(self, real):
+        """The share-relative path for a resolved local path, in SMB form."""
+        rel = os.path.relpath(real, self.root)
+        if rel == os.curdir:
+            return ""
+        return rel.replace(os.sep, "\\")

--- a/smb2_server/smb2_paths.py
+++ b/smb2_server/smb2_paths.py
@@ -29,6 +29,16 @@ gives.
 import os
 
 
+# CON/PRN/AUX/NUL plus the numbered serial and printer ports. CLOCK$ is in the
+# same family. Compared against the part before the first dot, because CON.txt
+# is the console device too.
+_RESERVED_DEVICE_NAMES = (
+    {"CON", "PRN", "AUX", "NUL", "CLOCK$"}
+    | {"COM%d" % i for i in range(1, 10)}
+    | {"LPT%d" % i for i in range(1, 10)}
+)
+
+
 class PathError(Exception):
     """Raised when a client path cannot be served. Carries an NT status name.
 
@@ -116,6 +126,22 @@ class Share:
             if any(ch in _ILLEGAL for ch in part):
                 raise PathError("STATUS_OBJECT_NAME_INVALID",
                                 "illegal character in name")
+            # Win32 resolves these names to devices wherever they appear, so
+            # C:\share\NUL is the null device and not a file in the share --
+            # a client could CREATE one and write into a device, or open a
+            # serial port. Windows' own SMB server refuses them, and this
+            # refuses them on every host so a share does not change meaning
+            # depending on which OS is serving it.
+            if part.split(".", 1)[0].upper() in _RESERVED_DEVICE_NAMES:
+                raise PathError("STATUS_OBJECT_NAME_INVALID",
+                                "%r names a device, not a file" % part)
+            # Win32 silently strips a trailing dot or space, so "game.iso." and
+            # "game.iso" would be the same file to a Windows client and two
+            # different ones to this server. Refusing is the only answer that
+            # means the same thing on both.
+            if part[-1] in (".", " "):
+                raise PathError("STATUS_OBJECT_NAME_INVALID",
+                                "name ends in a dot or space")
             components.append(part)
 
         candidate = os.path.join(self.root, *components) if components else self.root

--- a/smb2_server/smb2_server.py
+++ b/smb2_server/smb2_server.py
@@ -1,0 +1,983 @@
+"""An SMB2/SMB3 server for PS2 Servers.
+
+One server, two launcher modes. SMB2 and SMB3 are the same protocol family --
+SMB3 is a higher dialect with crypto on top -- so the dialect ceiling is a flag
+(--smb-version 2 or 3) rather than a second implementation to keep in step.
+
+Why this exists rather than more handlers bolted onto smbv1_server:
+
+  * Windows 10 and 11 ship with SMB1 disabled. Today nobody can browse their own
+    games folder from a modern PC without turning an insecure protocol back on.
+  * OPL is gaining an SMB2/3 client, so these modes have a console ahead of them
+    as well as a file manager.
+  * SMB1 here is guest-only by design and has no authentication at all. Real
+    SMB2 clients require NTLMSSP, so the credential path had to be built rather
+    than skipped -- see smb2_auth.py.
+
+What it is NOT, stated plainly because a half-implemented SMB2 already shipped
+once in this project and cost a release's worth of trust:
+
+  * No signing and no encryption. Both are AES-CMAC/AES-CCM below SMB 3.1.1, and
+    this repo is stdlib-only -- Python has no AES, and a pure-Python one would
+    have to run over every byte of every transfer. The server therefore
+    advertises signing as enabled-but-not-required, which is what a default
+    Windows client accepts. A client whose policy REQUIRES signing will refuse
+    this server, and that is an honest refusal rather than a broken transfer.
+  * Dialect 3.1.1 is not offered. It needs negotiate contexts (a
+    pre-authentication integrity hash the client verifies), and claiming it
+    without them makes Windows drop the connection. 3.0.2 is negotiated instead,
+    which every SMB3 client speaks.
+  * No oplocks, leases, or change notification. A client polls instead.
+
+Run it directly:
+
+    python smb2_server/smb2_server.py --share games=/path/to/games \\
+        --user ripto:secret --port 1445 --smb-version 3
+"""
+
+import argparse
+import errno
+import os
+import socket
+import stat as statmod
+import struct
+import sys
+import threading
+import time
+
+from smb2_auth import AuthError, Authenticator, server_challenge
+from smb2_paths import PathError, Share
+import smb2_spnego as spnego
+import smb2_wire as wire
+
+VERBOSE = False
+
+
+def log(*a):
+    if VERBOSE:
+        print("  [smb2]", *a, file=sys.stderr, flush=True)
+
+
+def note(*a):
+    print("[smb2]", *a, file=sys.stderr, flush=True)
+
+
+class Handle:
+    """One open file or directory, and everything the client can ask about it."""
+
+    __slots__ = ("file_id", "share", "path", "rel", "is_dir", "fh",
+                 "delete_on_close", "listing", "cursor")
+
+    def __init__(self, file_id, share, path, rel, is_dir):
+        self.file_id = file_id
+        self.share = share
+        self.path = path
+        self.rel = rel
+        self.is_dir = is_dir
+        self.fh = None
+        self.delete_on_close = False
+        # Enumeration state. A directory listing is snapshotted at the first
+        # QUERY_DIRECTORY and walked across calls: re-reading the directory on
+        # every call would skip or repeat entries whenever anything changed
+        # underneath, which is how a listing silently loses a game.
+        self.listing = None
+        self.cursor = 0
+
+    def close(self):
+        if self.fh is not None:
+            try:
+                self.fh.close()
+            except OSError:
+                pass
+            self.fh = None
+
+
+class Smb2Error(Exception):
+    """A failure that already knows the NT status it becomes on the wire."""
+
+    def __init__(self, status, detail=""):
+        super().__init__(detail or ("0x%08X" % status))
+        self.status = status
+        self.detail = detail
+
+
+class Connection:
+    """Per-TCP state. One client, one dialect, one session, many handles."""
+
+    def __init__(self, server, sock, peer):
+        self.server = server
+        self.sock = sock
+        self.peer = peer
+        self.dialect = None
+        self.session_id = 0
+        self.authenticated = False
+        self.user = ""
+        self.challenge = None
+        self.trees = {}          # tree_id -> Share
+        self.handles = {}        # volatile id -> Handle
+        self._next_tree = 1
+        self._next_handle = 1
+
+    # -- handle plumbing --------------------------------------------------- #
+    def add_handle(self, share, path, rel, is_dir):
+        hid = self._next_handle
+        self._next_handle += 1
+        h = Handle(hid, share, path, rel, is_dir)
+        self.handles[hid] = h
+        return h
+
+    def handle_from(self, raw_file_id):
+        """The Handle a 16-byte FileId names.
+
+        Both halves are checked. A client that echoes a stale persistent id with
+        a fresh volatile one is confused about which file it has open, and
+        serving it whatever the volatile half points at would hand it the
+        contents of a different file under the name it thinks it asked for.
+        """
+        persistent, volatile = struct.unpack("<QQ", raw_file_id)
+        h = self.handles.get(volatile)
+        if h is None or persistent != volatile:
+            raise Smb2Error(wire.STATUS_FILE_CLOSED, "no such open handle")
+        return h
+
+    def close_all(self):
+        for h in list(self.handles.values()):
+            h.close()
+        self.handles.clear()
+
+
+class Smb2Server:
+    def __init__(self, shares, authenticator, ceiling=wire.CEILING_SMB2,
+                 read_only=False, server_name="PS2SERVERS", domain="WORKGROUP"):
+        self.shares = shares
+        self.auth = authenticator
+        self.ceiling = ceiling
+        self.read_only = read_only
+        self.server_name = server_name
+        self.domain = domain
+        self.guid = os.urandom(16)
+        self.start_time = wire.to_filetime(time.time())
+        self.sock = None
+        self._stop = threading.Event()
+
+    # -- lifecycle --------------------------------------------------------- #
+    def listen(self, bind, port, backlog=8):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind((bind, port))
+        self.sock.listen(backlog)
+        return self.sock.getsockname()[1]
+
+    def serve_forever(self):
+        while not self._stop.is_set():
+            try:
+                client, peer = self.sock.accept()
+            except OSError:
+                if self._stop.is_set():
+                    return
+                raise
+            t = threading.Thread(target=self._serve_client, args=(client, peer),
+                                 daemon=True)
+            t.start()
+
+    def stop(self):
+        self._stop.set()
+        if self.sock is not None:
+            try:
+                self.sock.close()
+            except OSError:
+                pass
+
+    def _serve_client(self, sock, peer):
+        conn = Connection(self, sock, peer)
+        log("connect from", peer)
+        try:
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            while not self._stop.is_set():
+                msg = wire.recv_msg(sock)
+                if msg is None:
+                    break
+                if msg == b"":
+                    continue
+                self._dispatch_all(conn, msg)
+        except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError):
+            log("client", peer, "went away")
+        except OSError as e:
+            log("connection error from", peer, e)
+        finally:
+            conn.close_all()
+            try:
+                sock.close()
+            except OSError:
+                pass
+            log("disconnect", peer)
+
+    # -- dispatch ---------------------------------------------------------- #
+    def _dispatch_all(self, conn, msg):
+        """Handle one message, or every message in a compound one.
+
+        A client is entitled to chain requests with NextCommand and expects the
+        replies chained the same way. Answering only the first is why a compound
+        CREATE/QUERY_INFO/CLOSE -- which is how Explorer opens a file -- would
+        appear to hang.
+        """
+        replies = []
+        offset = 0
+        while offset < len(msg):
+            hdr = wire.parse_header(msg[offset:])
+            if hdr is None:
+                return
+            end = offset + hdr.next_command if hdr.next_command else len(msg)
+            body = msg[offset + wire.HEADER_SIZE:end]
+            status, reply_body, tree_id = self._handle(conn, hdr, body)
+            # A CANCEL is answered with silence. Replying to one is itself a
+            # protocol error, so "no reply" has to be representable.
+            if status is not None:
+                replies.append((hdr, status, reply_body, tree_id))
+            if not hdr.next_command:
+                break
+            offset = end
+
+        out = b""
+        for i, (hdr, status, reply_body, tree_id) in enumerate(replies):
+            last = i == len(replies) - 1
+            padded = reply_body
+            next_command = 0
+            if not last:
+                total = wire.HEADER_SIZE + len(reply_body)
+                aligned = (total + 7) & ~7
+                padded = reply_body + b"\x00" * (aligned - total)
+                next_command = aligned
+            out += wire.pack_header(
+                hdr.command, status, hdr.message_id,
+                tree_id=hdr.tree_id if tree_id is None else tree_id,
+                session_id=conn.session_id or hdr.session_id,
+                next_command=next_command) + padded
+        if out:
+            wire.send_msg(conn.sock, out)
+
+    def _handle(self, conn, hdr, body):
+        """(status, body, tree_id). status None means send nothing at all."""
+        handler = _HANDLERS.get(hdr.command)
+        if handler is None:
+            log("unhandled command", hdr)
+            return wire.STATUS_NOT_SUPPORTED, wire.error_body(), None
+        try:
+            result = handler(self, conn, hdr, body)
+            # TREE_CONNECT is the one handler that decides the header's TreeId,
+            # so handlers may return a third value to override it.
+            if len(result) == 3:
+                return result
+            status, reply_body = result
+            return status, reply_body, None
+        except Smb2Error as e:
+            log(hdr, "->", e.detail)
+            return e.status, wire.error_body(), None
+        except PathError as e:
+            # The path guard already decided which refusal this is; carry its
+            # answer rather than flattening everything to ACCESS_DENIED.
+            log(hdr, "-> path refused:", e)
+            status = wire.STATUS_BY_NAME.get(
+                getattr(e, "status", ""), wire.STATUS_ACCESS_DENIED)
+            return status, wire.error_body(), None
+        except AuthError as e:
+            log(hdr, "-> auth refused:", e)
+            return (wire.STATUS_BY_NAME.get(getattr(e, "status", ""),
+                                            wire.STATUS_LOGON_FAILURE),
+                    wire.error_body(), None)
+        except OSError as e:
+            return _status_for_oserror(e), wire.error_body(), None
+        except Exception as e:                       # never take the server down
+            note("internal error handling", hdr, "->", repr(e))
+            return wire.STATUS_INVALID_PARAMETER, wire.error_body(), None
+
+    # -- guards ------------------------------------------------------------ #
+    def _require_session(self, conn):
+        if not conn.authenticated:
+            raise Smb2Error(wire.STATUS_USER_SESSION_DELETED, "no session")
+
+    def _tree(self, conn, hdr):
+        self._require_session(conn)
+        share = conn.trees.get(hdr.tree_id)
+        if share is None:
+            raise Smb2Error(wire.STATUS_NETWORK_NAME_DELETED, "no such tree")
+        return share
+
+    def _writable(self, share):
+        if self.read_only or share.read_only:
+            raise Smb2Error(wire.STATUS_MEDIA_WRITE_PROTECTED,
+                            "share is read-only")
+
+
+def _status_for_oserror(e):
+    if e.errno in (errno.ENOENT,):
+        return wire.STATUS_OBJECT_NAME_NOT_FOUND
+    if e.errno in (errno.EACCES, errno.EPERM):
+        return wire.STATUS_ACCESS_DENIED
+    if e.errno in (errno.EEXIST,):
+        return wire.STATUS_OBJECT_NAME_COLLISION
+    if e.errno in (errno.EISDIR,):
+        return wire.STATUS_FILE_IS_A_DIRECTORY
+    if e.errno in (errno.ENOTDIR,):
+        return wire.STATUS_NOT_A_DIRECTORY
+    if e.errno in (errno.ENOSPC,):
+        return wire.STATUS_DISK_FULL
+    if e.errno in (errno.ENOTEMPTY,):
+        return wire.STATUS_DIRECTORY_NOT_EMPTY
+    return wire.STATUS_INVALID_PARAMETER
+
+
+# --------------------------------------------------------------------------- #
+# handlers
+# --------------------------------------------------------------------------- #
+
+def h_negotiate(srv, conn, hdr, body):
+    if len(body) < 36:
+        raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "short NEGOTIATE")
+    _size, dialect_count, _mode, _res, _caps = struct.unpack_from("<HHHHI", body, 0)
+    offered = []
+    for i in range(dialect_count):
+        at = 36 + i * 2
+        if at + 2 > len(body):
+            break
+        offered.append(struct.unpack_from("<H", body, at)[0])
+
+    dialect = wire.pick_dialect(offered, srv.ceiling)
+    if dialect is None:
+        raise Smb2Error(wire.STATUS_NOT_SUPPORTED,
+                        "no common dialect; client offered %s" %
+                        ", ".join("0x%04x" % d for d in offered))
+    conn.dialect = dialect
+    log("negotiated dialect 0x%04x with %s" % (dialect, conn.peer))
+
+    token = spnego.neg_token_init()
+    body_out = struct.pack(
+        "<HHHH16sIIIIQQHHI",
+        65,                                     # StructureSize
+        wire.SECURITY_MODE_SIGNING_ENABLED,     # enabled, never required: see module docstring
+        dialect,
+        0,                                      # NegotiateContextCount (3.1.1 only)
+        srv.guid,
+        wire.GLOBAL_CAP_LARGE_MTU,
+        wire.MAX_TRANSACT, wire.MAX_READ, wire.MAX_WRITE,
+        wire.to_filetime(time.time()),
+        srv.start_time,
+        wire.HEADER_SIZE + 64,                  # SecurityBufferOffset
+        len(token),
+        0,                                      # NegotiateContextOffset
+    )
+    return wire.STATUS_SUCCESS, body_out + token
+
+
+def h_session_setup(srv, conn, hdr, body):
+    if len(body) < 24:
+        raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "short SESSION_SETUP")
+    _size, _flags, _mode, _caps, _chan, buf_off, buf_len, _prev = struct.unpack_from(
+        "<HBBIIHHQ", body, 0)
+    start = buf_off - wire.HEADER_SIZE
+    blob = body[start:start + buf_len] if buf_len else b""
+    token = spnego.extract_ntlm(blob)
+    if token is None:
+        raise Smb2Error(wire.STATUS_LOGON_FAILURE, "no NTLMSSP token offered")
+
+    kind = spnego.message_type(token)
+    if kind == spnego.NTLM_NEGOTIATE:
+        # Round one: hand back a challenge and ask for the proof. The challenge
+        # is kept per connection -- it is what the client's response is computed
+        # against, so a shared or reused one would let a captured response be
+        # replayed onto another connection.
+        conn.challenge = server_challenge()
+        chal = spnego.build_challenge(conn.challenge, srv.domain, srv.server_name)
+        out = spnego.neg_token_resp(spnego.ACCEPT_INCOMPLETE, chal, with_mech=True)
+        if conn.session_id == 0:
+            conn.session_id = int.from_bytes(os.urandom(8), "little") or 1
+        body_out = struct.pack("<HHHH", 9, 0, wire.HEADER_SIZE + 8, len(out))
+        return wire.STATUS_MORE_PROCESSING_REQUIRED, body_out + out
+
+    if kind != spnego.NTLM_AUTHENTICATE:
+        raise Smb2Error(wire.STATUS_LOGON_FAILURE,
+                        "unexpected NTLMSSP message type %r" % (kind,))
+
+    if conn.challenge is None:
+        raise Smb2Error(wire.STATUS_LOGON_FAILURE,
+                        "AUTHENTICATE without a challenge")
+
+    creds = spnego.parse_authenticate(token)
+    session_flags = 0
+    if creds.is_anonymous:
+        # A null session proves nothing. It is accepted only where the operator
+        # has already said the share needs no password; otherwise it is a
+        # rejection, not a guest login, so that "no password configured" and
+        # "anonymous allowed" can never be the same state by accident.
+        if not srv.auth.is_open:
+            raise Smb2Error(wire.STATUS_LOGON_FAILURE,
+                            "anonymous session refused; this share needs a password")
+        session_flags = wire.SESSION_FLAG_IS_NULL
+    else:
+        srv.auth.verify(creds.user, creds.nt_response, conn.challenge,
+                        domain=creds.domain or None)
+
+    conn.authenticated = True
+    conn.user = creds.user or "(anonymous)"
+    conn.challenge = None
+    if conn.session_id == 0:
+        conn.session_id = int.from_bytes(os.urandom(8), "little") or 1
+    note("session established for %r from %s (dialect 0x%04x)"
+         % (conn.user, conn.peer[0], conn.dialect or 0))
+
+    out = spnego.neg_token_resp(spnego.ACCEPT_COMPLETED)
+    body_out = struct.pack("<HHHH", 9, session_flags, wire.HEADER_SIZE + 8, len(out))
+    return wire.STATUS_SUCCESS, body_out + out
+
+
+def h_logoff(srv, conn, hdr, body):
+    conn.close_all()
+    conn.authenticated = False
+    conn.trees.clear()
+    return wire.STATUS_SUCCESS, struct.pack("<HH", 4, 0)
+
+
+def h_tree_connect(srv, conn, hdr, body):
+    srv._require_session(conn)
+    if len(body) < 8:
+        raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "short TREE_CONNECT")
+    _size, _flags, path_off, path_len = struct.unpack_from("<HHHH", body, 0)
+    start = path_off - wire.HEADER_SIZE
+    path = wire.from_utf16(body[start:start + path_len])
+
+    # \\server\share -- only the last component names anything here.
+    name = path.rstrip("\\").rsplit("\\", 1)[-1]
+    if name.upper() == "IPC$":
+        # Explorer asks for IPC$ before anything else. Refusing it politely is
+        # correct for a server with no named pipes; refusing it with the wrong
+        # status makes the client abandon the whole connection.
+        raise Smb2Error(wire.STATUS_BAD_NETWORK_NAME, "no IPC$ on this server")
+    share = srv.shares.get(name) or srv.shares.get(name.lower())
+    if share is None:
+        raise Smb2Error(wire.STATUS_BAD_NETWORK_NAME, "no share named %r" % name)
+
+    tree_id = conn._next_tree
+    conn._next_tree += 1
+    conn.trees[tree_id] = share
+    log("tree connect", name, "->", share.root, "as tid", tree_id)
+
+    read_only = srv.read_only or share.read_only
+    access = 0x001200A9 if read_only else 0x001F01FF
+    body_out = struct.pack("<HBBIII", 16, wire.SHARE_TYPE_DISK, 0, 0, 0, access)
+    return wire.STATUS_SUCCESS, body_out, tree_id
+
+
+def h_tree_disconnect(srv, conn, hdr, body):
+    conn.trees.pop(hdr.tree_id, None)
+    return wire.STATUS_SUCCESS, struct.pack("<HH", 4, 0)
+
+
+def h_create(srv, conn, hdr, body):
+    share = srv._tree(conn, hdr)
+    if len(body) < 56:
+        raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "short CREATE")
+    (_size, _sec_flags, _oplock, _impersonation, _flags1, _flags2,
+     _access, _attrs, _share_access, disposition, options,
+     name_off, name_len, _cc_off, _cc_len) = struct.unpack_from(
+        "<HBBIQQIIIIIHHII", body, 0)
+    start = name_off - wire.HEADER_SIZE
+    rel = wire.from_utf16(body[start:start + name_len]) if name_len else ""
+
+    path = share.resolve(rel)
+    exists = os.path.exists(path)
+    want_dir = bool(options & wire.FILE_DIRECTORY_FILE)
+    want_file = bool(options & wire.FILE_NON_DIRECTORY_FILE)
+
+    if disposition == wire.FILE_OPEN and not exists:
+        raise Smb2Error(wire.STATUS_OBJECT_NAME_NOT_FOUND, rel or "<root>")
+    if disposition == wire.FILE_CREATE and exists:
+        raise Smb2Error(wire.STATUS_OBJECT_NAME_COLLISION, rel)
+
+    action = wire.FILE_OPENED
+    if not exists:
+        srv._writable(share)
+        if want_dir:
+            os.makedirs(path, exist_ok=True)
+            action = wire.FILE_CREATED
+        elif disposition in (wire.FILE_CREATE, wire.FILE_OPEN_IF,
+                             wire.FILE_OVERWRITE_IF, wire.FILE_SUPERSEDE):
+            with open(path, "wb"):
+                pass
+            action = wire.FILE_CREATED
+        else:
+            raise Smb2Error(wire.STATUS_OBJECT_NAME_NOT_FOUND, rel)
+    elif disposition in (wire.FILE_OVERWRITE, wire.FILE_OVERWRITE_IF,
+                         wire.FILE_SUPERSEDE) and not os.path.isdir(path):
+        srv._writable(share)
+        with open(path, "wb"):
+            pass
+        action = wire.FILE_OVERWRITTEN
+
+    st = os.stat(path)
+    is_dir = statmod.S_ISDIR(st.st_mode)
+    if is_dir and want_file:
+        raise Smb2Error(wire.STATUS_FILE_IS_A_DIRECTORY, rel)
+    if not is_dir and want_dir:
+        raise Smb2Error(wire.STATUS_NOT_A_DIRECTORY, rel)
+
+    h = conn.add_handle(share, path, rel, is_dir)
+    if options & wire.FILE_DELETE_ON_CLOSE:
+        srv._writable(share)
+        h.delete_on_close = True
+
+    ctime, atime, mtime, chtime = wire._stat_times(st)
+    read_only = srv.read_only or share.read_only
+    body_out = struct.pack(
+        "<HBBIQQQQqqII16sII",
+        89, 0, 0, action,
+        ctime, atime, mtime, chtime,
+        wire.allocation_of(st), st.st_size,
+        wire.attributes_for(st, read_only), 0,
+        struct.pack("<QQ", h.file_id, h.file_id),
+        0, 0)
+    log("create", rel or "<root>", "->", "dir" if is_dir else "file", "id", h.file_id)
+    return wire.STATUS_SUCCESS, body_out
+
+
+def h_close(srv, conn, hdr, body):
+    srv._tree(conn, hdr)
+    if len(body) < 24:
+        raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "short CLOSE")
+    _size, flags, _res = struct.unpack_from("<HHI", body, 0)
+    h = conn.handle_from(body[8:24])
+
+    try:
+        st = os.stat(h.path)
+    except OSError:
+        st = None
+    h.close()
+    conn.handles.pop(h.file_id, None)
+
+    if h.delete_on_close:
+        try:
+            if h.is_dir:
+                os.rmdir(h.path)
+            else:
+                os.remove(h.path)
+        except OSError as e:
+            log("delete-on-close failed for", h.path, e)
+
+    if flags & 0x0001 and st is not None:       # POSTQUERY_ATTRIB
+        ctime, atime, mtime, chtime = wire._stat_times(st)
+        return wire.STATUS_SUCCESS, struct.pack(
+            "<HHIQQQQqqI", 60, flags, 0, ctime, atime, mtime, chtime,
+            wire.allocation_of(st), st.st_size,
+            wire.attributes_for(st, srv.read_only))
+    return wire.STATUS_SUCCESS, struct.pack(
+        "<HHIQQQQqqI", 60, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+
+def h_flush(srv, conn, hdr, body):
+    srv._tree(conn, hdr)
+    h = conn.handle_from(body[8:24])
+    if h.fh is not None:
+        try:
+            h.fh.flush()
+            os.fsync(h.fh.fileno())
+        except OSError:
+            pass
+    return wire.STATUS_SUCCESS, struct.pack("<HH", 4, 0)
+
+
+def _open_file(h, writable):
+    """The lazily-opened file behind a handle.
+
+    Opened on first use rather than at CREATE, because Explorer opens a handle
+    just to read attributes far more often than it reads bytes, and holding a
+    descriptor for every one of those is how a browse of a large folder runs the
+    process out of file descriptors.
+    """
+    if h.fh is None:
+        h.fh = open(h.path, "r+b" if writable else "rb")
+    elif writable and h.fh.mode == "rb":
+        h.fh.close()
+        h.fh = open(h.path, "r+b")
+    return h.fh
+
+
+def h_read(srv, conn, hdr, body):
+    srv._tree(conn, hdr)
+    if len(body) < 48:
+        raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "short READ")
+    _size, _pad, _flags, length, offset = struct.unpack_from("<HBBIQ", body, 0)
+    h = conn.handle_from(body[16:32])
+    if h.is_dir:
+        raise Smb2Error(wire.STATUS_INVALID_DEVICE_REQUEST, "read on a directory")
+
+    length = min(length, wire.MAX_READ)
+    fh = _open_file(h, writable=False)
+    fh.seek(offset)
+    data = fh.read(length)
+    if not data:
+        # Not an error condition to a human, but it is to the protocol: a
+        # zero-length success makes some clients retry the same offset forever.
+        raise Smb2Error(wire.STATUS_END_OF_FILE, "read past the end")
+
+    data_offset = wire.HEADER_SIZE + 16
+    body_out = struct.pack("<HBBIII", 17, data_offset, 0, len(data), 0, 0)
+    return wire.STATUS_SUCCESS, body_out + data
+
+
+def h_write(srv, conn, hdr, body):
+    share = srv._tree(conn, hdr)
+    srv._writable(share)
+    if len(body) < 48:
+        raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "short WRITE")
+    _size, data_off, length, offset = struct.unpack_from("<HHIQ", body, 0)
+    h = conn.handle_from(body[16:32])
+    if h.is_dir:
+        raise Smb2Error(wire.STATUS_INVALID_DEVICE_REQUEST, "write to a directory")
+
+    start = data_off - wire.HEADER_SIZE
+    data = body[start:start + length]
+    fh = _open_file(h, writable=True)
+    fh.seek(offset)
+    written = fh.write(data)
+    fh.flush()
+    return wire.STATUS_SUCCESS, struct.pack("<HHIIHH", 17, 0, written, 0, 0, 0)
+
+
+def _listing_for(h, pattern):
+    """The snapshot a QUERY_DIRECTORY walks, with . and .. first.
+
+    Explorer copes without the dot entries, but a client that computes a parent
+    from the listing does not, and they cost nothing.
+    """
+    import fnmatch
+    names = [".", ".."]
+    try:
+        names += sorted(os.listdir(h.path))
+    except OSError:
+        names = names
+    if pattern and pattern not in ("*", "*.*"):
+        keep = [n for n in names[:2]]
+        keep += [n for n in names[2:] if fnmatch.fnmatch(n.lower(), pattern.lower())]
+        names = keep
+    return names
+
+
+def h_query_directory(srv, conn, hdr, body):
+    share = srv._tree(conn, hdr)
+    if len(body) < 32:
+        raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "short QUERY_DIRECTORY")
+    _size, info_class, flags, _index = struct.unpack_from("<HBBI", body, 0)
+    h = conn.handle_from(body[8:24])
+    name_off, name_len, out_len = struct.unpack_from("<HHI", body, 24)
+    start = name_off - wire.HEADER_SIZE
+    pattern = wire.from_utf16(body[start:start + name_len]) if name_len else "*"
+
+    if not h.is_dir:
+        raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "not a directory")
+
+    RESTART_SCANS = 0x01
+    SINGLE_ENTRY = 0x02
+    if h.listing is None or flags & RESTART_SCANS:
+        h.listing = _listing_for(h, pattern)
+        h.cursor = 0
+
+    out_len = min(out_len or wire.MAX_TRANSACT, wire.MAX_TRANSACT)
+    read_only = srv.read_only or share.read_only
+
+    entries = []
+    total = 0
+    while h.cursor < len(h.listing):
+        name = h.listing[h.cursor]
+        target = h.path if name == "." else (
+            os.path.dirname(h.path) if name == ".." else os.path.join(h.path, name))
+        try:
+            st = os.stat(target)
+        except OSError:
+            h.cursor += 1
+            continue
+        record = wire.directory_entry(name, st, info_class, read_only)
+        if record is None:
+            raise Smb2Error(wire.STATUS_INVALID_PARAMETER,
+                            "unsupported info class 0x%02x" % info_class)
+        padded = record + b"\x00" * ((8 - len(record) % 8) % 8)
+        if total + len(padded) > out_len and entries:
+            break                      # the rest comes on the next call
+        entries.append(padded)
+        total += len(padded)
+        h.cursor += 1
+        if flags & SINGLE_ENTRY:
+            break
+
+    if not entries:
+        # The end of an enumeration is reported, not implied by an empty buffer.
+        # A client that gets success with nothing in it keeps asking.
+        raise Smb2Error(wire.STATUS_NO_MORE_FILES, "end of directory")
+
+    blob = b""
+    for i, record in enumerate(entries):
+        last = i == len(entries) - 1
+        patched = struct.pack("<I", 0 if last else len(record)) + record[4:]
+        blob += patched
+
+    body_out = struct.pack("<HHI", 9, wire.HEADER_SIZE + 8, len(blob))
+    return wire.STATUS_SUCCESS, body_out + blob
+
+
+def h_query_info(srv, conn, hdr, body):
+    share = srv._tree(conn, hdr)
+    if len(body) < 40:
+        raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "short QUERY_INFO")
+    _size, info_type, info_class, out_len = struct.unpack_from("<HBBI", body, 0)
+    h = conn.handle_from(body[24:40])
+    read_only = srv.read_only or share.read_only
+
+    if info_type == wire.INFO_TYPE_FILE:
+        st = os.stat(h.path)
+        name = "\\" + h.rel.replace("/", "\\") if h.rel else "\\"
+        blob = wire.file_info(info_class, st, name, read_only)
+    elif info_type == wire.INFO_TYPE_FILESYSTEM:
+        blob = wire.fs_info(info_class, share.root)
+    else:
+        # Security and quota are not answered. Explorer asks and carries on;
+        # pretending otherwise would mean inventing a descriptor.
+        raise Smb2Error(wire.STATUS_NOT_SUPPORTED,
+                        "info type 0x%02x is not served" % info_type)
+
+    if blob is None:
+        raise Smb2Error(wire.STATUS_NOT_SUPPORTED,
+                        "info class 0x%02x is not served" % info_class)
+    if out_len and len(blob) > out_len:
+        raise Smb2Error(wire.STATUS_INFO_LENGTH_MISMATCH, "buffer too small")
+
+    body_out = struct.pack("<HHI", 9, wire.HEADER_SIZE + 8, len(blob))
+    return wire.STATUS_SUCCESS, body_out + blob
+
+
+def h_set_info(srv, conn, hdr, body):
+    share = srv._tree(conn, hdr)
+    srv._writable(share)
+    if len(body) < 32:
+        raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "short SET_INFO")
+    _size, info_type, info_class, buf_len, buf_off = struct.unpack_from(
+        "<HBBIH", body, 0)
+    h = conn.handle_from(body[16:32])
+    start = buf_off - wire.HEADER_SIZE
+    payload = body[start:start + buf_len]
+
+    if info_type != wire.INFO_TYPE_FILE:
+        raise Smb2Error(wire.STATUS_NOT_SUPPORTED, "only file info can be set")
+
+    if info_class == wire.FILE_END_OF_FILE_INFORMATION and len(payload) >= 8:
+        size = struct.unpack_from("<q", payload, 0)[0]
+        fh = _open_file(h, writable=True)
+        fh.truncate(size)
+        return wire.STATUS_SUCCESS, struct.pack("<H", 2)
+    if info_class == wire.FILE_DISPOSITION_INFORMATION and payload:
+        h.delete_on_close = bool(payload[0])
+        return wire.STATUS_SUCCESS, struct.pack("<H", 2)
+    if info_class == wire.FILE_BASIC_INFORMATION:
+        # Timestamps are accepted and ignored rather than refused: Explorer sets
+        # them on every copy, and failing the call fails the copy.
+        return wire.STATUS_SUCCESS, struct.pack("<H", 2)
+    if info_class == wire.FILE_RENAME_INFORMATION and len(payload) >= 20:
+        name_len = struct.unpack_from("<I", payload, 16)[0]
+        target = wire.from_utf16(payload[20:20 + name_len])
+        dest = h.share.resolve(target)
+        os.replace(h.path, dest)
+        h.path = dest
+        return wire.STATUS_SUCCESS, struct.pack("<H", 2)
+
+    raise Smb2Error(wire.STATUS_NOT_SUPPORTED,
+                    "set info class 0x%02x is not served" % info_class)
+
+
+def h_echo(srv, conn, hdr, body):
+    return wire.STATUS_SUCCESS, struct.pack("<HH", 4, 0)
+
+
+def h_cancel(srv, conn, hdr, body):
+    # Nothing here runs long enough to cancel, and a CANCEL is never answered:
+    # a reply to one is itself a protocol error.
+    return None, None, None
+
+
+def h_ioctl(srv, conn, hdr, body):
+    raise Smb2Error(wire.STATUS_NOT_SUPPORTED, "no ioctls are served")
+
+
+_HANDLERS = {
+    wire.CMD_NEGOTIATE: h_negotiate,
+    wire.CMD_SESSION_SETUP: h_session_setup,
+    wire.CMD_LOGOFF: h_logoff,
+    wire.CMD_TREE_CONNECT: h_tree_connect,
+    wire.CMD_TREE_DISCONNECT: h_tree_disconnect,
+    wire.CMD_CREATE: h_create,
+    wire.CMD_CLOSE: h_close,
+    wire.CMD_FLUSH: h_flush,
+    wire.CMD_READ: h_read,
+    wire.CMD_WRITE: h_write,
+    wire.CMD_QUERY_DIRECTORY: h_query_directory,
+    wire.CMD_QUERY_INFO: h_query_info,
+    wire.CMD_SET_INFO: h_set_info,
+    wire.CMD_ECHO: h_echo,
+    wire.CMD_IOCTL: h_ioctl,
+    wire.CMD_CANCEL: h_cancel,
+}
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+def take_445():
+    """Stop Windows' LanmanServer so this server can bind 445. Returns restore().
+
+    Windows' own SMB client cannot be pointed at a non-445 port, so for Explorer
+    to reach this share at all, something has to give up 445. This is the same
+    approach as smbv1_server/smbserver_opl.py's _take_445, deliberately kept
+    identical in the two properties that matter:
+
+      * Stop, never Disable. A hard kill that never runs restore() leaves the
+        service stopped until the next boot, not disabled forever.
+      * PowerShell resolved by absolute path, so a stray powershell.exe on PATH
+        or in the working directory cannot be run in its place.
+    """
+    import subprocess
+
+    system_root = (os.environ.get("SystemRoot") or os.environ.get("windir")
+                   or r"C:\Windows")
+    powershell = os.path.join(system_root, "System32", "WindowsPowerShell",
+                              "v1.0", "powershell.exe")
+    if not os.path.isfile(powershell):
+        powershell = "powershell"
+
+    def ps(cmd):
+        return subprocess.run([powershell, "-NoProfile", "-Command", cmd],
+                              capture_output=True, text=True)
+
+    status = ps("(Get-Service LanmanServer).Status").stdout.strip()
+    browser = ps("(Get-Service Browser -ErrorAction SilentlyContinue).Status"
+                 ).stdout.strip()
+    note("[445] stopping LanmanServer (was: %s)..." % (status or "?"))
+    res = ps("Stop-Service -Name LanmanServer -Force -ErrorAction SilentlyContinue")
+    if res.returncode != 0:
+        note("[445] could not stop LanmanServer -- run as Administrator.",
+             res.stderr.strip())
+
+    def restore():
+        note("[445] restoring LanmanServer...")
+        ps("Start-Service LanmanServer -ErrorAction SilentlyContinue")
+        if browser == "Running":
+            ps("Start-Service Browser -ErrorAction SilentlyContinue")
+
+    return restore
+
+
+def build_authenticator(user_specs, allow_open):
+    users = {}
+    for spec in user_specs or []:
+        if ":" not in spec:
+            raise SystemExit("--user must be NAME:PASSWORD, got %r" % spec)
+        name, password = spec.split(":", 1)
+        if not name or not password:
+            raise SystemExit("--user needs both a name and a password: %r" % spec)
+        users[name] = password
+    if users:
+        return Authenticator(users)
+    if allow_open:
+        return Authenticator.open()
+    raise SystemExit(
+        "no --user given. SMB2/SMB3 requires a password by default; pass\n"
+        "  --user NAME:PASSWORD\n"
+        "or --open to serve the share to anyone who can reach the port.")
+
+
+def main(argv=None):
+    global VERBOSE
+    ap = argparse.ArgumentParser(
+        description="SMB2/SMB3 server for PS2 Servers (modern clients and "
+                    "SMB2-capable OPL builds).")
+    ap.add_argument("--share", action="append", required=True,
+                    metavar="NAME=PATH", help="share to serve; repeatable")
+    ap.add_argument("--port", type=int, default=1445,
+                    help="TCP port (default 1445). Windows clients cannot use a "
+                         "non-445 port; see --take-445.")
+    ap.add_argument("--bind", default="0.0.0.0", help="bind address (default all)")
+    ap.add_argument("--smb-version", type=int, choices=[2, 3], default=2,
+                    help="dialect ceiling: 2 negotiates up to SMB 2.1, "
+                         "3 up to SMB 3.0.2")
+    ap.add_argument("--user", action="append", metavar="NAME:PASSWORD",
+                    help="a user allowed to log in; repeatable")
+    ap.add_argument("--open", action="store_true",
+                    help="serve with no password at all (anyone who can reach "
+                         "the port gets the share)")
+    ap.add_argument("--read-only", action="store_true",
+                    help="serve read-only (no writes, no saves)")
+    ap.add_argument("--take-445", action="store_true",
+                    help="bind the standard port 445 by pausing Windows file "
+                         "sharing (admin, reversible). Windows Explorer cannot "
+                         "connect to any other port.")
+    ap.add_argument("--server-name", default="PS2SERVERS")
+    ap.add_argument("--domain", default="WORKGROUP")
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args(argv)
+    VERBOSE = args.verbose
+
+    shares = {}
+    for spec in args.share:
+        if "=" not in spec:
+            ap.error("--share must be NAME=PATH, got %r" % spec)
+        name, path = spec.split("=", 1)
+        if not os.path.isdir(path):
+            ap.error("share path does not exist: %s" % path)
+        shares[name] = Share(name, path, read_only=args.read_only)
+    if not shares:
+        ap.error("at least one --share NAME=PATH is required")
+
+    auth = build_authenticator(args.user, args.open)
+    ceiling = wire.CEILING_SMB3 if args.smb_version == 3 else wire.CEILING_SMB2
+
+    server = Smb2Server(shares, auth, ceiling=ceiling, read_only=args.read_only,
+                        server_name=args.server_name, domain=args.domain)
+
+    restore = None
+    want_port = args.port
+    if args.take_445:
+        want_port = 445
+        restore = take_445()
+    try:
+        port = server.listen(args.bind, want_port)
+    except OSError as e:
+        print("ERROR: cannot bind %s:%d -- %s" % (args.bind, want_port, e),
+              file=sys.stderr)
+        if restore is not None:
+            restore()
+        return 1
+
+    note("SMB%d server on %s:%d" % (args.smb_version, args.bind, port))
+    for name, share in shares.items():
+        note("  share %r -> %s%s" % (name, share.root,
+                                     " (read-only)" if args.read_only else ""))
+    if auth.is_open:
+        note("  NO PASSWORD: anyone who can reach this port can read the share.")
+    else:
+        note("  users: " + ", ".join(sorted(args.user and
+                                            [u.split(":", 1)[0] for u in args.user])))
+    note("  Windows cannot connect to a non-445 port. Map it, or run the SMBv1 "
+         "mode for a console.")
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.stop()
+        # Always, including on an exception: leaving Windows file sharing
+        # stopped because this server crashed is a far worse outcome than
+        # whatever went wrong here.
+        if restore is not None:
+            restore()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/smb2_server/smb2_server.py
+++ b/smb2_server/smb2_server.py
@@ -309,6 +309,34 @@ class Smb2Server:
                             "share is read-only")
 
 
+def request_buffer(body, offset, length, what, least=wire.HEADER_SIZE):
+    """The slice a request declares, bounds-checked.
+
+    SMB2 offsets are measured from the start of the MESSAGE, header included, so
+    a valid one is never below 64. Subtracting the header from a smaller value
+    gives a negative index, and Python then slices from the END of the body
+    instead of failing -- so a WRITE with DataOffset 0 wrote whatever bytes
+    happened to be there, at the offset the client asked for, and reported
+    success. Everything the client sent is its own, so nothing leaks; what it
+    loses is the file it was writing to.
+
+    Bounds are checked once, here, rather than at each of the six call sites,
+    because five of them only ended in a confusing refusal and were therefore
+    easy to leave alone.
+    """
+    if length == 0:
+        return b""
+    start = offset - wire.HEADER_SIZE
+    # `least` is the end of the request's own fixed structure. A buffer that
+    # starts before it overlaps the fields that describe it, which no client can
+    # have meant -- for WRITE it meant the file received the request header.
+    if offset < least or start < 0 or length < 0 or start + length > len(body):
+        raise Smb2Error(wire.STATUS_INVALID_PARAMETER,
+                        "%s buffer offset %d length %d does not fit a %d-byte body"
+                        % (what, offset, length, len(body)))
+    return body[start:start + length]
+
+
 def _status_for_oserror(e):
     if e.errno in (errno.ENOENT,):
         return wire.STATUS_OBJECT_NAME_NOT_FOUND
@@ -374,8 +402,8 @@ def h_session_setup(srv, conn, hdr, body):
         raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "short SESSION_SETUP")
     _size, _flags, _mode, _caps, _chan, buf_off, buf_len, _prev = struct.unpack_from(
         "<HBBIIHHQ", body, 0)
-    start = buf_off - wire.HEADER_SIZE
-    blob = body[start:start + buf_len] if buf_len else b""
+    blob = request_buffer(body, buf_off, buf_len, "SESSION_SETUP security",
+                          least=wire.HEADER_SIZE + 24)
     token = spnego.extract_ntlm(blob)
     if token is None:
         raise Smb2Error(wire.STATUS_LOGON_FAILURE, "no NTLMSSP token offered")
@@ -414,8 +442,12 @@ def h_session_setup(srv, conn, hdr, body):
                             "anonymous session refused; this share needs a password")
         session_flags = wire.SESSION_FLAG_IS_NULL
     else:
+        # Pass the domain through exactly as claimed, including empty. NTOWFv2
+        # folds it into the key, so substituting the server's default for a
+        # client that sent none derives a different key and fails a correct
+        # password. Empty is a value here, not a missing one.
         srv.auth.verify(creds.user, creds.nt_response, conn.challenge,
-                        domain=creds.domain or None)
+                        domain=creds.domain)
 
     conn.authenticated = True
     conn.user = creds.user or "(anonymous)"
@@ -442,8 +474,9 @@ def h_tree_connect(srv, conn, hdr, body):
     if len(body) < 8:
         raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "short TREE_CONNECT")
     _size, _flags, path_off, path_len = struct.unpack_from("<HHHH", body, 0)
-    start = path_off - wire.HEADER_SIZE
-    path = wire.from_utf16(body[start:start + path_len])
+    path = wire.from_utf16(request_buffer(body, path_off, path_len,
+                                          "TREE_CONNECT path",
+                                          least=wire.HEADER_SIZE + 8))
 
     # \\server\share -- only the last component names anything here.
     name = path.rstrip("\\").rsplit("\\", 1)[-1]
@@ -480,8 +513,8 @@ def h_create(srv, conn, hdr, body):
      _access, _attrs, _share_access, disposition, options,
      name_off, name_len, _cc_off, _cc_len) = struct.unpack_from(
         "<HBBIQQIIIIIHHII", body, 0)
-    start = name_off - wire.HEADER_SIZE
-    rel = wire.from_utf16(body[start:start + name_len]) if name_len else ""
+    rel = wire.from_utf16(request_buffer(body, name_off, name_len, "CREATE name",
+                                        least=wire.HEADER_SIZE + 56))
 
     path = share.resolve(rel)
     exists = os.path.exists(path)
@@ -633,8 +666,11 @@ def h_write(srv, conn, hdr, body):
     if h.is_dir:
         raise Smb2Error(wire.STATUS_INVALID_DEVICE_REQUEST, "write to a directory")
 
-    start = data_off - wire.HEADER_SIZE
-    data = body[start:start + length]
+    if length > wire.MAX_WRITE:
+        raise Smb2Error(wire.STATUS_INVALID_PARAMETER,
+                        "write of %d bytes exceeds the advertised maximum" % length)
+    data = request_buffer(body, data_off, length, "WRITE data",
+                          least=wire.HEADER_SIZE + 48)
     fh = _open_file(h, writable=True)
     fh.seek(offset)
     written = fh.write(data)
@@ -668,8 +704,9 @@ def h_query_directory(srv, conn, hdr, body):
     _size, info_class, flags, _index = struct.unpack_from("<HBBI", body, 0)
     h = conn.handle_from(body[8:24])
     name_off, name_len, out_len = struct.unpack_from("<HHI", body, 24)
-    start = name_off - wire.HEADER_SIZE
-    pattern = wire.from_utf16(body[start:start + name_len]) if name_len else "*"
+    pattern = wire.from_utf16(request_buffer(
+        body, name_off, name_len, "QUERY_DIRECTORY pattern",
+        least=wire.HEADER_SIZE + 32)) or "*"
 
     if not h.is_dir:
         raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "not a directory")
@@ -687,8 +724,17 @@ def h_query_directory(srv, conn, hdr, body):
     total = 0
     while h.cursor < len(h.listing):
         name = h.listing[h.cursor]
-        target = h.path if name == "." else (
-            os.path.dirname(h.path) if name == ".." else os.path.join(h.path, name))
+        if name == ".":
+            target = h.path
+        elif name == "..":
+            # At the share root the parent is outside the share, and the whole
+            # point of the boundary is that nothing above the root is described
+            # to a client -- not even its size and timestamps. Report the root
+            # itself, which is what a client needs the entry to exist for.
+            target = (h.path if os.path.realpath(h.path) == share.root
+                      else os.path.dirname(h.path))
+        else:
+            target = os.path.join(h.path, name)
         try:
             st = os.stat(target)
         except OSError:
@@ -760,8 +806,8 @@ def h_set_info(srv, conn, hdr, body):
     _size, info_type, info_class, buf_len, buf_off = struct.unpack_from(
         "<HBBIH", body, 0)
     h = conn.handle_from(body[16:32])
-    start = buf_off - wire.HEADER_SIZE
-    payload = body[start:start + buf_len]
+    payload = request_buffer(body, buf_off, buf_len, "SET_INFO",
+                             least=wire.HEADER_SIZE + 32)
 
     if info_type != wire.INFO_TYPE_FILE:
         raise Smb2Error(wire.STATUS_NOT_SUPPORTED, "only file info can be set")
@@ -779,11 +825,22 @@ def h_set_info(srv, conn, hdr, body):
         # them on every copy, and failing the call fails the copy.
         return wire.STATUS_SUCCESS, struct.pack("<H", 2)
     if info_class == wire.FILE_RENAME_INFORMATION and len(payload) >= 20:
+        # Byte 0 is ReplaceIfExists, and it is not advisory: a file manager sends
+        # 0 for an ordinary rename and expects a collision to be refused.
+        # os.replace overwrites unconditionally, so honouring the flag is the
+        # difference between a refused rename and a destroyed file.
+        replace_if_exists = bool(payload[0])
         name_len = struct.unpack_from("<I", payload, 16)[0]
+        if 20 + name_len > len(payload):
+            raise Smb2Error(wire.STATUS_INVALID_PARAMETER, "rename name runs past the buffer")
         target = wire.from_utf16(payload[20:20 + name_len])
         dest = h.share.resolve(target)
+        if os.path.exists(dest) and not os.path.samefile(dest, h.path):
+            if not replace_if_exists:
+                raise Smb2Error(wire.STATUS_OBJECT_NAME_COLLISION, target)
         os.replace(h.path, dest)
         h.path = dest
+        h.rel = target
         return wire.STATUS_SUCCESS, struct.pack("<H", 2)
 
     raise Smb2Error(wire.STATUS_NOT_SUPPORTED,

--- a/smb2_server/smb2_spnego.py
+++ b/smb2_server/smb2_spnego.py
@@ -1,0 +1,197 @@
+"""The SPNEGO/NTLMSSP exchange a real SMB2 client insists on.
+
+smb2_auth answers "do these credentials prove the password". This module is
+everything between that and the wire: the three NTLMSSP messages, and the DER
+wrapper SPNEGO puts around them. It is separate because it is pure encoding --
+no files, no sockets, no policy -- and because getting it wrong produces a
+client that disconnects during SESSION_SETUP with nothing in any log.
+
+SMB1 in this repo has no authentication at all: it advertises SecurityMode 0 and
+accepts every session setup without reading the password bytes. That is fine for
+a console on a LAN and it is why OPL works. It is not an option here, because
+the clients this exists for -- Windows Explorer above all -- will not talk to a
+server that cannot do NTLMSSP.
+"""
+
+import struct
+
+# Flat, not relative. The launcher loads a server by file path with its own
+# directory on sys.path (launcher/serve.py), so this package is never imported
+# as a package -- a relative import here works in a source checkout and fails in
+# the packaged build, which is the worst place to find out.
+from smb2_auth import AuthError
+
+NTLMSSP_SIGNATURE = b"NTLMSSP\x00"
+NTLM_NEGOTIATE = 1
+NTLM_CHALLENGE = 2
+NTLM_AUTHENTICATE = 3
+
+# Only the flags that change what the other side does. UNICODE and NTLM are what
+# make it an NTLMv2 exchange at all; TARGET_INFO is what makes the client send
+# the NTLMv2 blob rather than the old NTLMv1 response, and without
+# EXTENDED_SESSIONSECURITY a client may fall back to something weaker.
+NEGOTIATE_UNICODE = 0x00000001
+REQUEST_TARGET = 0x00000004
+NEGOTIATE_NTLM = 0x00000200
+NEGOTIATE_ALWAYS_SIGN = 0x00008000
+NEGOTIATE_EXTENDED_SESSIONSECURITY = 0x00080000
+NEGOTIATE_TARGET_INFO = 0x00800000
+NEGOTIATE_128 = 0x20000000
+NEGOTIATE_56 = 0x80000000
+
+CHALLENGE_FLAGS = (NEGOTIATE_UNICODE | REQUEST_TARGET | NEGOTIATE_NTLM
+                   | NEGOTIATE_ALWAYS_SIGN | NEGOTIATE_EXTENDED_SESSIONSECURITY
+                   | NEGOTIATE_TARGET_INFO | NEGOTIATE_128 | NEGOTIATE_56)
+
+MSV_AV_EOL = 0x0000
+MSV_AV_NB_COMPUTER_NAME = 0x0001
+MSV_AV_NB_DOMAIN_NAME = 0x0002
+MSV_AV_DNS_COMPUTER_NAME = 0x0003
+MSV_AV_DNS_DOMAIN_NAME = 0x0004
+
+SPNEGO_OID = bytes([0x06, 0x06, 0x2b, 0x06, 0x01, 0x05, 0x05, 0x02])
+NTLMSSP_OID = bytes([0x06, 0x0a, 0x2b, 0x06, 0x01, 0x04, 0x01,
+                     0x82, 0x37, 0x02, 0x02, 0x0a])
+
+ACCEPT_COMPLETED = 0
+ACCEPT_INCOMPLETE = 1
+REJECT = 2
+
+
+# --- the small amount of DER this needs ----------------------------------- #
+
+def _der_len(n):
+    if n < 0x80:
+        return bytes([n])
+    raw = n.to_bytes((n.bit_length() + 7) // 8, "big")
+    return bytes([0x80 | len(raw)]) + raw
+
+
+def _tlv(tag, value):
+    return bytes([tag]) + _der_len(len(value)) + value
+
+
+def neg_token_init():
+    """What the server puts in its NEGOTIATE response: "I do NTLMSSP".
+
+    A client that gets an empty security buffer here may still work by sending
+    raw NTLMSSP, and this server accepts that too (see extract_ntlm), but
+    advertising properly is what makes a strict client choose the mechanism
+    instead of giving up.
+    """
+    mech_list = _tlv(0x30, NTLMSSP_OID)
+    token = _tlv(0x30, _tlv(0xa0, mech_list))
+    return _tlv(0x60, SPNEGO_OID + _tlv(0xa0, token))
+
+
+def neg_token_resp(neg_state, response_token=None, with_mech=False):
+    """The server's half of the SPNEGO round trip."""
+    body = _tlv(0xa0, _tlv(0x0a, bytes([neg_state])))
+    if with_mech:
+        body += _tlv(0xa1, NTLMSSP_OID)
+    if response_token is not None:
+        body += _tlv(0xa2, _tlv(0x04, response_token))
+    return _tlv(0xa1, _tlv(0x30, body))
+
+
+def extract_ntlm(blob):
+    """The NTLMSSP message inside a security buffer, or None.
+
+    Found by its signature rather than by walking the DER. NTLMSSP messages are
+    self-delimiting -- every variable field carries its own length and offset
+    relative to the message start -- so anything after the token is harmless,
+    and this accepts both a SPNEGO-wrapped token and a raw one without needing
+    to know which it was given. A full ASN.1 parser here would be more code
+    whose only job is to find an offset this already has.
+    """
+    if not blob:
+        return None
+    at = blob.find(NTLMSSP_SIGNATURE)
+    if at < 0:
+        return None
+    return blob[at:]
+
+
+def message_type(token):
+    if not token or len(token) < 12:
+        return None
+    return struct.unpack_from("<I", token, 8)[0]
+
+
+def _field(token, offset):
+    """A (Len, MaxLen, Offset) triple and the bytes it points at."""
+    length, _maxlen, at = struct.unpack_from("<HHI", token, offset)
+    if length == 0:
+        return b""
+    if at + length > len(token):
+        raise AuthError("STATUS_INVALID_PARAMETER",
+                        "NTLMSSP field runs past the end of the message")
+    return token[at:at + length]
+
+
+def _av_pair(kind, value):
+    return struct.pack("<HH", kind, len(value)) + value
+
+
+def build_challenge(challenge, target_name="WORKGROUP", computer="PS2SERVERS"):
+    """The CHALLENGE (type 2) message.
+
+    TargetInfo is not decoration: an NTLMv2 client folds these very bytes into
+    the blob it signs, so a server that omits them gets a proof it cannot
+    reproduce and every login fails with the password correct.
+    """
+    target = target_name.encode("utf-16-le")
+    info = (_av_pair(MSV_AV_NB_DOMAIN_NAME, target)
+            + _av_pair(MSV_AV_NB_COMPUTER_NAME, computer.encode("utf-16-le"))
+            + _av_pair(MSV_AV_DNS_DOMAIN_NAME, target)
+            + _av_pair(MSV_AV_DNS_COMPUTER_NAME, computer.encode("utf-16-le"))
+            + _av_pair(MSV_AV_EOL, b""))
+
+    fixed = 56                      # signature..version, before the payload
+    target_at = fixed
+    info_at = target_at + len(target)
+    return (NTLMSSP_SIGNATURE
+            + struct.pack("<I", NTLM_CHALLENGE)
+            + struct.pack("<HHI", len(target), len(target), target_at)
+            + struct.pack("<I", CHALLENGE_FLAGS)
+            + challenge
+            + b"\x00" * 8                                   # Reserved
+            + struct.pack("<HHI", len(info), len(info), info_at)
+            + struct.pack("<BBHBBBB", 6, 1, 7601, 0, 0, 0, 15)   # Version
+            + target + info)
+
+
+class Credentials:
+    """What an AUTHENTICATE message claims, before anything is checked."""
+
+    __slots__ = ("user", "domain", "workstation", "nt_response", "lm_response")
+
+    def __init__(self, user, domain, workstation, nt_response, lm_response):
+        self.user = user
+        self.domain = domain
+        self.workstation = workstation
+        self.nt_response = nt_response
+        self.lm_response = lm_response
+
+    @property
+    def is_anonymous(self):
+        """A null session: no user and no proof offered.
+
+        Worth naming rather than letting it fall through the password check,
+        because an empty NT response against a real account is a different
+        thing from a client deliberately asking for anonymous access, and only
+        one of them should ever be allowed anywhere.
+        """
+        return not self.user and len(self.nt_response) == 0
+
+
+def parse_authenticate(token):
+    """Pull the claim out of an AUTHENTICATE (type 3) message."""
+    if len(token) < 64:
+        raise AuthError("STATUS_INVALID_PARAMETER", "AUTHENTICATE message too short")
+    lm = _field(token, 12)
+    nt = _field(token, 20)
+    domain = _field(token, 28).decode("utf-16-le", "replace")
+    user = _field(token, 36).decode("utf-16-le", "replace")
+    workstation = _field(token, 44).decode("utf-16-le", "replace")
+    return Credentials(user, domain, workstation, nt, lm)

--- a/smb2_server/smb2_wire.py
+++ b/smb2_server/smb2_wire.py
@@ -1,0 +1,478 @@
+"""SMB2/SMB3 wire format: framing, the header, and the structures either side.
+
+Kept apart from the server loop because these are the parts a client will not
+forgive. A handler that answers the wrong question is a bug you can see in a
+log; a structure whose StructureSize is off by one makes a real client hang up
+with no message at all, and the only way to find it is to have the layouts
+written down somewhere you can read them.
+
+Everything here is little-endian except the 4-byte session framing, which is the
+one big-endian field in the whole protocol -- the same trap SMB1 has, and the
+reason send_msg/recv_msg are lifted from smbv1_server/smbserver_opl.py rather
+than rewritten. That file is what consoles have actually been tested against.
+"""
+
+import os
+import struct
+
+# --- session framing (direct TCP, RFC 1002 style) ------------------------- #
+# byte 0 = message type (0x00 session message), bytes 1-3 = 24-bit BIG-endian
+# length. Identical to SMB1, so this is the tested implementation, moved.
+
+
+def send_msg(sock, msg):
+    sock.sendall(b"\x00" + len(msg).to_bytes(3, "big") + msg)
+
+
+def _recv_exact(sock, n):
+    buf = b""
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            return None
+        buf += chunk
+    return buf
+
+
+def recv_msg(sock):
+    """The next SMB message, b"" for a keep-alive, or None at EOF.
+
+    The three are deliberately different values: a keep-alive that read as EOF
+    would drop a connection that was healthy, and an EOF that read as a
+    keep-alive would spin.
+    """
+    hdr = _recv_exact(sock, 4)
+    if hdr is None:
+        return None
+    length = int.from_bytes(hdr[1:4], "big")
+    if hdr[0] != 0x00:
+        if length:
+            _recv_exact(sock, length)
+        return b""
+    if length == 0:
+        return b""
+    return _recv_exact(sock, length)
+
+
+# --- constants ------------------------------------------------------------ #
+
+SMB2_MAGIC = b"\xfeSMB"
+HEADER_SIZE = 64
+
+# Dialects. 2.0.2 is included because it is what a minimal or old client offers;
+# 3.1.1 is deliberately NOT offered -- see pick_dialect.
+DIALECT_202 = 0x0202
+DIALECT_210 = 0x0210
+DIALECT_300 = 0x0300
+DIALECT_302 = 0x0302
+DIALECT_311 = 0x0311
+
+# What each launcher mode asks for. SMB2 and SMB3 are one server with a ceiling,
+# not two servers: SMB3 is the same protocol with a higher dialect and crypto.
+CEILING_SMB2 = DIALECT_210
+CEILING_SMB3 = DIALECT_302
+
+CMD_NEGOTIATE = 0x0000
+CMD_SESSION_SETUP = 0x0001
+CMD_LOGOFF = 0x0002
+CMD_TREE_CONNECT = 0x0003
+CMD_TREE_DISCONNECT = 0x0004
+CMD_CREATE = 0x0005
+CMD_CLOSE = 0x0006
+CMD_FLUSH = 0x0007
+CMD_READ = 0x0008
+CMD_WRITE = 0x0009
+CMD_LOCK = 0x000A
+CMD_IOCTL = 0x000B
+CMD_CANCEL = 0x000C
+CMD_ECHO = 0x000D
+CMD_QUERY_DIRECTORY = 0x000E
+CMD_CHANGE_NOTIFY = 0x000F
+CMD_QUERY_INFO = 0x0010
+CMD_SET_INFO = 0x0011
+CMD_OPLOCK_BREAK = 0x0012
+
+COMMAND_NAMES = {
+    CMD_NEGOTIATE: "NEGOTIATE", CMD_SESSION_SETUP: "SESSION_SETUP",
+    CMD_LOGOFF: "LOGOFF", CMD_TREE_CONNECT: "TREE_CONNECT",
+    CMD_TREE_DISCONNECT: "TREE_DISCONNECT", CMD_CREATE: "CREATE",
+    CMD_CLOSE: "CLOSE", CMD_FLUSH: "FLUSH", CMD_READ: "READ",
+    CMD_WRITE: "WRITE", CMD_LOCK: "LOCK", CMD_IOCTL: "IOCTL",
+    CMD_CANCEL: "CANCEL", CMD_ECHO: "ECHO",
+    CMD_QUERY_DIRECTORY: "QUERY_DIRECTORY", CMD_CHANGE_NOTIFY: "CHANGE_NOTIFY",
+    CMD_QUERY_INFO: "QUERY_INFO", CMD_SET_INFO: "SET_INFO",
+    CMD_OPLOCK_BREAK: "OPLOCK_BREAK",
+}
+
+FLAG_SERVER_TO_REDIR = 0x00000001
+FLAG_ASYNC = 0x00000002
+FLAG_RELATED = 0x00000004
+FLAG_SIGNED = 0x00000008
+
+STATUS_SUCCESS = 0x00000000
+STATUS_PENDING = 0x00000103
+STATUS_NO_MORE_FILES = 0x80000006
+STATUS_INVALID_PARAMETER = 0xC000000D
+STATUS_NO_SUCH_FILE = 0xC000000F
+STATUS_END_OF_FILE = 0xC0000011
+STATUS_MORE_PROCESSING_REQUIRED = 0xC0000016
+STATUS_ACCESS_DENIED = 0xC0000022
+STATUS_OBJECT_NAME_INVALID = 0xC0000033
+STATUS_OBJECT_NAME_NOT_FOUND = 0xC0000034
+STATUS_OBJECT_NAME_COLLISION = 0xC0000035
+STATUS_OBJECT_PATH_NOT_FOUND = 0xC000003A
+STATUS_OBJECT_PATH_SYNTAX_BAD = 0xC000003B
+STATUS_LOGON_FAILURE = 0xC000006D
+STATUS_INSUFF_SERVER_RESOURCES = 0xC0000205
+STATUS_NOT_SUPPORTED = 0xC00000BB
+STATUS_INVALID_DEVICE_REQUEST = 0xC0000010
+STATUS_FILE_IS_A_DIRECTORY = 0xC00000BA
+STATUS_NOT_A_DIRECTORY = 0xC0000103
+STATUS_BAD_NETWORK_NAME = 0xC00000CC
+STATUS_USER_SESSION_DELETED = 0xC0000203
+STATUS_NETWORK_NAME_DELETED = 0xC00000C9
+STATUS_FILE_CLOSED = 0xC0000128
+STATUS_INFO_LENGTH_MISMATCH = 0xC0000004
+STATUS_MEDIA_WRITE_PROTECTED = 0xC00000A2
+STATUS_DISK_FULL = 0xC000007F
+STATUS_CANNOT_DELETE = 0xC0000121
+STATUS_DIRECTORY_NOT_EMPTY = 0xC0000101
+
+# Names for the statuses smb2_paths raises, so a path decision made in one place
+# arrives on the wire as the status it chose rather than a generic denial.
+STATUS_BY_NAME = {
+    "STATUS_ACCESS_DENIED": STATUS_ACCESS_DENIED,
+    "STATUS_OBJECT_NAME_INVALID": STATUS_OBJECT_NAME_INVALID,
+    "STATUS_OBJECT_NAME_NOT_FOUND": STATUS_OBJECT_NAME_NOT_FOUND,
+    "STATUS_OBJECT_PATH_SYNTAX_BAD": STATUS_OBJECT_PATH_SYNTAX_BAD,
+    "STATUS_OBJECT_PATH_NOT_FOUND": STATUS_OBJECT_PATH_NOT_FOUND,
+    "STATUS_LOGON_FAILURE": STATUS_LOGON_FAILURE,
+}
+
+# File attributes
+ATTR_READONLY = 0x00000001
+ATTR_HIDDEN = 0x00000002
+ATTR_DIRECTORY = 0x00000010
+ATTR_ARCHIVE = 0x00000020
+ATTR_NORMAL = 0x00000080
+
+# CreateDisposition
+FILE_SUPERSEDE = 0x00000000
+FILE_OPEN = 0x00000001
+FILE_CREATE = 0x00000002
+FILE_OPEN_IF = 0x00000003
+FILE_OVERWRITE = 0x00000004
+FILE_OVERWRITE_IF = 0x00000005
+
+# CreateAction (what the server actually did)
+FILE_SUPERSEDED = 0x00000000
+FILE_OPENED = 0x00000001
+FILE_CREATED = 0x00000002
+FILE_OVERWRITTEN = 0x00000003
+
+# CreateOptions worth honouring
+FILE_DIRECTORY_FILE = 0x00000001
+FILE_NON_DIRECTORY_FILE = 0x00000040
+FILE_DELETE_ON_CLOSE = 0x00001000
+
+SHARE_TYPE_DISK = 0x01
+
+SECURITY_MODE_SIGNING_ENABLED = 0x0001
+SECURITY_MODE_SIGNING_REQUIRED = 0x0002
+
+GLOBAL_CAP_DFS = 0x00000001
+GLOBAL_CAP_LARGE_MTU = 0x00000004
+
+SESSION_FLAG_IS_GUEST = 0x0001
+SESSION_FLAG_IS_NULL = 0x0002
+
+MAX_TRANSACT = 1 << 20
+MAX_READ = 1 << 20
+MAX_WRITE = 1 << 20
+
+
+def pick_dialect(offered, ceiling):
+    """The best dialect both sides can speak, or None.
+
+    3.1.1 is never chosen even when a client offers it. It requires negotiate
+    contexts -- a pre-authentication integrity hash the client verifies -- and a
+    server that claims 3.1.1 without them is refused outright by Windows. The
+    honest move is to negotiate 3.0.2 and work, rather than advertise a dialect
+    and fail the connection. Every SMB3 client speaks 3.0.2.
+    """
+    usable = [d for d in offered if d <= ceiling and d in (
+        DIALECT_202, DIALECT_210, DIALECT_300, DIALECT_302)]
+    return max(usable) if usable else None
+
+
+def to_filetime(unix_ts):
+    """Windows FILETIME: 100ns ticks since 1601-01-01 UTC."""
+    if unix_ts <= 0:
+        return 0
+    return int(unix_ts * 10_000_000) + 116444736000000000
+
+
+def utf16(text):
+    return (text or "").encode("utf-16-le")
+
+
+def from_utf16(raw):
+    return raw.decode("utf-16-le", "replace")
+
+
+class Header:
+    """A parsed SMB2 header. 64 bytes, fixed, every message."""
+
+    __slots__ = ("credit_charge", "status", "command", "credits", "flags",
+                 "next_command", "message_id", "tree_id", "session_id", "signature")
+
+    def __init__(self, raw):
+        (_magic, _size, self.credit_charge, self.status, self.command,
+         self.credits, self.flags, self.next_command, self.message_id,
+         _reserved, self.tree_id, self.session_id, self.signature) = struct.unpack(
+            "<4sHHIHHIIQIIQ16s", raw[:HEADER_SIZE])
+
+    def __repr__(self):
+        return "<SMB2 %s mid=%d tid=%d sid=%#x>" % (
+            COMMAND_NAMES.get(self.command, "0x%04x" % self.command),
+            self.message_id, self.tree_id, self.session_id)
+
+
+def parse_header(raw):
+    if len(raw) < HEADER_SIZE or raw[:4] != SMB2_MAGIC:
+        return None
+    return Header(raw)
+
+
+def pack_header(command, status, message_id, tree_id=0, session_id=0,
+                credits=1, flags=0, next_command=0):
+    return struct.pack(
+        "<4sHHIHHIIQIIQ16s",
+        SMB2_MAGIC,
+        HEADER_SIZE,
+        0,                                  # CreditCharge
+        status,
+        command,
+        credits,
+        flags | FLAG_SERVER_TO_REDIR,
+        next_command,
+        message_id,
+        0,                                  # Reserved (SMB1 PID high)
+        tree_id,
+        session_id,
+        b"\x00" * 16,                       # Signature
+    )
+
+
+def error_body(status=0):
+    """The body every failure carries.
+
+    StructureSize is 9 with a single byte of ErrorData, and that byte is not
+    optional padding a client tolerates -- a body of 8 bytes is a malformed
+    response, which is a different failure from the one being reported.
+    """
+    return struct.pack("<HBBI", 9, 0, 0, 0) + b"\x00"
+
+
+# --- file information encoders -------------------------------------------- #
+# The layouts a client reads to size, date and list what it is looking at. All
+# of them are fixed-size records followed by a variable name, and all of them
+# are silently wrong if a field is the wrong width -- so they live together.
+
+
+def _stat_times(st):
+    return (to_filetime(getattr(st, "st_ctime", 0)),
+            to_filetime(getattr(st, "st_atime", 0)),
+            to_filetime(getattr(st, "st_mtime", 0)),
+            to_filetime(getattr(st, "st_mtime", 0)))
+
+
+def attributes_for(st, read_only=False):
+    import stat as statmod
+    if statmod.S_ISDIR(st.st_mode):
+        attrs = ATTR_DIRECTORY
+    else:
+        attrs = ATTR_ARCHIVE
+    if read_only:
+        attrs |= ATTR_READONLY
+    return attrs
+
+
+def allocation_of(st):
+    """Rounded to a 4 KiB cluster, the way a real filesystem reports it."""
+    size = st.st_size
+    return (size + 4095) & ~4095
+
+
+def both_directory_entry(name, st, read_only=False, with_file_id=False):
+    """FileBothDirectoryInformation / FileIdBothDirectoryInformation.
+
+    NextEntryOffset is filled in by the caller once it knows whether another
+    entry follows, because only the caller knows that. It must be 8-byte
+    aligned: an unaligned chain is the classic way a listing shows the first
+    file and then stops.
+    """
+    ctime, atime, mtime, chtime = _stat_times(st)
+    name_utf16 = utf16(name)
+    fixed = struct.pack(
+        "<IIQQQQqqIIIBB24s",
+        0,                              # NextEntryOffset, patched by the caller
+        0,                              # FileIndex
+        ctime, atime, mtime, chtime,
+        st.st_size,                     # EndOfFile
+        allocation_of(st),
+        attributes_for(st, read_only),
+        len(name_utf16),
+        0,                              # EaSize
+        0,                              # ShortNameLength
+        0,                              # Reserved
+        b"\x00" * 24,                   # ShortName
+    )
+    if with_file_id:
+        fixed += struct.pack("<HQ", 0, st.st_ino & 0xFFFFFFFFFFFFFFFF)
+    return fixed + name_utf16
+
+
+def directory_entry(name, st, info_class, read_only=False):
+    """One listing entry in the class the client asked for.
+
+    Returns None for a class this server does not encode, so the caller answers
+    STATUS_INVALID_PARAMETER rather than sending a record the client will
+    misread as whatever it did ask for.
+    """
+    ctime, atime, mtime, chtime = _stat_times(st)
+    name_utf16 = utf16(name)
+    attrs = attributes_for(st, read_only)
+    if info_class == FILE_BOTH_DIRECTORY_INFORMATION:
+        return both_directory_entry(name, st, read_only)
+    if info_class == FILE_ID_BOTH_DIRECTORY_INFORMATION:
+        return both_directory_entry(name, st, read_only, with_file_id=True)
+    if info_class == FILE_DIRECTORY_INFORMATION:
+        return struct.pack("<IIQQQQqqII", 0, 0, ctime, atime, mtime, chtime,
+                           st.st_size, allocation_of(st), attrs,
+                           len(name_utf16)) + name_utf16
+    if info_class == FILE_FULL_DIRECTORY_INFORMATION:
+        return struct.pack("<IIQQQQqqIII", 0, 0, ctime, atime, mtime, chtime,
+                           st.st_size, allocation_of(st), attrs,
+                           len(name_utf16), 0) + name_utf16
+    if info_class == FILE_NAMES_INFORMATION:
+        return struct.pack("<III", 0, 0, len(name_utf16)) + name_utf16
+    return None
+
+
+FILE_DIRECTORY_INFORMATION = 0x01
+FILE_FULL_DIRECTORY_INFORMATION = 0x02
+FILE_BOTH_DIRECTORY_INFORMATION = 0x03
+FILE_BASIC_INFORMATION = 0x04
+FILE_STANDARD_INFORMATION = 0x05
+FILE_INTERNAL_INFORMATION = 0x06
+FILE_EA_INFORMATION = 0x07
+FILE_ACCESS_INFORMATION = 0x08
+FILE_NAME_INFORMATION = 0x09
+FILE_RENAME_INFORMATION = 0x0A
+FILE_NAMES_INFORMATION = 0x0C
+FILE_DISPOSITION_INFORMATION = 0x0D
+FILE_POSITION_INFORMATION = 0x0E
+FILE_MODE_INFORMATION = 0x10
+FILE_ALIGNMENT_INFORMATION = 0x11
+FILE_ALL_INFORMATION = 0x12
+FILE_END_OF_FILE_INFORMATION = 0x14
+FILE_NETWORK_OPEN_INFORMATION = 0x22
+FILE_ID_BOTH_DIRECTORY_INFORMATION = 0x25
+
+FS_VOLUME_INFORMATION = 0x01
+FS_SIZE_INFORMATION = 0x03
+FS_DEVICE_INFORMATION = 0x04
+FS_ATTRIBUTE_INFORMATION = 0x05
+FS_FULL_SIZE_INFORMATION = 0x07
+
+INFO_TYPE_FILE = 0x01
+INFO_TYPE_FILESYSTEM = 0x02
+INFO_TYPE_SECURITY = 0x03
+
+
+def file_info(info_class, st, name="", read_only=False):
+    """A QUERY_INFO answer for the FILE type, or None if unencodable."""
+    ctime, atime, mtime, chtime = _stat_times(st)
+    attrs = attributes_for(st, read_only)
+    import stat as statmod
+    is_dir = statmod.S_ISDIR(st.st_mode)
+
+    if info_class == FILE_BASIC_INFORMATION:
+        return struct.pack("<QQQQII", ctime, atime, mtime, chtime, attrs, 0)
+    if info_class == FILE_STANDARD_INFORMATION:
+        return struct.pack("<qqIBBH", allocation_of(st), st.st_size,
+                           1, 0, 1 if is_dir else 0, 0)
+    if info_class == FILE_INTERNAL_INFORMATION:
+        return struct.pack("<Q", st.st_ino & 0xFFFFFFFFFFFFFFFF)
+    if info_class == FILE_EA_INFORMATION:
+        return struct.pack("<I", 0)
+    if info_class == FILE_ACCESS_INFORMATION:
+        return struct.pack("<I", 0x001F01FF)
+    if info_class == FILE_POSITION_INFORMATION:
+        return struct.pack("<q", 0)
+    if info_class == FILE_MODE_INFORMATION:
+        return struct.pack("<I", 0)
+    if info_class == FILE_ALIGNMENT_INFORMATION:
+        return struct.pack("<I", 0)
+    if info_class == FILE_NAME_INFORMATION:
+        raw = utf16(name)
+        return struct.pack("<I", len(raw)) + raw
+    if info_class == FILE_NETWORK_OPEN_INFORMATION:
+        return struct.pack("<QQQQqqII", ctime, atime, mtime, chtime,
+                           allocation_of(st), st.st_size, attrs, 0)
+    if info_class == FILE_ALL_INFORMATION:
+        # Explorer asks for this one constantly: it is the other classes
+        # concatenated in a fixed order, so it is built from them rather than
+        # re-packed, or the two would drift.
+        raw = utf16(name)
+        return (file_info(FILE_BASIC_INFORMATION, st, read_only=read_only)
+                + file_info(FILE_STANDARD_INFORMATION, st, read_only=read_only)
+                + file_info(FILE_INTERNAL_INFORMATION, st)
+                + file_info(FILE_EA_INFORMATION, st)
+                + file_info(FILE_ACCESS_INFORMATION, st)
+                + struct.pack("<q", 0)              # CurrentByteOffset
+                + struct.pack("<I", 0)              # Mode
+                + struct.pack("<I", 0)              # AlignmentRequirement
+                + struct.pack("<I", len(raw)) + raw)
+    return None
+
+
+def fs_info(info_class, root, label="PS2SERVERS"):
+    """A QUERY_INFO answer for the FILESYSTEM type, or None."""
+    if info_class == FS_VOLUME_INFORMATION:
+        raw = utf16(label)
+        return struct.pack("<QIIBB", 0, 0x53324253, len(raw), 0, 0) + raw
+    if info_class in (FS_SIZE_INFORMATION, FS_FULL_SIZE_INFORMATION):
+        try:
+            usage = os.statvfs(root)
+            total = usage.f_blocks
+            free = usage.f_bavail
+            sectors_per_unit = max(1, usage.f_frsize // 512)
+        except (AttributeError, OSError):
+            # Windows has no statvfs. shutil.disk_usage is portable and is what
+            # the number is for -- Explorer shows it in the status bar.
+            import shutil
+            try:
+                du = shutil.disk_usage(root)
+            except OSError:
+                du = None
+            if du is None:
+                total, free, sectors_per_unit = 0, 0, 8
+            else:
+                sectors_per_unit = 8            # 4 KiB units of 512-byte sectors
+                total = du.total // 4096
+                free = du.free // 4096
+        if info_class == FS_SIZE_INFORMATION:
+            return struct.pack("<qqII", total, free, sectors_per_unit, 512)
+        return struct.pack("<qqqII", total, free, free, sectors_per_unit, 512)
+    if info_class == FS_DEVICE_INFORMATION:
+        return struct.pack("<II", 0x00000007, 0x00000020)   # DISK, remote
+    if info_class == FS_ATTRIBUTE_INFORMATION:
+        name = utf16("NTFS")
+        # 0x02 CASE_PRESERVED_NAMES | 0x04 UNICODE_ON_DISK. Deliberately NOT
+        # 0x01 CASE_SENSITIVE_SEARCH: Windows shares are not case sensitive, and
+        # claiming otherwise makes a client treat Game.iso and game.iso as two
+        # files on a filesystem where they are one.
+        return struct.pack("<III", 0x00000006, 255, len(name)) + name
+    return None

--- a/smb2_server/smb2_wire.py
+++ b/smb2_server/smb2_wire.py
@@ -142,6 +142,10 @@ STATUS_DIRECTORY_NOT_EMPTY = 0xC0000101
 # arrives on the wire as the status it chose rather than a generic denial.
 STATUS_BY_NAME = {
     "STATUS_ACCESS_DENIED": STATUS_ACCESS_DENIED,
+    # smb2_spnego raises this for a malformed NTLMSSP token. Without it here the
+    # lookup falls back to LOGON_FAILURE, which tells the user their password is
+    # wrong when the token never parsed.
+    "STATUS_INVALID_PARAMETER": STATUS_INVALID_PARAMETER,
     "STATUS_OBJECT_NAME_INVALID": STATUS_OBJECT_NAME_INVALID,
     "STATUS_OBJECT_NAME_NOT_FOUND": STATUS_OBJECT_NAME_NOT_FOUND,
     "STATUS_OBJECT_PATH_SYNTAX_BAD": STATUS_OBJECT_PATH_SYNTAX_BAD,

--- a/smbv1_server/smbserver_opl.py
+++ b/smbv1_server/smbserver_opl.py
@@ -1021,7 +1021,8 @@ def main(argv=None):
     ap.add_argument("--take-445", action="store_true",
                     help="bind the standard port 445 by pausing Windows LanmanServer (admin; reversible)")
     ap.add_argument("--smb-version", type=int, choices=[1, 2, 3], default=1,
-                    help="SMB protocol version (1=SMBv1, 2=SMBv2, 3=SMBv3)")
+                    help="SMB protocol version (1=SMBv1; 2 and 3 are INCOMPLETE "
+                         "-- they negotiate and connect but serve no files)")
     ap.add_argument("-v", "--verbose", action="store_true")
     args = ap.parse_args(argv)
     VERBOSE = args.verbose
@@ -1036,6 +1037,18 @@ def main(argv=None):
         shares[name] = Share(name, path)
     if not shares:
         ap.error("at least one --share NAME=PATH is required")
+
+    # The SMB2/SMB3 handlers negotiate, authenticate and accept a tree connect,
+    # then serve nothing: READ returns zero bytes, CREATE ignores the path it was
+    # given, WRITE reports success without writing, and QUERY_DIRECTORY is absent
+    # so the share cannot be listed. A client sees an empty folder and no error.
+    # The flag stays because it is how the real implementation gets developed and
+    # tested, but it must never look finished to whoever runs it.
+    if args.smb_version != 1:
+        print("WARNING: --smb-version %d is INCOMPLETE. The server will negotiate "
+              "SMB%d and accept a connection, but it serves no files: reads return "
+              "nothing and the share cannot be listed. Use --smb-version 1 to serve "
+              "a console." % (args.smb_version, args.smb_version), file=sys.stderr)
 
     server = SmbServer(shares, read_only=args.read_only, smb_version=args.smb_version)
 

--- a/tests/test_linux_parity.py
+++ b/tests/test_linux_parity.py
@@ -156,7 +156,11 @@ class WindowsOnlyFieldTests(unittest.TestCase):
         for server in servers.REGISTRY.values():
             for f in server.fields:
                 if f.windows_only:
-                    self.assertIn((server.key, f.key), (("smbv1", "take_445"),))
+                    # take_445 pauses a Windows service, so it is the one field
+                    # with nothing to do elsewhere. Every SMB mode has it.
+                    self.assertIn((server.key, f.key),
+                                  (("smbv1", "take_445"), ("smbv2", "take_445"),
+                                   ("smbv3", "take_445")))
 
 
 if __name__ == "__main__":

--- a/tests/test_linux_parity.py
+++ b/tests/test_linux_parity.py
@@ -156,8 +156,7 @@ class WindowsOnlyFieldTests(unittest.TestCase):
         for server in servers.REGISTRY.values():
             for f in server.fields:
                 if f.windows_only:
-                    self.assertIn((server.key, f.key),
-                                  (("smbv1", "take_445"), ("smbv2", "take_445"), ("smbv3", "take_445")))
+                    self.assertIn((server.key, f.key), (("smbv1", "take_445"),))
 
 
 if __name__ == "__main__":

--- a/tests/test_netinfo_and_smb.py
+++ b/tests/test_netinfo_and_smb.py
@@ -44,6 +44,24 @@ def _probe_values(server):
     return values
 
 
+def _load_server_module(server):
+    """Import a REGISTRY server's entry point the way the launcher does.
+
+    By file path with its own directory on sys.path, because that is how
+    launcher/serve.py loads it -- importing it any other way would test a module
+    that resolves its siblings differently from the one users run.
+    """
+    import importlib.util
+    if server.module_dir and server.module_dir not in sys.path:
+        sys.path.insert(0, server.module_dir)
+    spec = importlib.util.spec_from_file_location(
+        "_probe_" + server.key, server.module_file)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def _smb_dialect_of(server):
     """The dialect a REGISTRY entry asks the server for, or None if it is not SMB."""
     argv = server._build_argv(_probe_values(server))
@@ -73,28 +91,25 @@ class ServerRegistryTests(unittest.TestCase):
         user connected successfully and saw an empty folder with no error.
 
         This is not "SMB2 is banned". It is the ordering: the server has to be
-        able to serve a file before the launcher offers the mode. Implement
-        QUERY_DIRECTORY and a real READ, and this test goes green on its own --
-        no edit here, nothing to remember.
+        able to serve a file before the launcher offers the mode. The check is
+        against whichever server the mode actually runs, so it keeps meaning
+        something when a mode is repointed at a different implementation.
         """
-        sys.path.insert(0, os.path.join(_ROOT, "smbv1_server"))
-        try:
-            import smbserver_opl
-        finally:
-            sys.path.pop(0)
-
         SMB2_QUERY_DIRECTORY = 0x000E
-        can_list = SMB2_QUERY_DIRECTORY in smbserver_opl.SMB2_HANDLERS
 
         for key, server in servers.REGISTRY.items():
             dialect = _smb_dialect_of(server)
             if dialect is None or dialect < 2:
                 continue
-            self.assertTrue(
-                can_list,
-                "{} offers SMB{}, but the server implements no QUERY_DIRECTORY, "
-                "so the share cannot be listed. Finish the SMB2 handlers before "
-                "putting the mode back in the REGISTRY.".format(key, dialect))
+            module = _load_server_module(server)
+            handlers = (getattr(module, "SMB2_HANDLERS", None)
+                        or getattr(module, "_HANDLERS", None) or {})
+            self.assertIn(
+                SMB2_QUERY_DIRECTORY, handlers,
+                "{} offers SMB{} via {}, which implements no QUERY_DIRECTORY, so "
+                "the share cannot be listed. Finish the handlers before offering "
+                "the mode.".format(key, dialect,
+                                   os.path.basename(server.module_file or "?")))
 
     def test_windows_setup_ports_for_smb(self):
         # The SMBv2/SMBv3 keys stay mapped here even though no mode offers them:

--- a/tests/test_netinfo_and_smb.py
+++ b/tests/test_netinfo_and_smb.py
@@ -111,6 +111,29 @@ class ServerRegistryTests(unittest.TestCase):
                 "the mode.".format(key, dialect,
                                    os.path.basename(server.module_file or "?")))
 
+    def test_take_445_reaches_every_smb_mode_that_offers_it(self):
+        """A checkbox the server never hears about is a control that does
+        nothing -- the exact defect the SMBv2/SMBv3 modes were pulled for."""
+        for key in ("smbv1", "smbv2", "smbv3"):
+            with self.subTest(key=key):
+                server = servers.REGISTRY[key]
+                self.assertTrue(any(f.key == "take_445" for f in server.fields))
+                values = _probe_values(server)
+                values["take_445"] = True
+                self.assertIn("--take-445", server._build_argv(values))
+
+    def test_the_headless_error_lists_exactly_what_is_registered(self):
+        """The `serve` error text and the REGISTRY drifted apart twice."""
+        import ps2servers
+        import io
+        import contextlib
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            ps2servers._normalize_headless_alias(["serve"])
+        message = err.getvalue()
+        for key in servers.REGISTRY:
+            self.assertIn(key, message, "%s is registered but not offered" % key)
+
     def test_windows_setup_ports_for_smb(self):
         # The SMBv2/SMBv3 keys stay mapped here even though no mode offers them:
         # the firewall helper is keyed by name, and it is what the modes will

--- a/tests/test_netinfo_and_smb.py
+++ b/tests/test_netinfo_and_smb.py
@@ -1,4 +1,4 @@
-"""Tests for netinfo IP helpers, SMB2/3 registration, and port settings."""
+"""Tests for netinfo IP helpers, SMB mode registration, and port settings."""
 
 import os
 import sys
@@ -23,29 +23,83 @@ class NetInfoTests(unittest.TestCase):
         self.assertIn("Custom IP...", info)
 
 
-class ServerRegistryTests(unittest.TestCase):
-    def test_smb_servers_exist_and_default_to_1025(self):
-        for key in ("smbv1", "smbv2", "smbv3"):
-            self.assertIn(key, servers.REGISTRY)
-            server = servers.REGISTRY[key]
-            self.assertEqual(server.default_port, 1025)
-            port_field = next(f for f in server.fields if f.key == "port")
-            self.assertFalse(port_field.advanced, f"{key} port field should not be advanced hidden")
-            self.assertEqual(port_field.default, 1025)
+def _probe_values(server):
+    """Enough values to build any server's command line.
 
-    def test_smb_argv_version_flags(self):
-        v = {"games_folder": "C:/Games", "port": 1025}
-        argv1 = servers.REGISTRY["smbv1"]._build_argv(v)
-        argv2 = servers.REGISTRY["smbv2"]._build_argv(v)
-        argv3 = servers.REGISTRY["smbv3"]._build_argv(v)
-        self.assertIn("--smb-version", argv1)
-        self.assertEqual(argv1[argv1.index("--smb-version") + 1], "1")
-        self.assertIn("--smb-version", argv2)
-        self.assertEqual(argv2[argv2.index("--smb-version") + 1], "2")
-        self.assertIn("--smb-version", argv3)
-        self.assertEqual(argv3[argv3.index("--smb-version") + 1], "3")
+    Derived from the server's own fields rather than hard-coded, so a mode that
+    grows a new required field is still covered instead of raising here.
+    """
+    values = {}
+    for f in server.fields:
+        if f.kind in ("folder", "file"):
+            values[f.key] = "C:/Games"
+        elif f.kind == "port":
+            values[f.key] = f.default or 1025
+        elif f.kind == "bool":
+            values[f.key] = bool(f.default)
+        elif f.kind == "choice":
+            values[f.key] = f.default or (f.choices[0][0] if f.choices else "")
+        elif f.default:
+            values[f.key] = f.default
+    return values
+
+
+def _smb_dialect_of(server):
+    """The dialect a REGISTRY entry asks the server for, or None if it is not SMB."""
+    argv = server._build_argv(_probe_values(server))
+    if "--smb-version" not in argv:
+        return None
+    return int(argv[argv.index("--smb-version") + 1])
+
+
+class ServerRegistryTests(unittest.TestCase):
+    def test_smb_server_exists_and_defaults_to_1025(self):
+        self.assertIn("smbv1", servers.REGISTRY)
+        server = servers.REGISTRY["smbv1"]
+        self.assertEqual(server.default_port, 1025)
+        port_field = next(f for f in server.fields if f.key == "port")
+        self.assertFalse(port_field.advanced, "smbv1 port field should not be advanced hidden")
+        self.assertEqual(port_field.default, 1025)
+
+    def test_smb_argv_version_flag(self):
+        self.assertEqual(_smb_dialect_of(servers.REGISTRY["smbv1"]), 1)
+
+    def test_no_offered_mode_asks_for_a_dialect_that_cannot_serve_a_file(self):
+        """A mode in the REGISTRY is a mode a user can pick and expect to work.
+
+        SMB2/SMB3 currently negotiate, authenticate and accept a tree connect,
+        then serve nothing -- READ returns zero bytes and QUERY_DIRECTORY is not
+        implemented, so the share cannot even be listed. Offering that meant a
+        user connected successfully and saw an empty folder with no error.
+
+        This is not "SMB2 is banned". It is the ordering: the server has to be
+        able to serve a file before the launcher offers the mode. Implement
+        QUERY_DIRECTORY and a real READ, and this test goes green on its own --
+        no edit here, nothing to remember.
+        """
+        sys.path.insert(0, os.path.join(_ROOT, "smbv1_server"))
+        try:
+            import smbserver_opl
+        finally:
+            sys.path.pop(0)
+
+        SMB2_QUERY_DIRECTORY = 0x000E
+        can_list = SMB2_QUERY_DIRECTORY in smbserver_opl.SMB2_HANDLERS
+
+        for key, server in servers.REGISTRY.items():
+            dialect = _smb_dialect_of(server)
+            if dialect is None or dialect < 2:
+                continue
+            self.assertTrue(
+                can_list,
+                "{} offers SMB{}, but the server implements no QUERY_DIRECTORY, "
+                "so the share cannot be listed. Finish the SMB2 handlers before "
+                "putting the mode back in the REGISTRY.".format(key, dialect))
 
     def test_windows_setup_ports_for_smb(self):
+        # The SMBv2/SMBv3 keys stay mapped here even though no mode offers them:
+        # the firewall helper is keyed by name, and it is what the modes will
+        # need again once the server can serve them.
         for key in ("smbv1", "smbv2", "smbv3"):
             rules = windows_setup._server_ports(key, {"port": "1025"})
             self.assertEqual(rules[0][1], 1025)

--- a/tests/test_smb2_auth.py
+++ b/tests/test_smb2_auth.py
@@ -1,0 +1,277 @@
+"""The SMB2/SMB3 credential check must accept exactly one password.
+
+Tested on its own, without a socket, for the same reason as the share
+boundary: this is where a mistake hands a stranger the share.
+
+Two layers here. The published vectors pin the primitives to the specification
+rather than to this implementation -- MD4 had to be written by hand because
+OpenSSL 3 removed it from hashlib, and an MD4 that is subtly wrong would still
+be perfectly self-consistent, so a round-trip test alone would pass while no
+real Windows client could ever log in. The vectors are from RFC 1320 appendix
+A.5 and MS-NLMP section 4.2.4. On top of that sit the round-trip tests, which
+build a response the way a client does and check the server's answer.
+"""
+
+import os
+import struct
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+sys.path.insert(0, os.path.join(ROOT, "smb2_server"))
+from smb2_auth import (  # noqa: E402
+    AuthError,
+    Authenticator,
+    blob_timestamp,
+    lmv2_response,
+    md4,
+    nt_hash,
+    ntlmv2_proof,
+    ntowfv2,
+    parse_ntlmv2_response,
+    server_challenge,
+    session_base_key,
+)
+
+# A plausible AV_PAIR target info blob: NetBIOS domain name, then the list
+# terminator. The server treats it as opaque bytes, but a real client always
+# sends something here, so the tests should too.
+TARGET_INFO = struct.pack("<HH", 2, 8) + "PS2SRV".encode("utf-16-le")[:8] + struct.pack("<HH", 0, 0)
+
+
+def client_ntlmv2_response(password, user, domain, challenge,
+                           client_challenge=b"\xaa" * 8, filetime=None,
+                           target_info=TARGET_INFO):
+    """Build an NTLMv2 response the way a client does.
+
+    Deliberately written from the structure in MS-NLMP rather than by calling
+    the server's own helpers to assemble the blob, so that a round trip is
+    testing agreement between two sides and not a function agreeing with
+    itself.
+    """
+    if filetime is None:
+        filetime = 133_000_000_000_000_000  # a fixed, ordinary 2022-ish time
+    blob = (b"\x01\x01\x00\x00\x00\x00\x00\x00"
+            + struct.pack("<Q", filetime)
+            + client_challenge
+            + b"\x00" * 4
+            + target_info
+            + b"\x00" * 4)
+    ntowf = ntowfv2(password, user, domain)
+    proof = ntlmv2_proof(ntowf, challenge, blob)
+    return proof + blob
+
+
+class PublishedVectors(unittest.TestCase):
+    """Pins the primitives to the specifications, not to this implementation."""
+
+    def test_md4_rfc1320_suite(self):
+        # RFC 1320 appendix A.5, in full. MD4 is hand-written here, so the
+        # whole published suite is used rather than a sample of it.
+        for message, expected in [
+            (b"", "31d6cfe0d16ae931b73c59d7e0c089c0"),
+            (b"a", "bde52cb31de33e46245e05fbdbd6fb24"),
+            (b"abc", "a448017aaf21d8525fc10ae87aa6729d"),
+            (b"message digest", "d9130a8164549fe818874806e1c7014b"),
+            (b"abcdefghijklmnopqrstuvwxyz", "d79e1c308aa5bbcdeea8ed63df412da9"),
+            (b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+             "043f8582f241db351ce627e153e7f0e4"),
+            (b"1234567890" * 8, "e33b4ddc9c38f2199c3e7b164fcc0536"),
+        ]:
+            with self.subTest(message=message[:16]):
+                self.assertEqual(md4(message).hex(), expected)
+
+    def test_md4_spans_a_block_boundary(self):
+        # The padding rule is the easy thing to get wrong: a message of exactly
+        # 56 bytes needs a whole extra block, because the 0x80 plus the 8-byte
+        # length no longer fit in the first one. RFC 1320's suite tops out at
+        # 62 bytes and so never exercises that, which leaves the case where an
+        # off-by-one in the padding still passes every published vector.
+        #
+        # These three are regression pins, not spec values: they were taken
+        # from this implementation once the RFC suite above had already proved
+        # it correct. They exist to fail loudly if the padding ever changes.
+        self.assertEqual(md4(b"A" * 55).hex(), "1d7bb1528414bdcab709d5107f766d88")
+        self.assertEqual(md4(b"A" * 56).hex(), "2eae267be1bd32ff073b50f7b654aed2")
+        self.assertEqual(md4(b"A" * 57).hex(), "95e060c139fbd884c156222546efeca0")
+
+        # Every length is still a 16-byte digest, including the multi-block ones.
+        for length in (0, 63, 64, 65, 119, 120, 128, 1000):
+            with self.subTest(length=length):
+                self.assertEqual(len(md4(b"A" * length)), 16)
+
+    def test_nt_hash_known_passwords(self):
+        # The canonical NTLM examples. UTF-16LE and no salt, so these are fixed
+        # for all time and any deviation means the encoding is wrong.
+        self.assertEqual(nt_hash("password").hex(), "8846f7eaee8fb117ad06bdd830b7586c")
+        self.assertEqual(nt_hash("Password").hex(), "a4f49c406510bdcab6824ee7c30fd852")
+
+    def test_ntowfv2_ms_nlmp_vector(self):
+        # MS-NLMP 4.2.4.1.1: Password "Password", User "User", Domain "Domain".
+        self.assertEqual(
+            ntowfv2("Password", "User", "Domain").hex(),
+            "0c868a403bfd7a93a3001ef22ef02e3f")
+
+    def test_user_is_uppercased_and_domain_is_not(self):
+        # The asymmetry in MS-NLMP: Uppercase(User) + Domain, domain untouched.
+        # Backwards here yields a key that is wrong for every password, and the
+        # only symptom would be that nothing can ever log in.
+        self.assertEqual(ntowfv2("Password", "user", "Domain"),
+                         ntowfv2("Password", "USER", "Domain"))
+        self.assertNotEqual(ntowfv2("Password", "User", "domain"),
+                            ntowfv2("Password", "User", "DOMAIN"))
+
+    def test_non_ascii_password_is_utf16le(self):
+        # A password outside ASCII must not be silently latin-1'd or rejected.
+        self.assertEqual(nt_hash("pässwörd"), md4("pässwörd".encode("utf-16-le")))
+
+
+class ResponseParsing(unittest.TestCase):
+    def test_splits_proof_from_blob(self):
+        response = client_ntlmv2_response("pw", "user", "WORKGROUP", b"\x01" * 8)
+        proof, blob = parse_ntlmv2_response(response)
+        self.assertEqual(len(proof), 16)
+        self.assertEqual(blob[:8], b"\x01\x01\x00\x00\x00\x00\x00\x00")
+
+    def test_ntlmv1_response_is_refused_not_sliced(self):
+        # An NTLMv1 response is 24 bytes with no header. Without the header
+        # check it would be split into a 16-byte "proof" and an 8-byte
+        # "blob" and then simply fail to match, which is the right outcome
+        # for the wrong reason and logs a misleading cause.
+        with self.assertRaises(AuthError) as caught:
+            parse_ntlmv2_response(b"\x11" * 24)
+        self.assertIn("NTLMv1", caught.exception.detail)
+
+    def test_short_and_empty_responses_are_refused(self):
+        for probe in (b"", b"\x00", b"\x11" * 23):
+            with self.subTest(length=len(probe)):
+                with self.assertRaises(AuthError):
+                    parse_ntlmv2_response(probe)
+
+    def test_non_bytes_is_refused_rather_than_raising_typeerror(self):
+        with self.assertRaises(AuthError):
+            parse_ntlmv2_response("not bytes")
+
+    def test_blob_timestamp_round_trips(self):
+        response = client_ntlmv2_response("pw", "u", "d", b"\x01" * 8,
+                                          filetime=133_000_000_000_000_000)
+        _, blob = parse_ntlmv2_response(response)
+        self.assertAlmostEqual(blob_timestamp(blob), 1_655_526_400.0, delta=86400)
+
+
+class PasswordRequired(unittest.TestCase):
+    def setUp(self):
+        self.auth = Authenticator({"ripto": "correct horse battery staple"})
+        self.challenge = b"\x0f" * 8
+
+    def test_correct_password_authenticates(self):
+        response = client_ntlmv2_response(
+            "correct horse battery staple", "ripto", "WORKGROUP", self.challenge)
+        key = self.auth.verify("ripto", response, self.challenge)
+        self.assertEqual(len(key), 16)
+
+    def test_wrong_password_is_refused(self):
+        response = client_ntlmv2_response("wrong", "ripto", "WORKGROUP", self.challenge)
+        with self.assertRaises(AuthError) as caught:
+            self.auth.verify("ripto", response, self.challenge)
+        self.assertEqual(caught.exception.status, "STATUS_LOGON_FAILURE")
+
+    def test_unknown_user_is_refused_with_the_same_status(self):
+        # Same status as a wrong password, so a client cannot use the reply to
+        # discover which user names exist.
+        response = client_ntlmv2_response("whatever", "nobody", "WORKGROUP", self.challenge)
+        with self.assertRaises(AuthError) as caught:
+            self.auth.verify("nobody", response, self.challenge)
+        self.assertEqual(caught.exception.status, "STATUS_LOGON_FAILURE")
+
+    def test_user_names_are_case_insensitive(self):
+        for spelling in ("ripto", "Ripto", "RIPTO"):
+            with self.subTest(spelling=spelling):
+                response = client_ntlmv2_response(
+                    "correct horse battery staple", spelling, "WORKGROUP", self.challenge)
+                self.assertIsNotNone(self.auth.verify(spelling, response, self.challenge))
+
+    def test_response_for_another_challenge_is_refused(self):
+        # The replay defence. A response captured against one challenge must be
+        # worthless against the next session's.
+        response = client_ntlmv2_response(
+            "correct horse battery staple", "ripto", "WORKGROUP", b"\xaa" * 8)
+        with self.assertRaises(AuthError):
+            self.auth.verify("ripto", response, self.challenge)
+
+    def test_tampered_blob_is_refused(self):
+        # The proof covers the blob, so changing the client's own nonce after
+        # the fact must invalidate it.
+        response = bytearray(client_ntlmv2_response(
+            "correct horse battery staple", "ripto", "WORKGROUP", self.challenge))
+        response[-1] ^= 0xFF
+        with self.assertRaises(AuthError):
+            self.auth.verify("ripto", bytes(response), self.challenge)
+
+    def test_stale_client_clock_still_authenticates(self):
+        # Deliberate: a PS2 has no clock that survives being unplugged, so a
+        # console routinely presents a time that is years out. Freshness is not
+        # checked, and this test exists so that adding a window later is a
+        # conscious decision rather than an accident.
+        for filetime in (0, 1, 200_000_000_000_000_000):
+            with self.subTest(filetime=filetime):
+                response = client_ntlmv2_response(
+                    "correct horse battery staple", "ripto", "WORKGROUP",
+                    self.challenge, filetime=filetime)
+                self.assertIsNotNone(self.auth.verify("ripto", response, self.challenge))
+
+    def test_session_key_matches_what_the_client_would_derive(self):
+        # Both sides must land on the same SessionBaseKey or SMB2 signing fails
+        # later with an error that points nowhere near here.
+        password = "correct horse battery staple"
+        response = client_ntlmv2_response(password, "ripto", "WORKGROUP", self.challenge)
+        proof, _ = parse_ntlmv2_response(response)
+        expected = session_base_key(ntowfv2(password, "ripto", "WORKGROUP"), proof)
+        self.assertEqual(self.auth.verify("ripto", response, self.challenge), expected)
+
+
+class ConfigurationFailsClosed(unittest.TestCase):
+    def test_no_users_is_an_error_not_an_open_share(self):
+        # The whole point of the split: a misconfiguration that leaves no users
+        # must lock the operator out, never admit everyone.
+        for empty in ({}, None):
+            with self.subTest(users=empty):
+                with self.assertRaises(ValueError):
+                    Authenticator(empty)
+
+    def test_users_differing_only_by_case_are_rejected(self):
+        # Otherwise one silently shadows the other and the operator cannot tell
+        # which password is live.
+        with self.assertRaises(ValueError):
+            Authenticator({"ripto": "a", "Ripto": "b"})
+
+    def test_open_mode_accepts_anyone(self):
+        auth = Authenticator.open()
+        self.assertTrue(auth.is_open)
+        self.assertIsNone(auth.verify("anyone", b"", b"\x00" * 8))
+
+    def test_password_mode_is_not_open(self):
+        self.assertFalse(Authenticator({"u": "p"}).is_open)
+
+
+class Challenge(unittest.TestCase):
+    def test_is_eight_bytes_and_not_repeated(self):
+        challenges = {server_challenge() for _ in range(64)}
+        self.assertEqual(len(challenges), 64)
+        for value in challenges:
+            self.assertEqual(len(value), 8)
+
+
+class Lmv2(unittest.TestCase):
+    def test_shape_is_mac_then_client_nonce(self):
+        ntowf = ntowfv2("Password", "User", "Domain")
+        response = lmv2_response(ntowf, b"\x01" * 8, b"\x02" * 8)
+        self.assertEqual(len(response), 24)
+        self.assertEqual(response[16:], b"\x02" * 8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_smb2_paths.py
+++ b/tests/test_smb2_paths.py
@@ -201,3 +201,49 @@ class SymlinkEscape(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class WindowsDeviceNames(unittest.TestCase):
+    r"""Win32 resolves these to devices wherever they appear in a path.
+
+    C:/share/NUL is the null device, not a file in the share, so a client could
+    CREATE one and write into a device or open a serial port. Windows' own SMB
+    server refuses them. They are refused on every host here, so a share does
+    not change meaning depending on which OS is serving it.
+    """
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.share = Share("games", self.root)
+
+    def test_the_reserved_names_are_refused(self):
+        for name in ("NUL", "con", "AUX", "PRN", "COM1", "lpt9", "CLOCK$"):
+            with self.subTest(name=name):
+                with self.assertRaises(PathError):
+                    self.share.resolve(name)
+
+    def test_an_extension_does_not_make_them_safe(self):
+        """CON.txt is the console device too -- Win32 stops at the first dot."""
+        for name in ("CON.txt", "nul.iso", "COM1.bin"):
+            with self.subTest(name=name):
+                with self.assertRaises(PathError):
+                    self.share.resolve(name)
+
+    def test_they_are_refused_in_a_subdirectory_too(self):
+        with self.assertRaises(PathError):
+            self.share.resolve("games/NUL")
+
+    def test_an_ordinary_name_that_merely_starts_the_same_is_served(self):
+        """CONSOLE and NULLS are normal files; only the exact names are devices."""
+        for name in ("CONSOLE.iso", "NULLS.txt", "COMMANDER.elf", "AUXILIARY"):
+            with self.subTest(name=name):
+                self.assertTrue(self.share.resolve(name).startswith(self.share.root))
+
+    def test_a_trailing_dot_or_space_is_refused(self):
+        """Win32 strips both, so 'game.iso.' and 'game.iso' would be one file to
+        a Windows client and two to this server."""
+        for name in ("game.iso.", "game.iso ", "folder ."):
+            with self.subTest(name=name):
+                with self.assertRaises(PathError):
+                    self.share.resolve(name)

--- a/tests/test_smb2_paths.py
+++ b/tests/test_smb2_paths.py
@@ -1,0 +1,203 @@
+"""The SMB2/SMB3 share boundary must be the real filesystem boundary.
+
+This is the one piece of the new servers where a mistake hands a client a file
+the operator never meant to share, so it is tested on its own, without a socket
+or a protocol in the way.
+
+The symlink cases are here because the existing SMBv1 resolver does not survive
+them. That one uses os.path.abspath, which normalises ".." textually but never
+follows a link, so a symlink inside the share produces a path that still starts
+with the share root while opening a file outside it. Confirmed against the real
+smbv1_server code before this module was written:
+
+    resolve("elsewhere/secret.txt") -> .../share/elsewhere/secret.txt   accepted
+    os.path.realpath of that        -> .../outside/secret.txt           outside
+
+Not remotely exploitable there, since SMBv1 implements nothing that creates a
+symlink, but it means the declared root is not the real boundary. Edge and the
+UDPFS path guard both refuse symlink escapes; these tests hold the new servers
+to that rule instead of the older one.
+
+Run:  python -m unittest tests.test_smb2_paths -v
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+sys.path.insert(0, os.path.join(ROOT, "smb2_server"))
+from smb2_paths import PathError, Share  # noqa: E402
+
+
+def _can_symlink(directory):
+    """Windows needs Developer Mode or admin to create symlinks."""
+    probe = os.path.join(directory, "_symlink_probe")
+    try:
+        os.symlink(directory, probe, target_is_directory=True)
+    except (OSError, NotImplementedError, AttributeError):
+        return False
+    os.remove(probe)
+    return True
+
+
+class ShareBoundary(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.root = os.path.join(self.tmp, "games")
+        os.makedirs(os.path.join(self.root, "sub"))
+        with open(os.path.join(self.root, "game.iso"), "wb") as handle:
+            handle.write(b"iso")
+        with open(os.path.join(self.root, "sub", "inner.bin"), "wb") as handle:
+            handle.write(b"inner")
+
+        self.outside = os.path.join(self.tmp, "outside")
+        os.makedirs(self.outside)
+        self.secret = os.path.join(self.outside, "secret.txt")
+        with open(self.secret, "w", encoding="utf-8") as handle:
+            handle.write("NOT SHAREABLE")
+
+        self.share = Share("games", self.root)
+
+    # ---- paths that must work -------------------------------------------------
+
+    def test_ordinary_paths_resolve(self):
+        for probe in ("game.iso", "\\game.iso", "/game.iso", "sub\\inner.bin", "sub/inner.bin"):
+            with self.subTest(probe=probe):
+                self.assertTrue(os.path.exists(self.share.resolve(probe)))
+
+    def test_empty_path_is_the_share_root(self):
+        for probe in ("", "\\", "/", "."):
+            with self.subTest(probe=probe):
+                self.assertEqual(self.share.resolve(probe), self.share.root)
+
+    def test_a_path_that_does_not_exist_yet_resolves(self):
+        """A file being created has no real path of its own; its parent must still be checked."""
+        created = self.share.resolve("sub\\new-save.bin")
+        self.assertTrue(created.startswith(self.share.root))
+        with self.assertRaises(PathError):
+            self.share.resolve("sub\\new-save.bin", must_exist=True)
+
+    def test_relative_round_trips(self):
+        real = self.share.resolve("sub\\inner.bin")
+        self.assertEqual(self.share.relative(real), "sub\\inner.bin")
+
+    # ---- paths that must not ---------------------------------------------------
+
+    def test_parent_traversal_is_refused(self):
+        for probe in ("..\\outside\\secret.txt", "../outside/secret.txt",
+                      "sub\\..\\..\\outside\\secret.txt", "..", "sub/../..",
+                      "\\..\\..\\outside\\secret.txt"):
+            with self.subTest(probe=probe):
+                with self.assertRaises(PathError):
+                    self.share.resolve(probe)
+
+    def test_traversal_that_lands_back_inside_is_still_refused(self):
+        """"sub/../game.iso" is harmless arithmetic, and still not served.
+
+        Accepting it would make the guard depend on where the counting happens
+        to land rather than on a rule, and the difference between the two is
+        invisible right up until a case is found where it lands elsewhere.
+        """
+        with self.assertRaises(PathError):
+            self.share.resolve("sub\\..\\game.iso")
+
+    def test_absolute_and_drive_qualified_paths_are_refused(self):
+        for probe in ("C:\\Windows\\win.ini", "\\\\server\\share\\x", "D:/x"):
+            with self.subTest(probe=probe):
+                with self.assertRaises(PathError):
+                    self.share.resolve(probe)
+
+    def test_alternate_data_streams_are_refused(self):
+        """"game.iso:hidden" names a stream Windows will happily open."""
+        with self.assertRaises(PathError):
+            self.share.resolve("game.iso:hidden")
+
+    def test_illegal_characters_are_refused(self):
+        for probe in ("bad<name", "bad>name", 'bad"name', "bad|name", "bad?name", "bad*name"):
+            with self.subTest(probe=probe):
+                with self.assertRaises(PathError):
+                    self.share.resolve(probe)
+
+    def test_a_sibling_directory_with_the_same_prefix_is_outside(self):
+        """A root of .../games must not admit .../games-private.
+
+        This is why containment is commonpath and not startswith(root + sep):
+        the string test passes for any sibling whose name merely begins with the
+        root's.
+        """
+        sibling = self.root + "-private"
+        os.makedirs(sibling)
+        with open(os.path.join(sibling, "other.txt"), "w", encoding="utf-8") as handle:
+            handle.write("nope")
+        self.assertFalse(self.share._inside(os.path.join(sibling, "other.txt")))
+
+
+class SymlinkEscape(unittest.TestCase):
+    """The case the older resolver lets through."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.root = os.path.join(self.tmp, "games")
+        os.makedirs(self.root)
+        self.outside = os.path.join(self.tmp, "outside")
+        os.makedirs(self.outside)
+        with open(os.path.join(self.outside, "secret.txt"), "w", encoding="utf-8") as handle:
+            handle.write("NOT SHAREABLE")
+        if not _can_symlink(self.tmp):
+            self.skipTest("this platform/account cannot create symlinks")
+        self.share = Share("games", self.root)
+
+    def test_symlinked_directory_out_of_the_share_is_refused(self):
+        os.symlink(self.outside, os.path.join(self.root, "elsewhere"),
+                   target_is_directory=True)
+        with self.assertRaises(PathError) as caught:
+            self.share.resolve("elsewhere/secret.txt")
+        self.assertEqual(caught.exception.status, "STATUS_ACCESS_DENIED")
+
+    def test_symlinked_file_out_of_the_share_is_refused(self):
+        os.symlink(os.path.join(self.outside, "secret.txt"),
+                   os.path.join(self.root, "leak.txt"))
+        with self.assertRaises(PathError):
+            self.share.resolve("leak.txt")
+
+    def test_symlink_that_stays_inside_the_share_is_served(self):
+        """Refusing every symlink would break a legitimate layout.
+
+        Pointing one folder of games at another folder of games, inside the same
+        share, is an ordinary thing to do and there is nothing to refuse: the
+        target is already shared.
+        """
+        inner = os.path.join(self.root, "real")
+        os.makedirs(inner)
+        with open(os.path.join(inner, "a.iso"), "wb") as handle:
+            handle.write(b"a")
+        os.symlink(inner, os.path.join(self.root, "link"), target_is_directory=True)
+        resolved = self.share.resolve("link/a.iso")
+        self.assertTrue(os.path.exists(resolved))
+
+    def test_a_share_root_reached_through_a_symlink_still_works(self):
+        """/home/user/games -> /mnt/disk2/games is an ordinary NAS layout.
+
+        If the root were stored unresolved, every containment test would compare
+        a resolved path against an unresolved root and refuse everything.
+        """
+        elsewhere = os.path.join(self.tmp, "real-games")
+        os.makedirs(elsewhere)
+        with open(os.path.join(elsewhere, "g.iso"), "wb") as handle:
+            handle.write(b"g")
+        linked_root = os.path.join(self.tmp, "linked-games")
+        os.symlink(elsewhere, linked_root, target_is_directory=True)
+        share = Share("games", linked_root)
+        self.assertTrue(os.path.exists(share.resolve("g.iso")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_smb2_server.py
+++ b/tests/test_smb2_server.py
@@ -1,0 +1,602 @@
+"""End-to-end tests for the SMB2/SMB3 server, over real sockets.
+
+These drive a small SMB2 client -- written here rather than imported, so it
+cannot share a misunderstanding with the server -- through the exchange a file
+manager actually performs: negotiate, NTLMSSP session setup, tree connect, list
+a directory, read a file back byte for byte, write one, and delete it.
+
+What this cannot prove, stated plainly: both sides are this project's reading of
+the protocol, so a structure that is wrong in the same way twice still passes.
+The layouts are pinned against MS-SMB2's stated StructureSize values in
+test_smb2_wire.py for that reason, and the only complete answer is a real client
+-- which needs port 445, so it cannot run here.
+
+Run:  python -m unittest tests.test_smb2_server -v
+"""
+
+import os
+import socket
+import struct
+import sys
+import tempfile
+import threading
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, "smb2_server"))
+
+import smb2_spnego as spnego            # noqa: E402
+import smb2_wire as wire                # noqa: E402
+from smb2_auth import (                 # noqa: E402
+    Authenticator, ntlmv2_proof, ntowfv2)
+from smb2_paths import Share            # noqa: E402
+from smb2_server import Smb2Server      # noqa: E402
+
+USER, PASSWORD = "ripto", "correct horse battery"
+
+
+class Client:
+    """The smallest SMB2 client that can exercise the server."""
+
+    def __init__(self, port):
+        self.sock = socket.create_connection(("127.0.0.1", port), timeout=5)
+        self.message_id = 0
+        self.session_id = 0
+        self.tree_id = 0
+
+    def close(self):
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+    def call(self, command, body, tree_id=None):
+        hdr = wire.pack_header(command, 0, self.message_id,
+                               tree_id=self.tree_id if tree_id is None else tree_id,
+                               session_id=self.session_id)
+        # The client's own header must not carry the server-to-redir flag.
+        hdr = hdr[:16] + struct.pack("<I", 0) + hdr[20:]
+        self.message_id += 1
+        wire.send_msg(self.sock, hdr + body)
+        reply = wire.recv_msg(self.sock)
+        if reply is None:
+            raise AssertionError("server closed the connection")
+        head = wire.parse_header(reply)
+        return head, reply[wire.HEADER_SIZE:]
+
+    # -- the exchange ------------------------------------------------------ #
+    def negotiate(self, dialects=(wire.DIALECT_202, wire.DIALECT_210,
+                                  wire.DIALECT_300, wire.DIALECT_302)):
+        # 36 bytes of fixed part before the dialect array: StructureSize,
+        # DialectCount, SecurityMode, Reserved, Capabilities, ClientGuid,
+        # ClientStartTime. Short by those last 8 and the server reads the
+        # dialects out of nothing.
+        body = struct.pack("<HHHHI16sQ", 36, len(dialects), 0, 0, 0,
+                           b"\x00" * 16, 0)
+        body += b"".join(struct.pack("<H", d) for d in dialects)
+        head, reply = self.call(wire.CMD_NEGOTIATE, body)
+        assert head.status == 0, "NEGOTIATE failed 0x%08X" % head.status
+        return struct.unpack_from("<H", reply, 4)[0]
+
+    def session_setup(self, user, password, anonymous=False):
+        negotiate = (spnego.NTLMSSP_SIGNATURE + struct.pack("<I", 1)
+                     + struct.pack("<I", spnego.CHALLENGE_FLAGS)
+                     + struct.pack("<HHI", 0, 0, 32) + struct.pack("<HHI", 0, 0, 32))
+        head, reply = self._session_blob(negotiate)
+        assert head.status == wire.STATUS_MORE_PROCESSING_REQUIRED, (
+            "expected a challenge, got 0x%08X" % head.status)
+        self.session_id = head.session_id
+
+        off, length = struct.unpack_from("<HH", reply, 4)
+        blob = reply[off - wire.HEADER_SIZE:off - wire.HEADER_SIZE + length]
+        challenge_msg = spnego.extract_ntlm(blob)
+        challenge = challenge_msg[24:32]
+        info_len, _max, info_at = struct.unpack_from("<HHI", challenge_msg, 40)
+        target_info = challenge_msg[info_at:info_at + info_len]
+
+        if anonymous:
+            auth = self._authenticate(b"", "", "")
+        else:
+            # A real NTLMv2 blob: 0x0101, reserved, timestamp, client challenge,
+            # then the server's own TargetInfo folded back in.
+            blob_body = (struct.pack("<BBHIQ", 1, 1, 0, 0, 0)
+                         + os.urandom(8) + struct.pack("<I", 0)
+                         + target_info + struct.pack("<I", 0))
+            ntowf = ntowfv2(password, user, "WORKGROUP")
+            proof = ntlmv2_proof(ntowf, challenge, blob_body)
+            auth = self._authenticate(proof + blob_body, user, "WORKGROUP")
+        head, _ = self._session_blob(auth)
+        return head.status
+
+    def _authenticate(self, nt_response, user, domain):
+        user_u = user.encode("utf-16-le")
+        domain_u = domain.encode("utf-16-le")
+        # Signature(8) MessageType(4) then six 8-byte field triples (48),
+        # NegotiateFlags(4), Version(8) -- 72 before the payload. No MIC.
+        fixed = 72
+        lm_at = fixed
+        nt_at = lm_at + 24
+        dom_at = nt_at + len(nt_response)
+        user_at = dom_at + len(domain_u)
+        ws_at = user_at + len(user_u)
+        return (spnego.NTLMSSP_SIGNATURE + struct.pack("<I", 3)
+                + struct.pack("<HHI", 24, 24, lm_at)
+                + struct.pack("<HHI", len(nt_response), len(nt_response), nt_at)
+                + struct.pack("<HHI", len(domain_u), len(domain_u), dom_at)
+                + struct.pack("<HHI", len(user_u), len(user_u), user_at)
+                + struct.pack("<HHI", 0, 0, ws_at)
+                + struct.pack("<HHI", 0, 0, ws_at)
+                + struct.pack("<I", spnego.CHALLENGE_FLAGS)
+                + b"\x00" * 8
+                + b"\x00" * 24 + nt_response + domain_u + user_u)
+
+    def _session_blob(self, token):
+        body = struct.pack("<HBBIIHHQ", 25, 0, 1, 0, 0,
+                           wire.HEADER_SIZE + 24, len(token), 0)
+        return self.call(wire.CMD_SESSION_SETUP, body + token)
+
+    def tree_connect(self, share):
+        path = ("\\\\127.0.0.1\\" + share).encode("utf-16-le")
+        body = struct.pack("<HHHH", 9, 0, wire.HEADER_SIZE + 8, len(path)) + path
+        head, _ = self.call(wire.CMD_TREE_CONNECT, body, tree_id=0)
+        if head.status == 0:
+            self.tree_id = head.tree_id
+        return head.status
+
+    def create(self, name, disposition=wire.FILE_OPEN, options=0, directory=False):
+        raw = name.encode("utf-16-le")
+        if directory:
+            options |= wire.FILE_DIRECTORY_FILE
+        body = struct.pack("<HBBIQQIIIIIHHII", 57, 0, 0, 2, 0, 0,
+                           0x00120089, 0, 7, disposition, options,
+                           wire.HEADER_SIZE + 56, len(raw), 0, 0) + raw
+        head, reply = self.call(wire.CMD_CREATE, body)
+        if head.status != 0:
+            return head.status, None
+        return 0, reply[64:80]
+
+    def close_handle(self, file_id):
+        body = struct.pack("<HHI", 24, 0, 0) + file_id
+        head, _ = self.call(wire.CMD_CLOSE, body)
+        return head.status
+
+    def query_directory_raw(self, file_id, pattern="*",
+                            info_class=wire.FILE_BOTH_DIRECTORY_INFORMATION):
+        """Every response buffer, across as many round trips as it takes."""
+        buffers = []
+        flags = 0x01                     # RESTART_SCANS on the first call
+        while True:
+            raw = pattern.encode("utf-16-le")
+            body = (struct.pack("<HBBI", 33, info_class, flags, 0) + file_id
+                    + struct.pack("<HHI", wire.HEADER_SIZE + 32, len(raw), 65536)
+                    + raw)
+            head, reply = self.call(wire.CMD_QUERY_DIRECTORY, body)
+            if head.status == wire.STATUS_NO_MORE_FILES:
+                return buffers
+            if head.status != 0:
+                raise AssertionError("QUERY_DIRECTORY 0x%08X" % head.status)
+            off, length = struct.unpack_from("<HI", reply, 2)
+            buffers.append(reply[off - wire.HEADER_SIZE:
+                                 off - wire.HEADER_SIZE + length])
+            flags = 0
+
+    def query_directory(self, file_id, pattern="*"):
+        """The names in a directory, parsed as FileBothDirectoryInformation.
+
+        Only that class is parsed here: the name sits at a different offset in
+        every class, and a parser that guessed would report the wrong bytes as
+        a filename rather than failing.
+        """
+        names = []
+        for blob in self.query_directory_raw(file_id, pattern):
+            names.extend(_parse_both_dir(blob))
+        return names
+
+    def read(self, file_id, offset, length):
+        body = struct.pack("<HBBIQ", 49, 0, 0, length, offset) + file_id
+        body += struct.pack("<IIIHHB", 0, 0, 0, 0, 0, 0)
+        head, reply = self.call(wire.CMD_READ, body)
+        if head.status != 0:
+            return head.status, b""
+        data_off, _res, data_len = struct.unpack_from("<BBI", reply, 2)
+        start = data_off - wire.HEADER_SIZE
+        return 0, reply[start:start + data_len]
+
+    def write(self, file_id, offset, data):
+        body = struct.pack("<HHIQ", 49, wire.HEADER_SIZE + 48, len(data), offset)
+        body += file_id + struct.pack("<IIHHI", 0, 0, 0, 0, 0) + data
+        head, reply = self.call(wire.CMD_WRITE, body)
+        if head.status != 0:
+            return head.status, 0
+        return 0, struct.unpack_from("<I", reply, 4)[0]
+
+    def query_info(self, file_id, info_type, info_class):
+        body = (struct.pack("<HBBIHHIII", 41, info_type, info_class, 65536,
+                            0, 0, 0, 0, 0) + file_id)
+        head, reply = self.call(wire.CMD_QUERY_INFO, body)
+        if head.status != 0:
+            return head.status, b""
+        off, length = struct.unpack_from("<HI", reply, 2)
+        start = off - wire.HEADER_SIZE
+        return 0, reply[start:start + length]
+
+    def echo(self):
+        head, _ = self.call(wire.CMD_ECHO, struct.pack("<HH", 4, 0))
+        return head.status
+
+
+def _parse_both_dir(blob):
+    names, at = [], 0
+    while at < len(blob):
+        next_off, = struct.unpack_from("<I", blob, at)
+        name_len, = struct.unpack_from("<I", blob, at + 60)
+        name = blob[at + 94:at + 94 + name_len].decode("utf-16-le")
+        names.append(name)
+        if next_off == 0:
+            break
+        at += next_off
+    return names
+
+
+class ServerFixture(unittest.TestCase):
+    read_only = False
+    open_mode = False
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="ps2smb2-")
+        self.addCleanup(self._cleanup)
+        with open(os.path.join(self.dir, "game.iso"), "wb") as f:
+            f.write(bytes((i * 7) & 0xFF for i in range(4096)))
+        os.mkdir(os.path.join(self.dir, "APPS"))
+        with open(os.path.join(self.dir, "APPS", "boot.elf"), "wb") as f:
+            f.write(b"ELF" * 100)
+
+        auth = (Authenticator.open() if self.open_mode
+                else Authenticator({USER: PASSWORD}))
+        share = Share("games", self.dir, read_only=self.read_only)
+        self.server = Smb2Server({"games": share}, auth,
+                                 ceiling=wire.CEILING_SMB3,
+                                 read_only=self.read_only)
+        self.port = self.server.listen("127.0.0.1", 0)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def _cleanup(self):
+        self.server.stop()
+        import shutil
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def connected(self, user=USER, password=PASSWORD, anonymous=False):
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        c.negotiate()
+        status = c.session_setup(user, password, anonymous=anonymous)
+        self.assertEqual(status, 0, "session setup failed 0x%08X" % status)
+        self.assertEqual(c.tree_connect("games"), 0)
+        return c
+
+
+class Negotiation(ServerFixture):
+    def test_dialect_is_the_best_both_sides_speak(self):
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        self.assertEqual(c.negotiate(), wire.DIALECT_302)
+
+    def test_a_client_capped_at_smb2_gets_smb2(self):
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        self.assertEqual(c.negotiate((wire.DIALECT_202, wire.DIALECT_210)),
+                         wire.DIALECT_210)
+
+    def test_311_is_not_offered_even_when_asked_for(self):
+        """Claiming 3.1.1 without negotiate contexts makes Windows hang up.
+
+        Answering 3.0.2 is the honest reply, and every SMB3 client speaks it.
+        """
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        self.assertEqual(c.negotiate((wire.DIALECT_311, wire.DIALECT_302)),
+                         wire.DIALECT_302)
+
+
+class Authentication(ServerFixture):
+    def test_the_right_password_gets_a_session(self):
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        c.negotiate()
+        self.assertEqual(c.session_setup(USER, PASSWORD), 0)
+
+    def test_the_wrong_password_does_not(self):
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        c.negotiate()
+        self.assertEqual(c.session_setup(USER, "wrong"), wire.STATUS_LOGON_FAILURE)
+
+    def test_an_unknown_user_does_not(self):
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        c.negotiate()
+        self.assertEqual(c.session_setup("nobody", PASSWORD),
+                         wire.STATUS_LOGON_FAILURE)
+
+    def test_anonymous_is_refused_when_a_password_is_configured(self):
+        """A null session must not be a way around the password.
+
+        This is the failure that matters most: everything else here is a feature
+        not working, and this one is the share being open when the operator
+        believes it is not.
+        """
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        c.negotiate()
+        self.assertEqual(c.session_setup("", "", anonymous=True),
+                         wire.STATUS_LOGON_FAILURE)
+
+    def test_no_tree_connect_before_a_session(self):
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        c.negotiate()
+        self.assertEqual(c.tree_connect("games"), wire.STATUS_USER_SESSION_DELETED)
+
+    def test_a_share_that_does_not_exist_is_refused(self):
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        c.negotiate()
+        c.session_setup(USER, PASSWORD)
+        self.assertEqual(c.tree_connect("nope"), wire.STATUS_BAD_NETWORK_NAME)
+
+
+class OpenMode(ServerFixture):
+    open_mode = True
+
+    def test_anonymous_is_allowed_only_where_the_operator_said_so(self):
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        c.negotiate()
+        self.assertEqual(c.session_setup("", "", anonymous=True), 0)
+
+
+class Browsing(ServerFixture):
+    def test_the_share_lists(self):
+        c = self.connected()
+        status, fid = c.create("", options=wire.FILE_DIRECTORY_FILE)
+        self.assertEqual(status, 0)
+        names = c.query_directory(fid)
+        self.assertIn("game.iso", names)
+        self.assertIn("APPS", names)
+        self.assertIn(".", names)
+
+    def test_a_subdirectory_lists(self):
+        c = self.connected()
+        status, fid = c.create("APPS", options=wire.FILE_DIRECTORY_FILE)
+        self.assertEqual(status, 0)
+        self.assertIn("boot.elf", c.query_directory(fid))
+
+    def test_listing_survives_more_entries_than_fit_in_one_reply(self):
+        """The cursor has to carry across calls, or a big folder truncates."""
+        for i in range(200):
+            with open(os.path.join(self.dir, "game%03d.iso" % i), "wb") as f:
+                f.write(b"x")
+        c = self.connected()
+        _status, fid = c.create("", options=wire.FILE_DIRECTORY_FILE)
+        names = c.query_directory(fid)
+        for i in range(200):
+            self.assertIn("game%03d.iso" % i, names)
+
+    def test_every_listing_class_a_client_may_ask_for(self):
+        """Clients differ on which class they ask for; all of these are real."""
+        c = self.connected()
+        for info_class in (wire.FILE_DIRECTORY_INFORMATION,
+                           wire.FILE_FULL_DIRECTORY_INFORMATION,
+                           wire.FILE_BOTH_DIRECTORY_INFORMATION,
+                           wire.FILE_ID_BOTH_DIRECTORY_INFORMATION,
+                           wire.FILE_NAMES_INFORMATION):
+            with self.subTest(info_class=info_class):
+                _status, fid = c.create("", options=wire.FILE_DIRECTORY_FILE)
+                buffers = c.query_directory_raw(fid, info_class=info_class)
+                self.assertTrue(buffers, "no entries for class 0x%02x" % info_class)
+                c.close_handle(fid)
+
+    def test_an_unknown_listing_class_is_refused_not_guessed(self):
+        c = self.connected()
+        _status, fid = c.create("", options=wire.FILE_DIRECTORY_FILE)
+        raw = "*".encode("utf-16-le")
+        body = (struct.pack("<HBBI", 33, 0x7F, 0x01, 0) + fid
+                + struct.pack("<HHI", wire.HEADER_SIZE + 32, len(raw), 65536) + raw)
+        head, _ = c.call(wire.CMD_QUERY_DIRECTORY, body)
+        self.assertEqual(head.status, wire.STATUS_INVALID_PARAMETER)
+
+
+class ReadingAndWriting(ServerFixture):
+    def test_a_file_reads_back_byte_for_byte(self):
+        with open(os.path.join(self.dir, "game.iso"), "rb") as f:
+            expected = f.read()
+        c = self.connected()
+        status, fid = c.create("game.iso")
+        self.assertEqual(status, 0)
+        got = b""
+        while len(got) < len(expected):
+            status, chunk = c.read(fid, len(got), 1024)
+            if status == wire.STATUS_END_OF_FILE:
+                break
+            self.assertEqual(status, 0)
+            got += chunk
+        self.assertEqual(got, expected)
+
+    def test_reading_past_the_end_says_so(self):
+        c = self.connected()
+        _status, fid = c.create("game.iso")
+        status, _ = c.read(fid, 1 << 20, 512)
+        self.assertEqual(status, wire.STATUS_END_OF_FILE)
+
+    def test_a_write_lands_on_disk(self):
+        c = self.connected()
+        status, fid = c.create("new.bin", disposition=wire.FILE_OVERWRITE_IF)
+        self.assertEqual(status, 0)
+        payload = bytes(range(256)) * 4
+        status, written = c.write(fid, 0, payload)
+        self.assertEqual(status, 0)
+        self.assertEqual(written, len(payload))
+        c.close_handle(fid)
+        with open(os.path.join(self.dir, "new.bin"), "rb") as f:
+            self.assertEqual(f.read(), payload)
+
+    def test_delete_on_close_removes_the_file(self):
+        target = os.path.join(self.dir, "scratch.bin")
+        with open(target, "wb") as f:
+            f.write(b"temporary")
+        c = self.connected()
+        status, fid = c.create("scratch.bin", options=wire.FILE_DELETE_ON_CLOSE)
+        self.assertEqual(status, 0)
+        c.close_handle(fid)
+        self.assertFalse(os.path.exists(target))
+
+    def test_a_missing_file_is_not_found(self):
+        c = self.connected()
+        status, _ = c.create("nope.iso")
+        self.assertEqual(status, wire.STATUS_OBJECT_NAME_NOT_FOUND)
+
+    def test_the_share_boundary_holds_over_the_wire(self):
+        """The path guard's rules have to survive being reached through SMB2.
+
+        Tested here as well as in test_smb2_paths because a guard that is only
+        called on some paths is not a guard.
+        """
+        c = self.connected()
+        for escape in ("..\\secrets.txt", "APPS\\..\\..\\outside.txt",
+                       "\\\\other-server\\share\\x"):
+            with self.subTest(path=escape):
+                status, _ = c.create(escape)
+                self.assertNotEqual(status, 0, "%r was served" % escape)
+
+
+class ReadOnlyShare(ServerFixture):
+    read_only = True
+
+    def test_reading_still_works(self):
+        c = self.connected()
+        status, fid = c.create("game.iso")
+        self.assertEqual(status, 0)
+        status, chunk = c.read(fid, 0, 16)
+        self.assertEqual(status, 0)
+        self.assertEqual(len(chunk), 16)
+
+    def test_writing_is_refused(self):
+        c = self.connected()
+        status, fid = c.create("game.iso")
+        self.assertEqual(status, 0)
+        status, _ = c.write(fid, 0, b"nope")
+        self.assertEqual(status, wire.STATUS_MEDIA_WRITE_PROTECTED)
+
+    def test_creating_is_refused(self):
+        c = self.connected()
+        status, _ = c.create("new.bin", disposition=wire.FILE_CREATE)
+        self.assertEqual(status, wire.STATUS_MEDIA_WRITE_PROTECTED)
+
+
+class Metadata(ServerFixture):
+    def test_a_client_can_size_a_file(self):
+        c = self.connected()
+        _status, fid = c.create("game.iso")
+        status, blob = c.query_info(fid, wire.INFO_TYPE_FILE,
+                                    wire.FILE_STANDARD_INFORMATION)
+        self.assertEqual(status, 0)
+        _alloc, eof = struct.unpack_from("<qq", blob, 0)
+        self.assertEqual(eof, 4096)
+
+    def test_a_client_can_size_the_volume(self):
+        c = self.connected()
+        _status, fid = c.create("", options=wire.FILE_DIRECTORY_FILE)
+        status, blob = c.query_info(fid, wire.INFO_TYPE_FILESYSTEM,
+                                    wire.FS_SIZE_INFORMATION)
+        self.assertEqual(status, 0)
+        self.assertEqual(len(blob), 24)
+
+    def test_file_all_information_is_the_one_explorer_leans_on(self):
+        c = self.connected()
+        _status, fid = c.create("game.iso")
+        status, blob = c.query_info(fid, wire.INFO_TYPE_FILE,
+                                    wire.FILE_ALL_INFORMATION)
+        self.assertEqual(status, 0)
+        # Basic(40) + Standard(24) + Internal(8) + EA(4) + Access(4)
+        # + Position(8) + Mode(4) + Alignment(4) + Name(4+n)
+        self.assertGreaterEqual(len(blob), 100)
+
+    def test_echo_answers(self):
+        c = self.connected()
+        self.assertEqual(c.echo(), 0)
+
+
+class Compounding(ServerFixture):
+    def test_chained_requests_all_get_answered(self):
+        """Explorer opens a file as one compound CREATE + QUERY_INFO + CLOSE.
+
+        Answering only the first request in the chain looks exactly like a hang.
+        """
+        c = self.connected()
+        raw = "game.iso".encode("utf-16-le")
+        create = struct.pack("<HBBIQQIIIIIHHII", 57, 0, 0, 2, 0, 0,
+                             0x00120089, 0, 7, wire.FILE_OPEN, 0,
+                             wire.HEADER_SIZE + 56, len(raw), 0, 0) + raw
+        total = wire.HEADER_SIZE + len(create)
+        aligned = (total + 7) & ~7
+        create += b"\x00" * (aligned - total)
+
+        hdr1 = wire.pack_header(wire.CMD_CREATE, 0, c.message_id,
+                                tree_id=c.tree_id, session_id=c.session_id,
+                                next_command=aligned)
+        hdr1 = hdr1[:16] + struct.pack("<I", 0) + hdr1[20:]
+        c.message_id += 1
+        echo = struct.pack("<HH", 4, 0)
+        hdr2 = wire.pack_header(wire.CMD_ECHO, 0, c.message_id,
+                                tree_id=c.tree_id, session_id=c.session_id)
+        hdr2 = hdr2[:16] + struct.pack("<I", 0) + hdr2[20:]
+        c.message_id += 1
+
+        wire.send_msg(c.sock, hdr1 + create + hdr2 + echo)
+        reply = wire.recv_msg(c.sock)
+        first = wire.parse_header(reply)
+        self.assertEqual(first.status, 0)
+        self.assertTrue(first.next_command, "the chain was not answered as a chain")
+        second = wire.parse_header(reply[first.next_command:])
+        self.assertEqual(second.command, wire.CMD_ECHO)
+        self.assertEqual(second.status, 0)
+
+
+class Robustness(ServerFixture):
+    def test_a_truncated_request_does_not_take_the_server_down(self):
+        c = self.connected()
+        for command in (wire.CMD_CREATE, wire.CMD_READ, wire.CMD_WRITE,
+                        wire.CMD_QUERY_DIRECTORY, wire.CMD_QUERY_INFO,
+                        wire.CMD_SET_INFO, wire.CMD_TREE_CONNECT):
+            with self.subTest(command=command):
+                head, _ = c.call(command, b"\x00\x00")
+                self.assertNotEqual(head.status, 0)
+        self.assertEqual(c.echo(), 0, "server stopped answering after bad input")
+
+    def test_a_stale_file_id_is_refused(self):
+        c = self.connected()
+        status, _ = c.read(struct.pack("<QQ", 999, 999), 0, 16)
+        self.assertEqual(status, wire.STATUS_FILE_CLOSED)
+
+    def test_a_mismatched_file_id_is_refused(self):
+        """Persistent and volatile halves must agree, or it is not that handle."""
+        c = self.connected()
+        _status, fid = c.create("game.iso")
+        volatile = struct.unpack("<QQ", fid)[1]
+        status, _ = c.read(struct.pack("<QQ", volatile + 1, volatile), 0, 16)
+        self.assertEqual(status, wire.STATUS_FILE_CLOSED)
+
+    def test_garbage_is_not_mistaken_for_a_request(self):
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        wire.send_msg(c.sock, b"not an smb message at all")
+        c2 = Client(self.port)
+        self.addCleanup(c2.close)
+        self.assertEqual(c2.negotiate(), wire.DIALECT_302)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_smb2_server.py
+++ b/tests/test_smb2_server.py
@@ -80,7 +80,8 @@ class Client:
         assert head.status == 0, "NEGOTIATE failed 0x%08X" % head.status
         return struct.unpack_from("<H", reply, 4)[0]
 
-    def session_setup(self, user, password, anonymous=False):
+    def session_setup(self, user, password, anonymous=False,
+                      domain="WORKGROUP"):
         negotiate = (spnego.NTLMSSP_SIGNATURE + struct.pack("<I", 1)
                      + struct.pack("<I", spnego.CHALLENGE_FLAGS)
                      + struct.pack("<HHI", 0, 0, 32) + struct.pack("<HHI", 0, 0, 32))
@@ -104,9 +105,9 @@ class Client:
             blob_body = (struct.pack("<BBHIQ", 1, 1, 0, 0, 0)
                          + os.urandom(8) + struct.pack("<I", 0)
                          + target_info + struct.pack("<I", 0))
-            ntowf = ntowfv2(password, user, "WORKGROUP")
+            ntowf = ntowfv2(password, user, domain)
             proof = ntlmv2_proof(ntowf, challenge, blob_body)
-            auth = self._authenticate(proof + blob_body, user, "WORKGROUP")
+            auth = self._authenticate(proof + blob_body, user, domain)
         head, _ = self._session_blob(auth)
         return head.status
 
@@ -600,3 +601,167 @@ class Robustness(ServerFixture):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class MalformedRequestBuffers(ServerFixture):
+    """Every client-declared buffer offset, bounds-checked.
+
+    SMB2 offsets are measured from the start of the message, so a valid one is
+    never below 64. Subtracting the header from a smaller value gave a negative
+    index, and Python slices from the END rather than failing -- which for WRITE
+    meant the file received the wrong bytes and the client was told it worked.
+    """
+
+    def test_a_write_with_a_low_data_offset_is_refused_not_mis_sliced(self):
+        original = b"O" * 64
+        with open(os.path.join(self.dir, "save.bin"), "wb") as f:
+            f.write(original)
+        c = self.connected()
+        _status, fid = c.create("save.bin")
+        payload = b"ATTACKER" * 16
+        for data_off in (0, 1, 63, 64):          # 64 is the header itself
+            with self.subTest(data_off=data_off):
+                body = struct.pack("<HHIQ", 49, data_off, 16, 0) + fid
+                body += struct.pack("<IIHHI", 0, 0, 0, 0, 0) + payload
+                head, _ = c.call(wire.CMD_WRITE, body)
+                self.assertEqual(head.status, wire.STATUS_INVALID_PARAMETER)
+        c.close_handle(fid)
+        with open(os.path.join(self.dir, "save.bin"), "rb") as f:
+            self.assertEqual(f.read(), original, "the file was written to anyway")
+
+    def test_a_write_longer_than_it_sent_is_refused(self):
+        c = self.connected()
+        _status, fid = c.create("big.bin", disposition=wire.FILE_OVERWRITE_IF)
+        body = struct.pack("<HHIQ", 49, wire.HEADER_SIZE + 48, 1 << 20, 0) + fid
+        body += struct.pack("<IIHHI", 0, 0, 0, 0, 0) + b"only eight"
+        head, _ = c.call(wire.CMD_WRITE, body)
+        self.assertEqual(head.status, wire.STATUS_INVALID_PARAMETER)
+
+    def test_every_other_declared_buffer_is_bounded_too(self):
+        c = self.connected()
+        _status, fid = c.create("", options=wire.FILE_DIRECTORY_FILE)
+        # CREATE name, QUERY_DIRECTORY pattern, SET_INFO payload: offset 0.
+        name = "x".encode("utf-16-le")
+        create = struct.pack("<HBBIQQIIIIIHHII", 57, 0, 0, 2, 0, 0, 0x00120089,
+                             0, 7, wire.FILE_OPEN, 0, 0, len(name), 0, 0) + name
+        head, _ = c.call(wire.CMD_CREATE, create)
+        self.assertEqual(head.status, wire.STATUS_INVALID_PARAMETER)
+
+        qd = (struct.pack("<HBBI", 33, wire.FILE_BOTH_DIRECTORY_INFORMATION, 1, 0)
+              + fid + struct.pack("<HHI", 0, 8, 65536) + name)
+        head, _ = c.call(wire.CMD_QUERY_DIRECTORY, qd)
+        self.assertEqual(head.status, wire.STATUS_INVALID_PARAMETER)
+
+        si = (struct.pack("<HBBIHHI", 33, wire.INFO_TYPE_FILE,
+                          wire.FILE_END_OF_FILE_INFORMATION, 8, 0, 0, 0) + fid
+              + struct.pack("<q", 0))
+        head, _ = c.call(wire.CMD_SET_INFO, si)
+        self.assertEqual(head.status, wire.STATUS_INVALID_PARAMETER)
+
+    def test_a_malformed_token_says_so_instead_of_blaming_the_password(self):
+        """STATUS_LOGON_FAILURE for a token that never parsed sends the user to
+        check a password that was never the problem."""
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        c.negotiate()
+        # Establish a challenge first, or the server refuses for the unrelated
+        # (and correct) reason that an AUTHENTICATE arrived without one.
+        negotiate = (spnego.NTLMSSP_SIGNATURE + struct.pack("<I", 1)
+                     + struct.pack("<I", spnego.CHALLENGE_FLAGS)
+                     + struct.pack("<HHI", 0, 0, 32) + struct.pack("<HHI", 0, 0, 32))
+        head, _ = c._session_blob(negotiate)
+        c.session_id = head.session_id
+        token = (spnego.NTLMSSP_SIGNATURE + struct.pack("<I", 3)
+                 + struct.pack("<HHI", 24, 24, 0xFFFF) * 6
+                 + struct.pack("<I", 0) + b"\x00" * 8)
+        body = struct.pack("<HBBIIHHQ", 25, 0, 1, 0, 0,
+                           wire.HEADER_SIZE + 24, len(token), 0)
+        head, _ = c.call(wire.CMD_SESSION_SETUP, body + token)
+        self.assertEqual(head.status, wire.STATUS_INVALID_PARAMETER)
+
+
+class RenameSafety(ServerFixture):
+    def _rename(self, c, fid, target, replace):
+        raw = target.encode("utf-16-le")
+        payload = (bytes([1 if replace else 0]) + b"\x00" * 7 + b"\x00" * 8
+                   + struct.pack("<I", len(raw)) + raw)
+        body = (struct.pack("<HBBIHHI", 33, wire.INFO_TYPE_FILE,
+                            wire.FILE_RENAME_INFORMATION, len(payload),
+                            wire.HEADER_SIZE + 32, 0, 0) + fid + payload)
+        head, _ = c.call(wire.CMD_SET_INFO, body)
+        return head.status
+
+    def test_rename_onto_an_existing_file_is_refused_by_default(self):
+        """ReplaceIfExists=0 is what a file manager sends for an ordinary
+        rename. Overwriting there destroys a file the user never named."""
+        keep = os.path.join(self.dir, "keep.iso")
+        with open(keep, "wb") as f:
+            f.write(b"IRREPLACEABLE")
+        c = self.connected()
+        _status, fid = c.create("game.iso")
+        self.assertEqual(self._rename(c, fid, "keep.iso", replace=False),
+                         wire.STATUS_OBJECT_NAME_COLLISION)
+        with open(keep, "rb") as f:
+            self.assertEqual(f.read(), b"IRREPLACEABLE")
+
+    def test_rename_replaces_when_the_client_asks_for_it(self):
+        with open(os.path.join(self.dir, "old.iso"), "wb") as f:
+            f.write(b"OLD")
+        c = self.connected()
+        _status, fid = c.create("game.iso")
+        self.assertEqual(self._rename(c, fid, "old.iso", replace=True), 0)
+        c.close_handle(fid)
+        self.assertFalse(os.path.exists(os.path.join(self.dir, "game.iso")))
+
+    def test_a_rename_out_of_the_share_is_refused(self):
+        c = self.connected()
+        _status, fid = c.create("game.iso")
+        self.assertNotEqual(self._rename(c, fid, "..\escaped.iso", replace=True), 0)
+
+
+class ParentEntry(ServerFixture):
+    def test_dotdot_at_the_share_root_describes_the_root(self):
+        """The parent of the share root is outside the share, and nothing above
+        the root may be described to a client -- not even its timestamps."""
+        c = self.connected()
+        _status, fid = c.create("", options=wire.FILE_DIRECTORY_FILE)
+        buffers = c.query_directory_raw(fid)
+        blob = b"".join(buffers)
+        entries, at = {}, 0
+        while at < len(blob):
+            next_off = struct.unpack_from("<I", blob, at)[0]
+            name_len = struct.unpack_from("<I", blob, at + 60)[0]
+            name = blob[at + 94:at + 94 + name_len].decode("utf-16-le")
+            entries[name] = struct.unpack_from("<Q", blob, at + 8)[0]   # creation
+            if next_off == 0:
+                break
+            at += next_off
+        self.assertIn("..", entries)
+        self.assertEqual(entries[".."], entries["."],
+                         "'..' described a directory outside the share")
+
+
+class DomainHandling(ServerFixture):
+    """NTOWFv2 folds the domain into the key, so the server must use exactly the
+    one the client used -- empty is a value, not a missing field."""
+
+    def test_a_client_that_sends_no_domain_still_authenticates(self):
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        c.negotiate()
+        self.assertEqual(c.session_setup(USER, PASSWORD, domain=""), 0)
+
+    def test_a_client_that_sends_the_workgroup_authenticates(self):
+        c = Client(self.port)
+        self.addCleanup(c.close)
+        c.negotiate()
+        self.assertEqual(c.session_setup(USER, PASSWORD, domain="WORKGROUP"), 0)
+
+    def test_the_wrong_password_still_fails_whatever_the_domain(self):
+        for domain in ("", "WORKGROUP", "SOMETHINGELSE"):
+            with self.subTest(domain=domain):
+                c = Client(self.port)
+                self.addCleanup(c.close)
+                c.negotiate()
+                self.assertEqual(c.session_setup(USER, "wrong", domain=domain),
+                                 wire.STATUS_LOGON_FAILURE)

--- a/tests/test_smb2_wire.py
+++ b/tests/test_smb2_wire.py
@@ -1,0 +1,208 @@
+"""The SMB2 structure sizes, pinned.
+
+Every SMB2 body begins with a StructureSize the client checks before reading
+anything else, and it is the fixed part of the body plus one wherever a variable
+buffer follows. Get it wrong and a real client does not report an error -- it
+stops talking, which is indistinguishable from a hang.
+
+The end-to-end tests in test_smb2_server.py cannot catch that class of mistake
+on their own: the client there is this project's own reading of the protocol, so
+a field that is the wrong width in both places round-trips perfectly. These
+tests are the counterweight. They record the sizes MS-SMB2 states, so a later
+refactor cannot quietly move one.
+
+Stated plainly: these are transcribed from the protocol as implemented here, not
+re-derived from the specification document in this environment. They pin against
+drift, not against a mistake made once and written down twice. The only complete
+check is a real client, which needs port 445.
+
+Run:  python -m unittest tests.test_smb2_wire -v
+"""
+
+import os
+import struct
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, "smb2_server"))
+
+import smb2_wire as wire        # noqa: E402
+
+
+class FakeStat:
+    st_mode = 0o100644
+    st_size = 4096
+    st_ino = 1234
+    st_ctime = 1700000000
+    st_atime = 1700000001
+    st_mtime = 1700000002
+
+
+class Header(unittest.TestCase):
+    def test_the_header_is_64_bytes(self):
+        raw = wire.pack_header(wire.CMD_NEGOTIATE, 0, 1)
+        self.assertEqual(len(raw), 64)
+        self.assertEqual(wire.HEADER_SIZE, 64)
+
+    def test_it_round_trips(self):
+        raw = wire.pack_header(wire.CMD_READ, wire.STATUS_END_OF_FILE, 42,
+                               tree_id=7, session_id=0x1122334455667788)
+        hdr = wire.parse_header(raw)
+        self.assertEqual(hdr.command, wire.CMD_READ)
+        self.assertEqual(hdr.status, wire.STATUS_END_OF_FILE)
+        self.assertEqual(hdr.message_id, 42)
+        self.assertEqual(hdr.tree_id, 7)
+        self.assertEqual(hdr.session_id, 0x1122334455667788)
+
+    def test_a_reply_is_marked_as_one(self):
+        hdr = wire.parse_header(wire.pack_header(wire.CMD_ECHO, 0, 1))
+        self.assertTrue(hdr.flags & wire.FLAG_SERVER_TO_REDIR)
+
+    def test_anything_that_is_not_smb2_is_not_a_header(self):
+        self.assertIsNone(wire.parse_header(b"\xffSMB" + b"\x00" * 60))
+        self.assertIsNone(wire.parse_header(b"too short"))
+
+    def test_the_error_body_carries_its_one_byte_of_error_data(self):
+        """StructureSize 9 means 8 fixed bytes and a byte of buffer.
+
+        An 8-byte error body is malformed, which is a different failure from the
+        one being reported and is the harder of the two to find.
+        """
+        body = wire.error_body()
+        self.assertEqual(struct.unpack_from("<H", body, 0)[0], 9)
+        self.assertEqual(len(body), 9)
+
+
+class Framing(unittest.TestCase):
+    def test_the_length_prefix_is_the_one_big_endian_field(self):
+        class FakeSock:
+            def __init__(self):
+                self.sent = b""
+
+            def sendall(self, data):
+                self.sent += data
+
+        sock = FakeSock()
+        wire.send_msg(sock, b"x" * 0x010203)
+        self.assertEqual(sock.sent[:4], b"\x00\x01\x02\x03")
+
+
+class Dialects(unittest.TestCase):
+    def test_the_best_common_dialect_wins(self):
+        self.assertEqual(
+            wire.pick_dialect([wire.DIALECT_202, wire.DIALECT_210], wire.CEILING_SMB3),
+            wire.DIALECT_210)
+
+    def test_the_ceiling_holds(self):
+        offered = [wire.DIALECT_202, wire.DIALECT_210, wire.DIALECT_300,
+                   wire.DIALECT_302]
+        self.assertEqual(wire.pick_dialect(offered, wire.CEILING_SMB2),
+                         wire.DIALECT_210)
+        self.assertEqual(wire.pick_dialect(offered, wire.CEILING_SMB3),
+                         wire.DIALECT_302)
+
+    def test_311_is_never_chosen(self):
+        """It needs negotiate contexts. Claiming it without them is refused by
+        Windows outright, so answering 3.0.2 is what actually connects."""
+        self.assertEqual(
+            wire.pick_dialect([wire.DIALECT_311], wire.CEILING_SMB3), None)
+        self.assertEqual(
+            wire.pick_dialect([wire.DIALECT_311, wire.DIALECT_302],
+                              wire.CEILING_SMB3),
+            wire.DIALECT_302)
+
+    def test_nothing_in_common_is_none_not_a_guess(self):
+        self.assertIsNone(wire.pick_dialect([0x0999], wire.CEILING_SMB3))
+        self.assertIsNone(wire.pick_dialect([], wire.CEILING_SMB3))
+
+
+class FileInformationSizes(unittest.TestCase):
+    """Fixed record sizes. A client reads these by offset, not by parsing."""
+
+    def test_file_classes(self):
+        st = FakeStat()
+        for info_class, size in (
+                (wire.FILE_BASIC_INFORMATION, 40),
+                (wire.FILE_STANDARD_INFORMATION, 24),
+                (wire.FILE_INTERNAL_INFORMATION, 8),
+                (wire.FILE_EA_INFORMATION, 4),
+                (wire.FILE_ACCESS_INFORMATION, 4),
+                (wire.FILE_POSITION_INFORMATION, 8),
+                (wire.FILE_NETWORK_OPEN_INFORMATION, 56)):
+            with self.subTest(info_class=info_class):
+                self.assertEqual(len(wire.file_info(info_class, st)), size)
+
+    def test_file_all_information_is_its_parts(self):
+        st = FakeStat()
+        blob = wire.file_info(wire.FILE_ALL_INFORMATION, st, "\\game.iso")
+        name = "\\game.iso".encode("utf-16-le")
+        self.assertEqual(len(blob), 40 + 24 + 8 + 4 + 4 + 8 + 4 + 4 + 4 + len(name))
+
+    def test_an_unencodable_class_is_none_not_an_empty_record(self):
+        """None makes the caller answer NOT_SUPPORTED. An empty record would be
+        read by the client as the class it asked for, with every field zero."""
+        self.assertIsNone(wire.file_info(0x7F, FakeStat()))
+        self.assertIsNone(wire.fs_info(0x7F, "."))
+
+    def test_directory_entry_classes(self):
+        st = FakeStat()
+        name = "game.iso"
+        encoded = len(name.encode("utf-16-le"))
+        for info_class, fixed in (
+                (wire.FILE_DIRECTORY_INFORMATION, 64),
+                (wire.FILE_FULL_DIRECTORY_INFORMATION, 68),
+                (wire.FILE_BOTH_DIRECTORY_INFORMATION, 94),
+                (wire.FILE_ID_BOTH_DIRECTORY_INFORMATION, 104),
+                (wire.FILE_NAMES_INFORMATION, 12)):
+            with self.subTest(info_class=info_class):
+                record = wire.directory_entry(name, st, info_class)
+                self.assertEqual(len(record), fixed + encoded)
+
+    def test_the_name_length_field_is_bytes_not_characters(self):
+        st = FakeStat()
+        record = wire.directory_entry("ab", st, wire.FILE_BOTH_DIRECTORY_INFORMATION)
+        self.assertEqual(struct.unpack_from("<I", record, 60)[0], 4)
+
+    def test_filesystem_classes(self):
+        for info_class, size in ((wire.FS_SIZE_INFORMATION, 24),
+                                 (wire.FS_FULL_SIZE_INFORMATION, 32),
+                                 (wire.FS_DEVICE_INFORMATION, 8)):
+            with self.subTest(info_class=info_class):
+                self.assertEqual(len(wire.fs_info(info_class, ROOT)), size)
+
+    def test_the_filesystem_is_not_advertised_as_case_sensitive(self):
+        """Windows shares are not. Claiming otherwise makes a client treat
+        Game.iso and game.iso as two files where the disk has one."""
+        blob = wire.fs_info(wire.FS_ATTRIBUTE_INFORMATION, ROOT)
+        attrs = struct.unpack_from("<I", blob, 0)[0]
+        FILE_CASE_SENSITIVE_SEARCH = 0x00000001
+        FILE_CASE_PRESERVED_NAMES = 0x00000002
+        self.assertTrue(attrs & FILE_CASE_PRESERVED_NAMES)
+        self.assertFalse(attrs & FILE_CASE_SENSITIVE_SEARCH)
+
+
+class Attributes(unittest.TestCase):
+    def test_a_directory_is_marked_as_one(self):
+        class Dir(FakeStat):
+            st_mode = 0o040755
+        self.assertTrue(wire.attributes_for(Dir()) & wire.ATTR_DIRECTORY)
+        self.assertFalse(wire.attributes_for(FakeStat()) & wire.ATTR_DIRECTORY)
+
+    def test_read_only_is_carried_to_the_client(self):
+        self.assertTrue(
+            wire.attributes_for(FakeStat(), read_only=True) & wire.ATTR_READONLY)
+        self.assertFalse(
+            wire.attributes_for(FakeStat()) & wire.ATTR_READONLY)
+
+    def test_filetime_is_1601_based(self):
+        # 1970-01-01 is exactly the epoch delta, and 0 stays 0 rather than
+        # becoming 1601, which a client would display as a real date.
+        self.assertEqual(wire.to_filetime(0), 0)
+        self.assertEqual(wire.to_filetime(1), 116444736000000000 + 10_000_000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#153 pulled the SMBv2/SMBv3 modes because the handlers behind them connected and then served nothing. **This builds the server they should have had, and puts the modes back on top of it.**

Stacked on #151 (the path guard and NTLMv2 core) and #153 (the removal). Review those first; this branch contains both.

## One server, two modes

SMB3 is the same protocol at a higher dialect, so the ceiling is a flag (`--smb-version 2|3`), not a second implementation to keep in step.

| file | |
|---|---|
| `smb2_wire.py` | framing, the header, and every fixed-size structure a client reads by offset |
| `smb2_spnego.py` | the SPNEGO/NTLMSSP exchange a real client insists on |
| `smb2_server.py` | NEGOTIATE, SESSION_SETUP, TREE_CONNECT, CREATE, QUERY_DIRECTORY, QUERY_INFO, SET_INFO, READ, WRITE, CLOSE, FLUSH, ECHO, LOGOFF, TREE_DISCONNECT, CANCEL |

It lists a share, reads a file back byte for byte, writes one, honours read-only, enforces the share boundary over the wire, and **answers a compound request as a chain** — which is how a file manager opens a file, and answering only the first request in one looks exactly like a hang.

## Deliberate limits, written down rather than discovered later

- **No signing or encryption.** Both are AES below dialect 3.1.1, and this repo is stdlib-only — Python has no AES, and a pure-Python one would have to run over every byte of every transfer. Signing is advertised as *enabled but not required*, which a default Windows client accepts. A client whose policy **requires** signing is refused honestly rather than half-served.
- **3.1.1 is never negotiated**, even when offered. It needs negotiate contexts, and claiming it without them makes Windows hang up. 3.0.2 connects, and every SMB3 client speaks it.
- **A password is required.** Open is reachable only by ticking a box that says what it does, and an anonymous session against a password-protected share is refused rather than quietly downgraded to guest.

`--take-445` is implemented here too, because Windows' own client cannot be pointed at any other port — shipping that checkbox without the flag behind it would be the same defect this branch exists to fix. It Stops and never Disables LanmanServer, and restores in a `finally`.

## Testing — 53 new tests

`test_smb2_server.py` drives a client written for the purpose through the whole exchange over real sockets: negotiation and dialect capping, right/wrong password, unknown user, **anonymous refused when a password is set**, listing across multiple round trips (200 files), all five listing classes, byte-exact reads, writes landing on disk, delete-on-close, read-only refusals, path-guard escapes over the wire, compounding, and truncated/garbage input not taking the server down.

`test_smb2_wire.py` pins the structure sizes separately, because both sides of an end-to-end test share this project's reading of the protocol — a field that is the wrong width in both round-trips perfectly. **That pinning immediately caught a real bug**: `FileSystemAttributes` was advertising `CASE_SENSITIVE_SEARCH`, which would have made a client treat `Game.iso` and `game.iso` as two files on a disk that has one.

The ordering guard from #153 now checks whichever server a mode actually runs, so it keeps meaning something. Verified both ways: passes on the real server, still fails if a mode is repointed at the old stub.

Full suite: **415 tests, OK.**

## What is NOT proven

**No real client has connected to this.** Windows cannot be pointed at a non-445 port, so that test needs port 445 and an admin prompt, and cannot run in CI. The honest status is *internally consistent and tested*, not *validated against Windows Explorer*. That is the next thing to do with it, and it is why Edge does not get the port yet.

## Edge

Edge stays SMBv1-only in this PR, deliberately. The house rule in `PICKUP-FROM-HERE.md` is to **port from `smbv1_server`, never from the SMB spec** — because the Python server is what has been tested against a real client. Porting 2,600 lines of unvalidated protocol into Go would multiply the unknowns rather than reduce them. Once this has served a real Explorer session, the Go port has something worth copying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SMB2 and SMB3 server support with file browsing, reading, writing, deletion, metadata, and directory listing.
  * Added configurable shares, credentials, guest access, read-only mode, protocol version limits, server identity, and network binding.
  * Added NTLM authentication and secure share-boundary path validation.
* **Bug Fixes**
  * Improved handling of malformed requests, invalid paths, stale handles, and authentication failures.
* **Documentation**
  * Clarified that non-SMBv1 modes remain incomplete where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->