### PR TITLE
fix(packaging): bundle stdlib dependencies in frozen builds and add games_folder to SMBv1 fields

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -94,6 +94,36 @@ INCLUDE_PACKAGES = [
     "lz4",
 ]
 
+INCLUDE_MODULES = [
+    "argparse",
+    "collections",
+    "ctypes",
+    "dataclasses",
+    "enum",
+    "errno",
+    "fnmatch",
+    "gzip",
+    "hashlib",
+    "hmac",
+    "ipaddress",
+    "math",
+    "posixpath",
+    "queue",
+    "re",
+    "secrets",
+    "select",
+    "shutil",
+    "socket",
+    "stat",
+    "struct",
+    "subprocess",
+    "threading",
+    "time",
+    "typing",
+    "uuid",
+    "zlib",
+]
+
 # Optional Linux system-tray backend. pystray (+ Pillow for the icon, + the
 # pure-Python Xlib xorg fallback) is bundled so the packaged Linux build has a
 # working tray. Each is included only if actually installed in the build
@@ -150,6 +180,9 @@ def main():
 
     for pkg in INCLUDE_PACKAGES:
         cmd.append("--include-package=" + pkg)
+
+    for mod in INCLUDE_MODULES:
+        cmd.append("--include-module=" + mod)
 
     if system == "Linux":
         for pkg in LINUX_TRAY_PACKAGES:

--- a/launcher/serve.py
+++ b/launcher/serve.py
@@ -10,6 +10,36 @@ import importlib.util
 import os
 import sys
 
+# Explicitly import standard library modules required by dynamic server engines
+# so PyInstaller, Nuitka, and static bundlers include them in frozen builds.
+import argparse
+import collections
+import ctypes
+import dataclasses
+import enum
+import errno
+import fnmatch
+import gzip
+import hashlib
+import hmac
+import ipaddress
+import math
+import posixpath
+import queue
+import re
+import secrets
+import select
+import shutil
+import socket
+import stat
+import struct
+import subprocess
+import threading
+import time
+import typing
+import uuid
+import zlib
+
 
 def _load_module(path):
     name = "_ps2srv_" + os.path.splitext(os.path.basename(path))[0]

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -123,7 +123,7 @@ def _smb_argv(v, smb_version="1"):
     # choose. "games" stays the default because it is what every OPL guide and
     # every existing saved configuration says.
     share = (v.get("share_name") or "games").strip() or "games"
-    folder = v.get("games_folder") or v.get("root_dir") or ""
+    folder = (v.get("games_folder") or v.get("root_dir") or "").strip()
     if not folder:
         raise ValueError("SMB server requires a Games folder to share.")
     args = ["--share", "{}={}".format(share, folder),

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -124,6 +124,8 @@ def _smb_argv(v, smb_version="1"):
     # every existing saved configuration says.
     share = (v.get("share_name") or "games").strip() or "games"
     folder = v.get("games_folder") or v.get("root_dir") or ""
+    if not folder:
+        raise ValueError("SMB server requires a Games folder to share.")
     args = ["--share", "{}={}".format(share, folder),
             "--smb-version", str(smb_version)]
     if v.get("port"):
@@ -354,6 +356,8 @@ SMBV1 = ServerDef(
     module_file=_repo("smbv1_server", "smbserver_opl.py"),
     module_dir=_repo("smbv1_server"),
     fields=[
+        Field("games_folder", "Games folder", "folder", required=True,
+              help="Folder to share over SMBv1 for OPL."),
         Field("share_name", "Share name", "text", default="games",
               help="The name typed after the IP on a client, and in OPL's "
                    "Share field. 'games' is what the guides assume."),

--- a/tests/test_packaging_data_files.py
+++ b/tests/test_packaging_data_files.py
@@ -116,6 +116,27 @@ class SiblingImportsAreShippedTests(unittest.TestCase):
                         "the packaged build would fail to import it".format(
                             rel, name, _rel(sibling)))
 
+    def test_all_server_stdlib_imports_are_statically_imported_by_serve(self):
+        serve_path = os.path.join(ROOT, "launcher", "serve.py")
+        serve_imports = self._imported_names(serve_path)
+        shipped = set(BUILD.DATA_FILES)
+        for rel in sorted(shipped):
+            path = os.path.join(ROOT, rel)
+            directory = os.path.dirname(path)
+            for name in self._imported_names(path):
+                sibling = os.path.join(directory, name + ".py")
+                if os.path.isfile(sibling):
+                    continue  # local sibling, not stdlib
+                # Ignore local packages / third-party libs handled via INCLUDE_PACKAGES or sys.path
+                if name in ("compressed_iso", "lz4", "launcher", "udpfs_server", "smb2_server", "smbv1_server", "udpbd_server"):
+                    continue
+                with self.subTest(source=rel, stdlib_module=name):
+                    self.assertIn(
+                        name, serve_imports,
+                        "{} imports stdlib module '{}' but launcher/serve.py does not import it; "
+                        "frozen builds will fail with ModuleNotFoundError: No module named '{}'".format(
+                            rel, name, name))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Fixes `ModuleNotFoundError: No module named 'hmac'` when launching Python servers (SMBv1, SMBv2/3, UDPFS, UDPBD) from compiled single-file executables (`PS2Servers.exe`), and adds the missing `games_folder` field to `SMBV1.fields`.

### Changes Included
1. **Bundle Server Stdlib Dependencies in Frozen Builds**:
   - `launcher/serve.py`: Added static imports for all standard library modules required by dynamic server engines (`hmac`, `hashlib`, `ipaddress`, `secrets`, `uuid`, `ctypes`, `struct`, `socket`, `threading`, `math`, `select`, `argparse`, `collections`, `errno`, `fnmatch`, `gzip`, `queue`, `re`, `shutil`, `stat`, `typing`, `zlib`) so Nuitka/PyInstaller's static dependency scanner bundles them into `PS2Servers.exe`.
   - `build/build.py`: Added `INCLUDE_MODULES` to Nuitka build flags.
   - `tests/test_packaging_data_files.py`: Added automated regression test `test_all_server_stdlib_imports_are_statically_imported_by_serve`.

2. **Add `games_folder` Field to SMBv1 & Validate Path**:
   - `launcher/servers.py`: Added `Field("games_folder", ...)` to `SMBV1.fields` so the GUI card displays the Games folder picker for SMBv1.
   - `_smb_argv`: Validates `if not folder: raise ValueError(...)` so empty share paths (`--share games=`) are prevented at start.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packaged builds to include required standard-library components, reducing startup failures in bundled applications.
  * Added validation for SMBv1 configurations that do not specify a Games folder.
  * Improved error prevention for dynamically loaded server engines in frozen builds.

* **Tests**
  * Added automated checks to detect missing imports that could cause packaged applications to fail at launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->