### PR TITLE
feat(edge): add UDPFS handoff observability

### DIFF
--- a/docs/EDGE.md
+++ b/docs/EDGE.md
@@ -45,6 +45,10 @@ Observability:
 - `--metrics` — log periodic transfer counters
 - `--metrics-period 1m` — how often, from `1s` to `24h`
 
+For an OpenWrt command reference and a packet-by-packet NHDDL-to-Neutrino
+diagnostic procedure, see
+[UDPFS-HANDOFF-DIAGNOSTICS.md](UDPFS-HANDOFF-DIAGNOSTICS.md).
+
 Every option also reads an environment variable (`FSROOT`, `BIND`, `PORT`,
 `BDPATH`, `RO`, `NO_COMPRESSION`, `METRICS`, and so on), which is what the
 Docker images use.

--- a/docs/UDPFS-HANDOFF-DIAGNOSTICS.md
+++ b/docs/UDPFS-HANDOFF-DIAGNOSTICS.md
@@ -1,0 +1,584 @@
+# Edge UDPFS operation and handoff diagnostics
+
+This guide is for operating PS2 Servers Edge on OpenWrt and for tracing the
+handoff from NHDDL to Neutrino. The examples use the A5-V11 test layout:
+
+- router: `192.168.1.200`
+- PS2: `192.168.1.201`
+- USB root: `/mnt/ps2`
+- UDPFS discovery port: UDP `62966` (`0xF5F6`)
+- OpenWrt UCI section: `ps2servers-edge.main`
+
+The commands and option names below match the current Edge command line,
+OpenWrt init script, and default UCI configuration in this repository.
+
+## Pick the right Edge mode
+
+`ps2servers-edge` has three independent subcommands. The OpenWrt package can
+run more than one at once as separate `procd` instances.
+
+| Mode | What it serves | Use it for |
+|---|---|---|
+| `udpfs` | A directory tree, plus an optional block image through the same UDPFS instance | NHDDL, Neutrino's UDPFS backend, and UDPFS-aware file browsers such as wLaunchELF |
+| `udpbd` | One raw disk image over the separate UDPBD protocol | A client explicitly using UDPBD, not a named-file UDPFS client |
+| `smb` | One or more SMBv1 shares | OPL's SMB game list and POPSTARTER |
+
+The NHDDL-to-Neutrino investigation is a **UDPFS** test. Starting `udpbd` does
+not make a directory available to NHDDL, and SMB traffic cannot exercise the
+UDPFS handoff code.
+
+## What “UDPFS session” means
+
+UDP is connectionless. There is no TCP-style connection to establish, close,
+or query. Edge builds its own protocol session from the source IP, source port,
+packet sequences, and recent activity it observes.
+
+A normal two-port exchange is:
+
+1. The PS2 sends a UDPFS `DISCOVERY` datagram to the router's discovery port,
+   normally UDP 62966.
+2. Edge replies with an `INFORM` that identifies its data port.
+3. The PS2 sends file-operation and control datagrams to that data port.
+4. Edge associates those datagrams with the observed PS2 endpoint and UDPFS
+   sequence state.
+
+With `data_port` set to `0`, the operating system chooses the data port at each
+service start. The exact choice appears in the `UDPFS listening` log line:
+
+```text
+[info] UDPFS listening root=/mnt/ps2 discovery=0.0.0.0:62966 data=0.0.0.0:34724 ...
+```
+
+`single_port '1'` makes discovery and data share UDP 62966. In that mode Edge
+does not open a separate data socket, so `data_port` has no effect for that
+run. A fixed `data_port`, or single-port mode, is useful when a firewall cannot
+allow the automatically selected data port. It should be changed as a
+controlled test, not mixed into the initial baseline.
+
+In `protocol=auto`, `session negotiated` means the pending session saw its
+first payload-bearing DATA datagram, selected a profile, and selected the
+response socket. Edge allocated the peer's server-side state earlier, when it
+first accepted that peer. Forced `standard` and `modulo` modes do not emit this
+auto-classification marker; use the verbose negotiation and packet fields in
+those comparison runs. None of these events proves that the physical Ethernet
+link will survive an IOP reset, that Neutrino started, or that a later datagram
+will reach the process.
+
+## UDPFS option map
+
+Explicit command-line flags take precedence over environment defaults. The
+OpenWrt service does not rely on those environment variables: its init script
+reads UCI and emits explicit flags.
+
+| Purpose | CLI flag | Environment | Current OpenWrt UCI option | Default / constraint |
+|---|---|---|---|---|
+| Enable service | — | — | `main.enabled` | `1` in the package |
+| Directory root | `--root` | `FSROOT` | `main.root` | Required; `/mnt/sda1/PS2` in the package |
+| IPv4 bind address | `--bind` | `BIND` | `main.bind` | `0.0.0.0` |
+| Discovery port | `--port` | `PORT` | `main.port` | `62966`; `0` resolves to that default, otherwise range 1–65535 |
+| Data port | `--data-port` | `DATA_PORT` | `main.data_port` | `0` chooses automatically; range 0–65535 |
+| Protocol selection | `--protocol-mode` | `PROTOCOL_MODE` | `main.protocol` | `auto`, `standard`, or `modulo` |
+| One UDP port | `--single-port` | `SINGLE_PORT` | `main.single_port` | Off |
+| Idle-session expiry | `--peer-timeout` | `PEER_TIMEOUT` | `main.peer_timeout` | `1h`; range `1m`–`24h` |
+| Transmit pacing | `--tx-delay-ms` | `TX_DELAY_MS` | `main.tx_delay_ms` | `0`; non-negative milliseconds |
+| Read-only serving | `--read-only` | `RO` | `main.read_only` | Binary: writable; OpenWrt: read-only (`1`) |
+| Log format | `--log-format` | `LOG_FORMAT` | `main.log_format` | `text` or `json` |
+| Header/protocol trace | `--verbose` | `VERBOSE` | `main.verbose` | Off |
+| Periodic counters | `--metrics` | `METRICS` | `main.metrics` | Off |
+| Counter interval | `--metrics-period` | `METRICS_PERIOD` | `main.metrics_period` | `1m`; range `1s`–`24h` |
+| UDPFS block image | `--block-device` | `BDPATH` | `main.block_device` | Empty disables it |
+| Block-image sector size | `--sector-size` | `SECTOR_SIZE` | `main.sector_size` | `512`; multiple of 512, maximum 65536 |
+| Raw compressed containers | `--no-compression` | `NO_COMPRESSION` | `main.no_compression` | Off; diagnostic only |
+| Decompression cache | `--compression-cache-size` | `COMPRESSION_CACHE_SIZE` | `main.compression_cache_size` | `32`; range 0–4096 blocks per open image |
+
+Direct CLI also supports `--quiet`, which suppresses informational logs but not
+warnings or errors, and the deprecated `--modulo-mode` alias. Neither has a UCI
+option. Do not use `--quiet` for a handoff trace.
+
+### Protocol modes
+
+| Value | Behaviour | When to use it |
+|---|---|---|
+| `auto` | Begins pending and classifies the client's sequence shape as standard or Modulo | Normal operation and the first diagnostic baseline |
+| `standard` | Forces standard sequence interpretation | A one-variable comparison after `auto` has been captured |
+| `modulo` | Forces Modulo sequence interpretation | A one-variable comparison for a known Modulo client |
+
+Protocol mode controls sequence interpretation, not whether Edge uses one or
+two local sockets. Keep `protocol=auto` unless the test is intentionally
+isolating protocol classification.
+
+### Compression and pacing are later-stage controls
+
+`compression_cache_size` matters after a compressed game has been opened. It
+cannot make a missing post-reset datagram appear. Likewise, `tx_delay_ms` paces
+Edge's outgoing packets; it can help a slow link that is dropping bursts, but
+it cannot repair a PS2 Ethernet link that never comes back up. Start both at
+their defaults (`32` and `0`) for handoff isolation.
+
+`no_compression '1'` makes Edge expose CSO/ZSO container bytes without decoding
+them. A PS2 cannot boot those raw container bytes. Use it only to isolate the
+decoder after traffic and file access are already proven.
+
+## Operate the installed OpenWrt service
+
+The current package installs `/usr/bin/ps2servers-edge`,
+`/etc/init.d/ps2servers-edge`, and `/etc/config/ps2servers-edge`. The service
+runs as the unprivileged `ps2edge` user and sends stdout/stderr to syslog.
+
+| Task | Command |
+|---|---|
+| Start all enabled Edge instances | `/etc/init.d/ps2servers-edge start` |
+| Stop all Edge instances | `/etc/init.d/ps2servers-edge stop` |
+| Restart after a committed change | `/etc/init.d/ps2servers-edge restart` |
+| Show service state | `/etc/init.d/ps2servers-edge status` |
+| Start at boot | `/etc/init.d/ps2servers-edge enable` |
+| Disable start at boot | `/etc/init.d/ps2servers-edge disable` |
+| Show saved configuration | `uci show ps2servers-edge` |
+| Show existing Edge log lines | `logread -e ps2servers-edge` |
+| Follow Edge and Ethernet-link events | `logread -f | grep -E 'ps2servers-edge|link changed'` |
+| Show running command lines | `ps w | grep '[p]s2servers-edge'` |
+| Show listening UDP sockets | `netstat -lnup 2>/dev/null | grep ps2servers-edge` |
+
+`start`, `stop`, and `restart` affect every enabled Edge mode. A router running
+UDPFS and SMB will therefore have more than one `ps2servers-edge` process.
+
+`uci set` changes UCI's pending value, `uci commit ps2servers-edge` writes the
+package configuration to persistent storage, and `restart` rebuilds the
+enabled `procd` instances with those values. Always inspect the new process
+line and startup log after a change; editing UCI does not reconfigure an
+already running process by itself.
+
+The root must be mounted before Edge starts and must be readable and
+directory-traversable by `ps2edge`. `read_only '1'` controls UDPFS writes; it
+does not mount the USB filesystem read-only. To permit saves, both UCI
+`read_only '0'` and operating-system write permission for `ps2edge` are needed.
+
+Do not launch a second foreground UDPFS process while the service owns UDP
+62966. To test the CLI directly, stop the service first:
+
+```sh
+/etc/init.d/ps2servers-edge stop
+/usr/bin/ps2servers-edge udpfs \
+  --root /mnt/ps2 \
+  --bind 0.0.0.0 \
+  --port 62966 \
+  --data-port 0 \
+  --protocol-mode auto \
+  --peer-timeout 1h \
+  --tx-delay-ms 0 \
+  --compression-cache-size 32 \
+  --read-only \
+  --verbose \
+  --metrics \
+  --metrics-period 1s \
+  --log-format text
+```
+
+Press Ctrl-C to stop the foreground process, then restart the managed service.
+
+## Current UCI names versus older A5-V11 images
+
+The current init script reads:
+
+```text
+ps2servers-edge.main.port
+ps2servers-edge.main.protocol
+```
+
+Some earlier A5-V11 images reported options named `main.udpfs_port` and
+`main.protocol_mode`. Those legacy names are **not read by the current init
+script**. The hardware report's older image also ran the executable from
+`/usr/sbin`, while the current package init script uses
+`/usr/bin/ps2servers-edge`. The `/etc/init.d` commands avoid guessing the
+binary location. After installing a current build, use the names in this guide.
+On an unknown image, inspect the init script, saved values, and effective
+command before drawing conclusions:
+
+```sh
+uci show ps2servers-edge
+grep -n 'config_get.*main' /etc/init.d/ps2servers-edge
+ps w | grep '[p]s2servers-edge'
+```
+
+A UCI assignment only proves the value was saved. The process line and
+`UDPFS listening` log prove which value the running server actually received.
+
+## Safe A5-V11 baseline
+
+These commands keep the share read-only, preserve automatic protocol
+selection, and enable only diagnostic output. They do not change PS2-side
+configuration.
+
+First preserve the current file in RAM for this boot:
+
+```sh
+cp -p /etc/config/ps2servers-edge /tmp/ps2servers-edge.before-handoff-trace
+```
+
+Apply the baseline:
+
+```sh
+uci set ps2servers-edge.main.enabled='1'
+uci set ps2servers-edge.main.root='/mnt/ps2'
+uci set ps2servers-edge.main.bind='0.0.0.0'
+uci set ps2servers-edge.main.port='62966'
+uci set ps2servers-edge.main.data_port='0'
+uci set ps2servers-edge.main.protocol='auto'
+uci set ps2servers-edge.main.single_port='0'
+uci set ps2servers-edge.main.read_only='1'
+uci set ps2servers-edge.main.peer_timeout='1h'
+uci set ps2servers-edge.main.tx_delay_ms='0'
+uci set ps2servers-edge.main.log_format='text'
+uci set ps2servers-edge.main.verbose='1'
+uci set ps2servers-edge.main.metrics='1'
+uci set ps2servers-edge.main.metrics_period='1s'
+uci set ps2servers-edge.main.compression_cache_size='32'
+uci commit ps2servers-edge
+/etc/init.d/ps2servers-edge restart
+```
+
+Verify the configuration before touching the PS2:
+
+```sh
+/etc/init.d/ps2servers-edge status
+ps w | grep '[p]s2servers-edge'
+netstat -lnup 2>/dev/null | grep ps2servers-edge
+logread -e ps2servers-edge
+```
+
+The startup line must name `root=/mnt/ps2`, discovery port `62966`, and the
+actual data port. If the process repeatedly exits, read `logread -e
+ps2servers-edge`; `procd` respawns invalid configurations, so a bad value can
+look like an unstable binary.
+
+### Text versus JSON
+
+Use `text` while watching a serial console:
+
+```sh
+uci set ps2servers-edge.main.log_format='text'
+uci commit ps2servers-edge
+/etc/init.d/ps2servers-edge restart
+```
+
+Use `json` when the output will be collected and parsed:
+
+```sh
+uci set ps2servers-edge.main.log_format='json'
+uci commit ps2servers-edge
+/etc/init.d/ps2servers-edge restart
+```
+
+The JSON object is emitted by Edge, but `logread` may prefix it with syslog
+metadata. Capture the whole line rather than assuming the daemon log is a bare
+JSON file.
+
+## Controlled handoff trace
+
+Keep one variable set for the whole run. Do not change protocol mode, port
+topology, pacing, and compression at the same time.
+
+1. In a second terminal, capture the complete live syslog stream for the
+   positive control while displaying only Edge and switch-link events. `tee`
+   writes before `grep`, so the file retains context that is not shown on
+   screen and does not depend on the finite syslog ring still containing the
+   beginning of the run.
+
+   ```sh
+   logread -f | tee /tmp/edge-wle-positive-control.log | grep -E 'ps2servers-edge|link changed'
+   ```
+
+2. In the first terminal, restart Edge so its startup line, counters, and
+   session state all begin inside that live capture.
+
+   ```sh
+   /etc/init.d/ps2servers-edge restart
+   ```
+
+3. Run the wLaunchELF positive control. Browse the UDPFS root that maps to the
+   router's `/mnt/ps2` directory and open or list content.
+
+4. Stop that live capture with Ctrl-C. Then start a second live capture,
+   writing to a different file:
+
+   ```sh
+   logread -f | tee /tmp/edge-nhddl-neutrino-handoff.log | grep -E 'ps2servers-edge|link changed'
+   ```
+
+5. In the first terminal, restart Edge once more to separate the runs and put
+   the new startup line inside the second capture.
+
+   ```sh
+   /etc/init.d/ps2servers-edge restart
+   ```
+
+6. Start `mc0:/APP_NHDDL/nhddl.elf`, select the test game, and let it attempt
+   the Neutrino launch without changing any router setting.
+
+7. Continue recording through the Ethernet link-down event, any link-up event,
+   the return to the Sony Browser, or a successful game open.
+
+8. Stop the second live capture with Ctrl-C, then append runtime state to its
+   file:
+
+   ```sh
+   {
+     date
+     /etc/init.d/ps2servers-edge status
+     ps w | grep '[p]s2servers-edge'
+     netstat -lnup 2>/dev/null | grep ps2servers-edge
+   } >> /tmp/edge-nhddl-neutrino-handoff.log 2>&1
+   ```
+
+Both captures are in the router's RAM-backed `/tmp`; copy them off the router
+before rebooting.
+
+The Rumble Racing file on the A5-V11 host is:
+
+```text
+/mnt/ps2/CD/SLUS_201.74.Rumble Racing.iso
+```
+
+`UDPFS request` logs the client-supplied path before Edge resolves it below the
+configured root. It therefore will not log the `/mnt/ps2` host prefix. For this
+file, expect a relative request such as:
+
+```text
+CD/SLUS_201.74.Rumble Racing.iso
+```
+
+Edge rejects absolute client paths, so a leading `/` is not equivalent. Keep
+the exact observed request in the trace rather than rewriting it to the host
+path. A successful run should show that OPEN attempt followed by READ attempts
+and increasing `bytes_read`, only after Neutrino has restored Ethernet and
+resumed UDPFS.
+
+## Read the trace in stages
+
+### Startup and initial client
+
+| Evidence | What it establishes |
+|---|---|
+| `UDPFS listening` | Edge opened its configured root and UDP sockets |
+| `DISCOVERY received, console found this server` | A discovery datagram reached the Edge process from the shown endpoint |
+| `session negotiated` | In `auto` mode, Edge saw the first payload-bearing DATA exchange and classified the pending profile/response socket; forced profiles do not emit this marker |
+| First UDPFS operation / `OPEN` | The client progressed beyond transport negotiation into filesystem requests |
+| `READ` and increasing `bytes_read` | Edge is actually returning file content |
+
+The initial NHDDL discovery and negotiation are pre-handoff evidence. They do
+not count as post-reset Neutrino traffic.
+
+### The two handoff markers
+
+Only one marker may be applicable to a given reset:
+
+| Marker | Trigger | Meaning |
+|---|---|---|
+| `peer sequence reset (seq 0 received)` | The same PS2 IP:port sends payload-bearing DATA sequence zero when zero is neither the next expected sequence nor its immediately previous sequence | Edge discarded stale stream state and accepted a same-endpoint restart |
+| `replacing stale session for IP` | A packet arrives from the same PS2 IP with a different UDP source port, and the old session has no active write or that write has been quiet for more than one second | Edge removed the old endpoint's worker/session and created one for the new endpoint |
+
+Seeing a marker proves a datagram matching that restart/replacement condition
+reached the corresponding Edge branch. Attribute it to Neutrino after the
+reset only when its timestamp follows the captured launch and link-down
+events. The marker does not, by itself, prove the following file open or game
+boot succeeded. Absence of both markers is not a failed handoff implementation
+when no post-reset datagram was received.
+
+A payload-free control packet does not enter the reset branch. Sequence zero
+is also processed normally when zero is already expected, and it is treated as
+a duplicate/re-ACK when the next expected sequence is one. In those cases raw
+RX and the verbose sequence fields, rather than the reset marker, are the
+decisive packet evidence.
+
+The sequence-reset line includes `expected`, `received`, `profile`, `socket`,
+and `outcome`. The same-IP replacement line includes `old_peer`, `new_peer`,
+both source ports, quiet time, active-write state, eligibility, and `reason`.
+With verbose logging, `same-IP session replacement candidate` also records a
+candidate that was deliberately retained to protect a recent active write.
+
+### Datagram counters versus operation counters
+
+Periodic `UDPFS metrics` lines are cumulative from service start. Raw RX/TX
+counters answer whether packets crossed the process boundary; operation
+counters (`open`, `read`, `dread`, `getstat`, and so on) count recognized
+request attempts dispatched to a handler, including attempts that return an
+error. They establish protocol-layer progress, not operation success. Positive
+`bytes_read` or `bytes_written` establishes actual transferred file data.
+
+The transport and handoff fields are:
+
+| Metrics field | What it counts or records |
+|---|---|
+| `rx_discovery_datagrams`, `rx_discovery_bytes` | Datagrams and bytes read from the discovery socket |
+| `rx_data_datagrams`, `rx_data_bytes` | Datagrams and bytes read from the data socket |
+| `tx_discovery_datagrams`, `tx_discovery_bytes` | Datagrams and bytes successfully sent through the discovery socket |
+| `tx_data_datagrams`, `tx_data_bytes` | Datagrams and bytes successfully sent through the data socket |
+| `tx_send_errors` | UDP sends that returned an error |
+| `malformed_datagrams` | Received datagrams rejected during protocol parsing before application request handling |
+| `sequence_mismatches` | DATA sequence numbers that did not equal the session's next expected value |
+| `sequence_resets` | Same-endpoint sequence-zero handoffs accepted by Edge |
+| `same_ip_replacements` | Old sessions replaced after the same IP appeared from a new source port |
+| `last_rx_peer`, `last_rx_socket` | Endpoint and Edge socket of the most recently read datagram |
+| `last_rx_type`, `last_rx_sequence` | Parsed header values for that datagram, or `unknown` if its header could not be parsed |
+| `last_rx_age` | Time since Edge read that datagram; a growing value makes silence explicit |
+
+The `last_rx_*` fields are absent until the first datagram has been read.
+
+| Pattern | Interpretation |
+|---|---|
+| RX remains unchanged after the NHDDL session and link-down | Edge did not read a later datagram on either UDP socket |
+| Discovery RX grows, data RX does not | Discovery reaches Edge, but the client does not reach the advertised/fixed data path |
+| Data RX grows, but operation counters do not | A datagram arrived; correlate its timestamp with the reset, then inspect header trace, malformed counts, ACK/sequence state, and handoff markers |
+| `malformed_datagrams` grows | A datagram reached Edge but failed protocol parsing |
+| `open` grows, `read` stays zero | A recognized OPEN attempt reached the filesystem layer; inspect the requested path. This build does not decode an OPEN outcome into a log field |
+| `read` and `bytes_read` grow | Edge is serving content; a later boot failure is beyond initial UDPFS reachability |
+| TX grows without later RX | Edge emitted replies locally, but UDP send success does not prove the PS2 received or processed them |
+| Handoff counter/marker grows, then `open` grows | The server exercised the replacement path and a client resumed filesystem work; correlate the timeline before attributing it to Neutrino |
+
+Verbose packet lines are header-level diagnostics. They identify direction,
+socket, peer, packet type, size, sequence, ACK state, and parse failures without
+dumping ISO or save payloads. Disable verbose logging after the controlled run;
+on a transfer it can generate substantially more syslog traffic than the
+periodic metrics alone.
+
+The exact verbose markers are `UDP RX` and `UDP TX`. Each includes `socket`,
+`local`, `peer`, `bytes`, `type`, and `sequence` when the header is parseable.
+A parseable DATA datagram also includes `ack`, `flags`, `header_words`, and
+`data_bytes`. A non-empty `UDP RX` request includes its `opcode`, because Edge
+dispatches byte zero of that inbound payload as the UDPFS operation. On `UDP
+TX`, an opcode is included only when nonzero `header_words` identifies an
+application header; raw ISO/save continuation bytes are never interpreted or
+logged as an opcode. `UDP send failed` carries the same safe header fields plus
+the error. No packet payload is dumped.
+
+`UDPFS request` identifies an application request after valid dispatch. A
+safely decoded OPEN includes `path`, `is_dir`, and `flags`; a READ includes its
+`handle` and requested `size`. This is the line that distinguishes “a DATA
+packet arrived” from “Neutrino asked Edge to open the selected ISO.” It records
+the attempt, not the OPEN reply's result, handle, or size.
+
+## What silence proves—and what it does not
+
+If Edge remains running, its periodic metrics continue, and RX does not change
+after the NHDDL-created session, the defensible statement is:
+
+> No post-negotiation datagram was read by the Edge UDP sockets during the
+> captured interval.
+
+That result proves the sequence-reset, same-IP replacement, and file-open paths
+were not reached. It does **not** prove that:
+
+- Neutrino never attempted to send;
+- a packet was not dropped before reaching the process;
+- the Ethernet PHY/link was up;
+- the PS2 used the expected IP or destination port;
+- a firewall did not discard the packet;
+- the server's handoff logic would fail if a packet reached it.
+
+For the reported A5-V11 failure, the missing post-reset link-up event plus
+unchanged server RX focuses the next investigation on the NHDDL/Neutrino launch,
+IOP/DEV9/SMAP initialization, configuration, or route to the server. It does not
+exercise the Edge handoff branches.
+
+## The wLaunchELF positive control
+
+Browse `/mnt/ps2` through UDPFS from wLaunchELF with the same PS2, cable,
+addresses, router, USB drive, and Edge configuration used for the failing run.
+
+A successful browse proves, at that moment:
+
+- the PS2 Ethernet hardware and physical path can work;
+- `192.168.1.201` can reach the A5-V11 at `192.168.1.200`;
+- Edge discovery and data traffic can cross the network;
+- Edge can read and list the mounted `/mnt/ps2` tree.
+
+It does not prove that NHDDL selected the intended Neutrino ELF, passed a
+complete argument vector, that Neutrino loaded its network IRX modules, or that
+Ethernet returned after Neutrino's reset. Preserve this distinction when
+comparing the positive-control trace to the failing handoff trace.
+
+## One-variable follow-up tests
+
+Run these only after saving the `auto`, dynamic-data-port baseline.
+
+### Single port
+
+```sh
+uci set ps2servers-edge.main.single_port='1'
+uci commit ps2servers-edge
+/etc/init.d/ps2servers-edge restart
+```
+
+This isolates the advertised dynamic data-port path. Return it to `0` before a
+different comparison.
+
+### Fixed data port
+
+```sh
+uci set ps2servers-edge.main.single_port='0'
+uci set ps2servers-edge.main.data_port='62967'
+uci commit ps2servers-edge
+/etc/init.d/ps2servers-edge restart
+```
+
+Allow UDP 62966 and 62967 only from the trusted PS2 LAN. This test keeps the
+two-port protocol shape but removes the per-restart data-port change.
+
+### Forced standard mode
+
+```sh
+uci set ps2servers-edge.main.protocol='standard'
+uci commit ps2servers-edge
+/etc/init.d/ps2servers-edge restart
+```
+
+Use this only to compare against a trace that negotiated `profile=standard` in
+`auto`. Restore `auto` afterward. A forced profile cannot make Neutrino restore
+the Ethernet link or create its first socket.
+
+### Transmit pacing
+
+If packets arrive and large Edge responses show loss/retry symptoms, test a
+small delay such as `0.25` ms, then `1` ms in a separate run:
+
+```sh
+uci set ps2servers-edge.main.tx_delay_ms='0.25'
+uci commit ps2servers-edge
+/etc/init.d/ps2servers-edge restart
+```
+
+Do not use pacing as an explanation for a run where post-reset RX is zero.
+
+## Disable diagnostics and roll back
+
+To keep the current functional settings but stop high-volume diagnostics:
+
+```sh
+uci set ps2servers-edge.main.verbose='0'
+uci set ps2servers-edge.main.metrics='0'
+uci set ps2servers-edge.main.metrics_period='1m'
+uci set ps2servers-edge.main.log_format='text'
+uci commit ps2servers-edge
+/etc/init.d/ps2servers-edge restart
+```
+
+Also restore diagnostic comparison values if they were changed:
+
+```sh
+uci set ps2servers-edge.main.protocol='auto'
+uci set ps2servers-edge.main.single_port='0'
+uci set ps2servers-edge.main.data_port='0'
+uci set ps2servers-edge.main.tx_delay_ms='0'
+uci commit ps2servers-edge
+/etc/init.d/ps2servers-edge restart
+```
+
+To restore the exact pre-trace file saved earlier during the same boot:
+
+```sh
+cp -p /tmp/ps2servers-edge.before-handoff-trace /etc/config/ps2servers-edge
+/etc/init.d/ps2servers-edge restart
+```
+
+The `/tmp` backup is in RAM and disappears at reboot. Copy it somewhere
+persistent first if the diagnostic session will span a reboot.

--- a/native/ps2servers-edge/internal/udpfs/metrics.go
+++ b/native/ps2servers-edge/internal/udpfs/metrics.go
@@ -1,8 +1,12 @@
 package udpfs
 
 import (
+	"net"
 	"sync/atomic"
 	"time"
+
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/protocol"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/session"
 )
 
 // metrics counts protocol operations and bytes moved.
@@ -31,29 +35,143 @@ type metrics struct {
 	bytesRead    atomic.Int64
 	bytesWritten atomic.Int64
 
+	rxDiscoveryDatagrams atomic.Int64
+	rxDiscoveryBytes     atomic.Int64
+	rxDataDatagrams      atomic.Int64
+	rxDataBytes          atomic.Int64
+	txDiscoveryDatagrams atomic.Int64
+	txDiscoveryBytes     atomic.Int64
+	txDataDatagrams      atomic.Int64
+	txDataBytes          atomic.Int64
+	txSendErrors         atomic.Int64
+	malformedDatagrams   atomic.Int64
+	sequenceMismatches   atomic.Int64
+	sequenceResets       atomic.Int64
+	sameIPReplacements   atomic.Int64
+
+	rxOrdinal atomic.Uint64
+	lastRX    atomic.Pointer[lastRXObservation]
+
 	started time.Time
 }
 
-// snapshot renders the counters for one log line. The names match the Python
-// server's stats keys so the two are comparable when diagnosing a transfer that
-// behaves differently on one of them.
+// lastRXObservation is immutable once published through lastRX. Keeping the
+// related fields in one atomic pointer gives a metrics snapshot a coherent
+// peer/socket/header tuple without putting a mutex in the receive path.
+type lastRXObservation struct {
+	ordinal    uint64
+	at         time.Time
+	peer       string
+	socket     session.Socket
+	packetType int
+	sequence   int
+}
+
+func (m *metrics) recordRX(which session.Socket, bytes int, peer *net.UDPAddr, packet []byte) {
+	ordinal := m.rxOrdinal.Add(1)
+	switch which {
+	case session.DiscoverySocket:
+		m.rxDiscoveryDatagrams.Add(1)
+		m.rxDiscoveryBytes.Add(int64(bytes))
+	case session.DataSocket:
+		m.rxDataDatagrams.Add(1)
+		m.rxDataBytes.Add(int64(bytes))
+	}
+
+	peerString := ""
+	if peer != nil {
+		peerString = peer.String()
+	}
+	last := &lastRXObservation{
+		ordinal:    ordinal,
+		at:         time.Now(),
+		peer:       peerString,
+		socket:     which,
+		packetType: -1,
+		sequence:   -1,
+	}
+	if h, err := protocol.ParseHeader(packet); err == nil {
+		last.packetType = int(h.Type)
+		last.sequence = int(h.Sequence)
+	}
+	m.publishLastRX(last)
+}
+
+// publishLastRX keeps the most recently started observation when the two
+// socket read loops finish recordRX out of order. A plain Store allows an older
+// discovery observation that was descheduled to overwrite a newer data one.
+func (m *metrics) publishLastRX(next *lastRXObservation) {
+	for {
+		current := m.lastRX.Load()
+		if current != nil && current.ordinal >= next.ordinal {
+			return
+		}
+		if m.lastRX.CompareAndSwap(current, next) {
+			return
+		}
+	}
+}
+
+func (m *metrics) recordTX(which session.Socket, bytes int) {
+	switch which {
+	case session.DiscoverySocket:
+		m.txDiscoveryDatagrams.Add(1)
+		m.txDiscoveryBytes.Add(int64(bytes))
+	case session.DataSocket:
+		m.txDataDatagrams.Add(1)
+		m.txDataBytes.Add(int64(bytes))
+	}
+}
+
+// snapshot renders the counters for one log line. The operation names match
+// the Python server's stats keys; the transport and handoff fields are
+// Edge-specific diagnostics for traffic that has not reached an operation.
 func (m *metrics) snapshot() map[string]any {
 	elapsed := time.Since(m.started)
 	readBytes := m.bytesRead.Load()
 	fields := map[string]any{
-		"uptime":        elapsed.Truncate(time.Second).String(),
-		"discovery":     m.discovery.Load(),
-		"open":          m.open.Load(),
-		"read":          m.read.Load(),
-		"write":         m.write.Load(),
-		"close":         m.closeOp.Load(),
-		"dread":         m.dread.Load(),
-		"getstat":       m.getstat.Load(),
-		"lseek":         m.lseek.Load(),
-		"bread":         m.bread.Load(),
-		"bwrite":        m.bwrite.Load(),
-		"bytes_read":    readBytes,
-		"bytes_written": m.bytesWritten.Load(),
+		"uptime":                 elapsed.Truncate(time.Second).String(),
+		"discovery":              m.discovery.Load(),
+		"open":                   m.open.Load(),
+		"read":                   m.read.Load(),
+		"write":                  m.write.Load(),
+		"close":                  m.closeOp.Load(),
+		"dread":                  m.dread.Load(),
+		"getstat":                m.getstat.Load(),
+		"lseek":                  m.lseek.Load(),
+		"bread":                  m.bread.Load(),
+		"bwrite":                 m.bwrite.Load(),
+		"bytes_read":             readBytes,
+		"bytes_written":          m.bytesWritten.Load(),
+		"rx_discovery_datagrams": m.rxDiscoveryDatagrams.Load(),
+		"rx_discovery_bytes":     m.rxDiscoveryBytes.Load(),
+		"rx_data_datagrams":      m.rxDataDatagrams.Load(),
+		"rx_data_bytes":          m.rxDataBytes.Load(),
+		"tx_discovery_datagrams": m.txDiscoveryDatagrams.Load(),
+		"tx_discovery_bytes":     m.txDiscoveryBytes.Load(),
+		"tx_data_datagrams":      m.txDataDatagrams.Load(),
+		"tx_data_bytes":          m.txDataBytes.Load(),
+		"tx_send_errors":         m.txSendErrors.Load(),
+		"malformed_datagrams":    m.malformedDatagrams.Load(),
+		"sequence_mismatches":    m.sequenceMismatches.Load(),
+		"sequence_resets":        m.sequenceResets.Load(),
+		"same_ip_replacements":   m.sameIPReplacements.Load(),
+	}
+	if last := m.lastRX.Load(); last != nil {
+		age := time.Since(last.at)
+		if age < 0 {
+			age = 0
+		}
+		fields["last_rx_age"] = age.Truncate(time.Millisecond).String()
+		fields["last_rx_peer"] = last.peer
+		fields["last_rx_socket"] = last.socket
+		if last.packetType < 0 {
+			fields["last_rx_type"] = "unknown"
+			fields["last_rx_sequence"] = "unknown"
+		} else {
+			fields["last_rx_type"] = last.packetType
+			fields["last_rx_sequence"] = last.sequence
+		}
 	}
 	// A rate is what actually tells a slow transfer from a stalled one, which
 	// is the question someone enables metrics to answer.

--- a/native/ps2servers-edge/internal/udpfs/negotiation.go
+++ b/native/ps2servers-edge/internal/udpfs/negotiation.go
@@ -76,6 +76,7 @@ func (s *Server) handleDiscovery(in inbound, h protocol.Header) {
 				"service_id": dh.ServiceID, "service_port": dh.Port,
 			})
 	} else {
+		// Keep seq as the legacy alias for existing structured-log consumers.
 		s.cfg.Log.Debug("DISCOVERY", map[string]any{
 			"peer": in.peer.String(), "socket": in.socket, "seq": h.Sequence, "sequence": h.Sequence,
 			"service_id": dh.ServiceID, "service_port": dh.Port,

--- a/native/ps2servers-edge/internal/udpfs/negotiation.go
+++ b/native/ps2servers-edge/internal/udpfs/negotiation.go
@@ -27,10 +27,27 @@ func (s *Server) handleControl(st *session.State, dh protocol.DataHeader) {
 
 func (s *Server) handleDiscovery(in inbound, h protocol.Header) {
 	if len(in.packet) < 6 {
+		s.stats.malformedDatagrams.Add(1)
+		s.cfg.Log.Debug("dropping invalid DISCOVERY", map[string]any{
+			"peer": inboundPeerString(in.peer), "socket": in.socket, "bytes": len(in.packet), "sequence": h.Sequence,
+			"reason": "truncated discovery header",
+		})
 		return
 	}
 	dh, err := protocol.ParseDiscoveryHeader(in.packet[2:])
-	if err != nil || dh.ServiceID != protocol.ServiceUDPFS {
+	if err != nil {
+		s.stats.malformedDatagrams.Add(1)
+		s.cfg.Log.Debug("dropping invalid DISCOVERY", map[string]any{
+			"peer": inboundPeerString(in.peer), "socket": in.socket, "bytes": len(in.packet), "sequence": h.Sequence,
+			"reason": "malformed discovery header", "error": err,
+		})
+		return
+	}
+	if dh.ServiceID != protocol.ServiceUDPFS {
+		s.cfg.Log.Debug("dropping invalid DISCOVERY", map[string]any{
+			"peer": inboundPeerString(in.peer), "socket": in.socket, "bytes": len(in.packet), "sequence": h.Sequence,
+			"service_id": dh.ServiceID, "service_port": dh.Port, "reason": "unsupported service",
+		})
 		return
 	}
 	// First contact from a console is the most useful line this server emits.
@@ -54,9 +71,15 @@ func (s *Server) handleDiscovery(in inbound, h protocol.Header) {
 	}
 	if !known {
 		s.cfg.Log.Info("DISCOVERY received, console found this server",
-			map[string]any{"peer": in.peer.String()})
+			map[string]any{
+				"peer": in.peer.String(), "socket": in.socket, "sequence": h.Sequence,
+				"service_id": dh.ServiceID, "service_port": dh.Port,
+			})
 	} else {
-		s.cfg.Log.Debug("DISCOVERY", map[string]any{"peer": in.peer.String(), "seq": h.Sequence})
+		s.cfg.Log.Debug("DISCOVERY", map[string]any{
+			"peer": in.peer.String(), "socket": in.socket, "seq": h.Sequence, "sequence": h.Sequence,
+			"service_id": dh.ServiceID, "service_port": dh.Port,
+		})
 	}
 
 	st := w.state
@@ -64,6 +87,10 @@ func (s *Server) handleDiscovery(in inbound, h protocol.Header) {
 	defer st.Mu.Unlock()
 
 	quiet := time.Since(st.LastActivity)
+	s.cfg.Log.Debug("discovery negotiation input", map[string]any{
+		"peer": in.peer.String(), "socket": in.socket, "sequence": h.Sequence,
+		"profile": st.Profile, "streaming": st.Streaming, "quiet": quiet.String(), "known": known,
+	})
 	// Both client families may keep broadcasting sequence-zero discovery while
 	// an established transfer is active. Reply, but never reset that live stream.
 	// A quiet session is treated as a replacement from the same UDP endpoint.
@@ -180,8 +207,22 @@ func (s *Server) sendOn(which session.Socket, p []byte, peer *net.UDPAddr) {
 	if s.cfg.TxDelay > 0 {
 		time.Sleep(s.cfg.TxDelay)
 	}
-	if _, err := conn.WriteToUDP(p, peer); err != nil {
-		s.cfg.Log.Debug("UDP send failed", map[string]any{"peer": peer, "socket": which, "error": err})
+	n, err := conn.WriteToUDP(p, peer)
+	if err != nil {
+		if s.cfg.MetricsPeriod > 0 {
+			s.stats.txSendErrors.Add(1)
+		}
+		fields := datagramTraceFields(conn, which, peer, p, len(p))
+		fields["written_bytes"] = n
+		fields["error"] = err
+		s.cfg.Log.Debug("UDP send failed", fields)
+		return
+	}
+	if s.cfg.MetricsPeriod > 0 {
+		s.stats.recordTX(which, n)
+	}
+	if s.cfg.Log.Verbose {
+		s.cfg.Log.Debug("UDP TX", datagramTraceFields(conn, which, peer, p, n))
 	}
 }
 
@@ -195,7 +236,15 @@ func classify(discovery, first uint16) session.Profile {
 func (s *Server) handleData(st *session.State, in inbound) {
 	h, dh, payload, err := protocol.ParseDataPacket(in.packet)
 	if err != nil {
-		s.cfg.Log.Debug("dropping malformed DATA", map[string]any{"peer": in.peer, "error": err})
+		s.stats.malformedDatagrams.Add(1)
+		fields := map[string]any{
+			"peer": inboundPeerString(in.peer), "socket": in.socket, "bytes": len(in.packet), "error": err,
+		}
+		if parsed, headerErr := protocol.ParseHeader(in.packet); headerErr == nil {
+			fields["type"] = parsed.Type
+			fields["sequence"] = parsed.Sequence
+		}
+		s.cfg.Log.Debug("dropping malformed DATA", fields)
 		return
 	}
 
@@ -222,7 +271,15 @@ func (s *Server) handleData(st *session.State, in inbound) {
 				st.FallbackSent = false
 			}
 		}
-		s.cfg.Log.Info("session negotiated", map[string]any{"peer": in.peer, "profile": st.Profile, "response_socket": st.ResponseSocket})
+		fields := map[string]any{
+			"peer": inboundPeerString(in.peer), "profile": st.Profile, "response_socket": st.ResponseSocket,
+			"discovery_sequence": st.DiscoverySequence, "first_data_sequence": h.Sequence,
+			"ack": dh.AckSequence, "flags": dh.Flags, "data_bytes": dh.DataBytes,
+		}
+		if len(payload) > 0 {
+			fields["opcode"] = payload[0]
+		}
+		s.cfg.Log.Info("session negotiated", fields)
 	} else if !st.Streaming {
 		// Strict diagnostic modes still tolerate either local endpoint. The mode
 		// controls sequence interpretation, not network topology.
@@ -247,7 +304,14 @@ func (s *Server) handleData(st *session.State, in inbound) {
 	}
 
 	if h.Sequence != st.ExpectedReceive {
+		expected := st.ExpectedReceive
+		s.stats.sequenceMismatches.Add(1)
 		if h.Sequence == protocol.Previous(st.ExpectedReceive) {
+			s.cfg.Log.Debug("peer sequence mismatch", map[string]any{
+				"peer": inboundPeerString(in.peer), "socket": in.socket, "profile": st.Profile,
+				"expected": expected, "received": h.Sequence, "ack": dh.AckSequence,
+				"flags": dh.Flags, "outcome": "duplicate_reack",
+			})
 			s.sendACK(st, true)
 			if len(st.TxBuffer) > 0 {
 				s.retransmit(st, st.TxBuffer[0].Sequence)
@@ -262,12 +326,26 @@ func (s *Server) handleData(st *session.State, in inbound) {
 			if prof == "" || prof == session.Pending {
 				prof = session.Standard
 			}
+			s.cfg.Log.Debug("peer sequence mismatch", map[string]any{
+				"peer": inboundPeerString(in.peer), "socket": in.socket, "profile": prof,
+				"expected": expected, "received": h.Sequence, "ack": dh.AckSequence,
+				"flags": dh.Flags, "outcome": "session_reset",
+			})
 			st.Reset(prof)
 			st.ResponseSocket = in.socket
 			st.ExpectedReceive = 0
 			st.Touch()
-			s.cfg.Log.Info("peer sequence reset (seq 0 received)", map[string]any{"peer": in.peer})
+			s.stats.sequenceResets.Add(1)
+			s.cfg.Log.Info("peer sequence reset (seq 0 received)", map[string]any{
+				"peer": inboundPeerString(in.peer), "socket": in.socket, "profile": prof,
+				"expected": expected, "received": h.Sequence, "outcome": "session_reset",
+			})
 		} else {
+			s.cfg.Log.Debug("peer sequence mismatch", map[string]any{
+				"peer": inboundPeerString(in.peer), "socket": in.socket, "profile": st.Profile,
+				"expected": expected, "received": h.Sequence, "ack": dh.AckSequence,
+				"flags": dh.Flags, "outcome": "nack",
+			})
 			s.sendACK(st, false)
 			st.Mu.Unlock()
 			return

--- a/native/ps2servers-edge/internal/udpfs/observability_test.go
+++ b/native/ps2servers-edge/internal/udpfs/observability_test.go
@@ -569,4 +569,31 @@ func TestSameIPSourcePortReplacementInstrumentation(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("stale active write is replaced", func(t *testing.T) {
+		server, logs := newDirectObservabilityServer(true)
+		defer stopDirectWorkers(server)
+		oldPeer := &net.UDPAddr{IP: net.ParseIP("192.0.2.32"), Port: 26200}
+		newPeer := &net.UDPAddr{IP: net.ParseIP("192.0.2.32"), Port: 26201}
+		oldWorker := server.getWorker(oldPeer)
+		oldWorker.state.Mu.Lock()
+		oldWorker.state.WriteActive = true
+		oldWorker.state.LastActivity = time.Now().Add(-2 * sessionReplaceQuiet)
+		oldWorker.state.Mu.Unlock()
+		server.getWorker(newPeer)
+
+		if got := metricInt64(t, server.stats.snapshot(), "same_ip_replacements"); got != 1 {
+			t.Fatalf("same_ip_replacements = %d, want 1", got)
+		}
+		records := parseJSONLogRecords(t, logs.String())
+		candidate := findJSONLogRecord(t, records, "same-IP session replacement candidate", nil)
+		assertJSONField(t, candidate, "old_peer", oldPeer.String())
+		assertJSONField(t, candidate, "new_peer", newPeer.String())
+		assertJSONField(t, candidate, "write_active", true)
+		assertJSONField(t, candidate, "eligible", true)
+		assertJSONField(t, candidate, "reason", "active_write_quiet_over_1s")
+		findJSONLogRecord(t, records, "replacing stale session for IP", func(record map[string]any) bool {
+			return record["reason"] == "active_write_quiet_over_1s" && record["eligible"] == true
+		})
+	})
 }

--- a/native/ps2servers-edge/internal/udpfs/observability_test.go
+++ b/native/ps2servers-edge/internal/udpfs/observability_test.go
@@ -1,0 +1,572 @@
+package udpfs
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	edgelog "github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/protocol"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/session"
+)
+
+// synchronizedLogBuffer permits assertions while the server goroutines are
+// winding down without introducing a race in the test's log capture.
+type synchronizedLogBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (b *synchronizedLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(p)
+}
+
+func (b *synchronizedLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.String()
+}
+
+type observedTestServer struct {
+	server    *Server
+	discovery *net.UDPAddr
+	logs      *synchronizedLogBuffer
+	stop      func()
+}
+
+func startObservedTestServer(t *testing.T, verbose, metricsEnabled bool) *observedTestServer {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "game.iso"), []byte("0123456789abcdef"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logs := &synchronizedLogBuffer{}
+	metricsPeriod := time.Duration(0)
+	if metricsEnabled {
+		metricsPeriod = time.Second
+	}
+	server, err := New(Config{
+		Root: root, Bind: "127.0.0.1", Port: freeUDPPort(t), DataPort: 0,
+		ProtocolMode: session.Standard, PeerTimeout: time.Minute,
+		MetricsPeriod: metricsPeriod,
+		Log:           edgelog.New(logs, "json", false, verbose),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.Listen(); err != nil {
+		t.Fatal(err)
+	}
+	discovery, _ := server.Addr()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- server.Serve(ctx) }()
+
+	var stopOnce sync.Once
+	stop := func() {
+		t.Helper()
+		stopOnce.Do(func() {
+			cancel()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Errorf("Serve: %v", err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Error("server did not stop")
+			}
+		})
+	}
+	t.Cleanup(stop)
+	return &observedTestServer{server: server, discovery: discovery, logs: logs, stop: stop}
+}
+
+func waitForMetric(t *testing.T, snapshot func() map[string]any, key string, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if got := metricInt64(t, snapshot(), key); got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("metric %q did not reach %d; last snapshot: %#v", key, want, snapshot())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func metricInt64(t *testing.T, fields map[string]any, key string) int64 {
+	t.Helper()
+	v, ok := fields[key]
+	if !ok {
+		t.Fatalf("metric %q missing from snapshot: %#v", key, fields)
+	}
+	switch n := v.(type) {
+	case int:
+		return int64(n)
+	case int64:
+		return n
+	case uint16:
+		return int64(n)
+	case float64:
+		return int64(n)
+	default:
+		t.Fatalf("metric %q has non-numeric type %T (%v)", key, v, v)
+		return 0
+	}
+}
+
+func parseJSONLogRecords(t *testing.T, text string) []map[string]any {
+	t.Helper()
+	var records []map[string]any
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("invalid JSON log line %q: %v", line, err)
+		}
+		records = append(records, record)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return records
+}
+
+func findJSONLogRecord(t *testing.T, records []map[string]any, message string, match func(map[string]any) bool) map[string]any {
+	t.Helper()
+	for _, record := range records {
+		if record["message"] == message && (match == nil || match(record)) {
+			return record
+		}
+	}
+	t.Fatalf("log record %q not found in %#v", message, records)
+	return nil
+}
+
+func assertJSONField(t *testing.T, record map[string]any, key string, want any) {
+	t.Helper()
+	got, ok := record[key]
+	if !ok {
+		t.Fatalf("field %q missing from log record: %#v", key, record)
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("field %q = %v, want %v; record: %#v", key, got, want, record)
+	}
+}
+
+func TestRawDatagramMetricsAndLastRXMetadata(t *testing.T) {
+	observed := startObservedTestServer(t, false, true)
+	client, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	request := discoveryPacket(23)
+	if _, err := client.WriteToUDP(request, observed.discovery); err != nil {
+		t.Fatal(err)
+	}
+	reply, replyFrom := recvPacket(t, client)
+	h, err := protocol.ParseHeader(reply)
+	if err != nil || h.Type != protocol.Inform {
+		t.Fatalf("expected INFORM reply, got header=%+v err=%v", h, err)
+	}
+
+	waitForMetric(t, observed.server.stats.snapshot, "tx_data_datagrams", 1)
+	observed.stop()
+	snapshot := observed.server.stats.snapshot()
+	checks := map[string]int64{
+		"rx_discovery_datagrams": 1,
+		"rx_discovery_bytes":     int64(len(request)),
+		"rx_data_datagrams":      0,
+		"rx_data_bytes":          0,
+		"tx_discovery_datagrams": 0,
+		"tx_discovery_bytes":     0,
+		"tx_data_datagrams":      1,
+		"tx_data_bytes":          int64(len(reply)),
+		"tx_send_errors":         0,
+	}
+	for key, want := range checks {
+		if got := metricInt64(t, snapshot, key); got != want {
+			t.Errorf("%s = %d, want %d", key, got, want)
+		}
+	}
+	if got := fmt.Sprint(snapshot["last_rx_peer"]); got != client.LocalAddr().String() {
+		t.Errorf("last_rx_peer = %q, want %q", got, client.LocalAddr())
+	}
+	if got := fmt.Sprint(snapshot["last_rx_socket"]); got != string(session.DiscoverySocket) {
+		t.Errorf("last_rx_socket = %q, want %q", got, session.DiscoverySocket)
+	}
+	if got := metricInt64(t, snapshot, "last_rx_type"); got != int64(protocol.Discovery) {
+		t.Errorf("last_rx_type = %d, want %d", got, protocol.Discovery)
+	}
+	if got := metricInt64(t, snapshot, "last_rx_sequence"); got != 23 {
+		t.Errorf("last_rx_sequence = %d, want 23", got)
+	}
+	if age, ok := snapshot["last_rx_age"].(string); !ok || age == "" {
+		t.Errorf("last_rx_age missing or invalid: %#v", snapshot["last_rx_age"])
+	}
+	if replyFrom.Port == observed.discovery.Port {
+		t.Fatalf("standard INFORM unexpectedly came from discovery port %d", observed.discovery.Port)
+	}
+}
+
+func TestLastRXPublicationRejectsOlderConcurrentObservation(t *testing.T) {
+	var stats metrics
+	newer := &lastRXObservation{
+		ordinal: 2, at: time.Now(), peer: "192.0.2.2:2000",
+		socket: session.DataSocket, packetType: int(protocol.Data), sequence: 8,
+	}
+	older := &lastRXObservation{
+		ordinal: 1, at: newer.at.Add(-time.Millisecond), peer: "192.0.2.1:1000",
+		socket: session.DiscoverySocket, packetType: int(protocol.Discovery), sequence: 7,
+	}
+
+	// Model the discovery read loop starting first, being descheduled, and
+	// completing only after the data read loop has published its observation.
+	olderStarted := make(chan struct{})
+	finishOlder := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		close(olderStarted)
+		<-finishOlder
+		stats.publishLastRX(older)
+	}()
+	<-olderStarted
+	stats.publishLastRX(newer)
+	close(finishOlder)
+	wg.Wait()
+
+	got := stats.lastRX.Load()
+	if got != newer {
+		t.Fatalf("last RX regressed to ordinal %d (%s); want ordinal %d (%s)", got.ordinal, got.peer, newer.ordinal, newer.peer)
+	}
+}
+
+func TestVerboseJSONDatagramTraceContainsHeadersNotPayload(t *testing.T) {
+	observed := startObservedTestServer(t, true, true)
+	client, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	if _, err := client.WriteToUDP(discoveryPacket(0), observed.discovery); err != nil {
+		t.Fatal(err)
+	}
+	_, dataAddr := recvPacket(t, client)
+
+	const payloadMarker = "TRACE_PAYLOAD_MUST_NOT_APPEAR.iso"
+	open := make([]byte, 8)
+	open[0] = byte(protocol.OpenRequest)
+	open = append(open, payloadMarker...)
+	open = append(open, 0)
+	request := dataPacket(0, open)
+	if _, err := client.WriteToUDP(request, dataAddr); err != nil {
+		t.Fatal(err)
+	}
+	replyHeader, _, replyFrom := recvDataPayload(t, client)
+	if _, err := client.WriteToUDP(ackPacket(replyHeader.Sequence), replyFrom); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForMetric(t, observed.server.stats.snapshot, "rx_data_datagrams", 2)
+	observed.stop()
+	records := parseJSONLogRecords(t, observed.logs.String())
+	rx := findJSONLogRecord(t, records, "UDP RX", func(record map[string]any) bool {
+		return fmt.Sprint(record["type"]) == fmt.Sprint(protocol.Data) &&
+			fmt.Sprint(record["opcode"]) == fmt.Sprint(protocol.OpenRequest)
+	})
+	assertJSONField(t, rx, "socket", session.DataSocket)
+	assertJSONField(t, rx, "local", dataAddr.String())
+	assertJSONField(t, rx, "peer", client.LocalAddr().String())
+	assertJSONField(t, rx, "bytes", len(request))
+	assertJSONField(t, rx, "type", protocol.Data)
+	assertJSONField(t, rx, "sequence", 0)
+	assertJSONField(t, rx, "ack", 0)
+	assertJSONField(t, rx, "flags", 0)
+	assertJSONField(t, rx, "header_words", 0)
+	assertJSONField(t, rx, "data_bytes", len(request)-6)
+	assertJSONField(t, rx, "opcode", protocol.OpenRequest)
+	encoded, err := json.Marshal(rx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte(payloadMarker)) {
+		t.Fatalf("UDP header trace leaked payload bytes: %s", encoded)
+	}
+	for _, forbidden := range []string{"payload", "packet", "body"} {
+		if _, ok := rx[forbidden]; ok {
+			t.Errorf("UDP header trace contains forbidden %q field: %#v", forbidden, rx)
+		}
+	}
+	requestLog := findJSONLogRecord(t, records, "UDPFS request", func(record map[string]any) bool {
+		return record["operation"] == "OPEN"
+	})
+	assertJSONField(t, requestLog, "path", payloadMarker)
+	assertJSONField(t, requestLog, "is_dir", false)
+	assertJSONField(t, requestLog, "flags", 0)
+
+	tx := findJSONLogRecord(t, records, "UDP TX", func(record map[string]any) bool {
+		return fmt.Sprint(record["type"]) == fmt.Sprint(protocol.Inform)
+	})
+	assertJSONField(t, tx, "socket", session.DataSocket)
+	assertJSONField(t, tx, "local", dataAddr.String())
+	assertJSONField(t, tx, "peer", client.LocalAddr().String())
+	assertJSONField(t, tx, "type", protocol.Inform)
+	assertJSONField(t, tx, "sequence", 1)
+	if metricInt64(t, tx, "bytes") <= 0 {
+		t.Fatalf("UDP TX byte count is not positive: %#v", tx)
+	}
+}
+
+func TestSentContinuationTraceDoesNotExposePayloadByteAsOpcode(t *testing.T) {
+	packet := dataPacket(7, []byte{byte(protocol.OpenRequest), 0xaa, 0xbb, 0xcc})
+
+	tx := datagramTraceFields(nil, session.DataSocket, nil, packet, len(packet))
+	if opcode, ok := tx["opcode"]; ok {
+		t.Fatalf("TX continuation exposed payload byte as opcode: %v", opcode)
+	}
+
+	rx := receivedDatagramTraceFields(nil, session.DataSocket, nil, packet, len(packet))
+	assertJSONField(t, rx, "opcode", protocol.OpenRequest)
+}
+
+func TestVerboseOffSuppressesDatagramTrace(t *testing.T) {
+	observed := startObservedTestServer(t, false, true)
+	client, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	if _, err := client.WriteToUDP(discoveryPacket(4), observed.discovery); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = recvPacket(t, client)
+	waitForMetric(t, observed.server.stats.snapshot, "tx_data_datagrams", 1)
+	observed.stop()
+
+	records := parseJSONLogRecords(t, observed.logs.String())
+	findJSONLogRecord(t, records, "UDPFS listening", nil)
+	for _, record := range records {
+		if record["message"] == "UDP RX" || record["message"] == "UDP TX" {
+			t.Fatalf("verbose-off server emitted packet trace: %#v", record)
+		}
+	}
+}
+
+func TestMetricsOffSkipsRawTransportObservation(t *testing.T) {
+	observed := startObservedTestServer(t, false, false)
+	client, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	if _, err := client.WriteToUDP(discoveryPacket(9), observed.discovery); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = recvPacket(t, client)
+	observed.stop()
+
+	snapshot := observed.server.stats.snapshot()
+	if got := metricInt64(t, snapshot, "rx_discovery_datagrams"); got != 0 {
+		t.Fatalf("rx_discovery_datagrams = %d with metrics off, want 0", got)
+	}
+	if _, ok := snapshot["last_rx_peer"]; ok {
+		t.Fatalf("last_rx_peer recorded with metrics off: %#v", snapshot)
+	}
+}
+
+func TestSafePathForLogRejectsControlAndSeparatorCharacters(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "ASCII control", path: "game\nname.iso"},
+		{name: "Unicode format control", path: "game\u202ename.iso"},
+		{name: "Unicode line separator", path: "game\u2028name.iso"},
+		{name: "Unicode paragraph separator", path: "game\u2029name.iso"},
+		{name: "invalid UTF-8", path: string([]byte{'g', 'a', 'm', 'e', 0xff})},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, ok := safePathForLog(tc.path); ok {
+				t.Fatalf("safePathForLog(%q) = %q, true; want rejection", tc.path, got)
+			}
+		})
+	}
+}
+
+func newDirectObservabilityServer(verbose bool) (*Server, *synchronizedLogBuffer) {
+	logs := &synchronizedLogBuffer{}
+	server := &Server{
+		cfg: Config{
+			ProtocolMode: session.Standard,
+			Log:          edgelog.New(logs, "json", false, verbose),
+		},
+		sessions: make(map[string]*peerWorker),
+		closed:   make(chan struct{}),
+	}
+	server.stats.started = time.Now()
+	return server, logs
+}
+
+func TestSequenceMismatchAndResetCountersAndEvents(t *testing.T) {
+	server, logs := newDirectObservabilityServer(true)
+	peer := &net.UDPAddr{IP: net.ParseIP("192.0.2.10"), Port: 25000}
+
+	nackState := session.New(peer, session.Standard)
+	nackState.Streaming = true
+	nackState.ExpectedReceive = 5
+	server.handleData(nackState, inbound{
+		packet: dataPacket(3, []byte{0xff}),
+		peer:   peer,
+		socket: session.DataSocket,
+	})
+
+	resetState := session.New(peer, session.Standard)
+	resetState.Streaming = true
+	resetState.ExpectedReceive = 5
+	server.handleData(resetState, inbound{
+		packet: dataPacket(0, []byte{0xff}),
+		peer:   peer,
+		socket: session.DataSocket,
+	})
+
+	snapshot := server.stats.snapshot()
+	if got := metricInt64(t, snapshot, "sequence_mismatches"); got != 2 {
+		t.Fatalf("sequence_mismatches = %d, want 2", got)
+	}
+	if got := metricInt64(t, snapshot, "sequence_resets"); got != 1 {
+		t.Fatalf("sequence_resets = %d, want 1", got)
+	}
+
+	records := parseJSONLogRecords(t, logs.String())
+	nack := findJSONLogRecord(t, records, "peer sequence mismatch", func(record map[string]any) bool {
+		return record["outcome"] == "nack"
+	})
+	assertJSONField(t, nack, "peer", peer.String())
+	assertJSONField(t, nack, "socket", session.DataSocket)
+	assertJSONField(t, nack, "profile", session.Standard)
+	assertJSONField(t, nack, "expected", 5)
+	assertJSONField(t, nack, "received", 3)
+	assertJSONField(t, nack, "ack", 0)
+	assertJSONField(t, nack, "flags", 0)
+
+	reset := findJSONLogRecord(t, records, "peer sequence mismatch", func(record map[string]any) bool {
+		return record["outcome"] == "session_reset"
+	})
+	assertJSONField(t, reset, "expected", 5)
+	assertJSONField(t, reset, "received", 0)
+	findJSONLogRecord(t, records, "peer sequence reset (seq 0 received)", func(record map[string]any) bool {
+		return record["outcome"] == "session_reset" && fmt.Sprint(record["expected"]) == "5" && fmt.Sprint(record["received"]) == "0"
+	})
+}
+
+func TestMalformedDatagramCounter(t *testing.T) {
+	server, logs := newDirectObservabilityServer(true)
+	peer := &net.UDPAddr{IP: net.ParseIP("192.0.2.20"), Port: 25001}
+	server.dispatch(inbound{packet: []byte{0x02}, peer: peer, socket: session.DataSocket})
+
+	if got := metricInt64(t, server.stats.snapshot(), "malformed_datagrams"); got != 1 {
+		t.Fatalf("malformed_datagrams = %d, want 1", got)
+	}
+	record := findJSONLogRecord(t, parseJSONLogRecords(t, logs.String()), "dropping malformed datagram", nil)
+	assertJSONField(t, record, "peer", peer.String())
+	assertJSONField(t, record, "socket", session.DataSocket)
+	assertJSONField(t, record, "bytes", 1)
+}
+
+func stopDirectWorkers(server *Server) {
+	server.sessionsMu.Lock()
+	workers := make([]*peerWorker, 0, len(server.sessions))
+	for _, worker := range server.sessions {
+		workers = append(workers, worker)
+	}
+	server.sessions = make(map[string]*peerWorker)
+	server.sessionsMu.Unlock()
+	for _, worker := range workers {
+		worker.stop()
+	}
+	server.wg.Wait()
+	for _, worker := range workers {
+		worker.state.Close()
+	}
+}
+
+func TestSameIPSourcePortReplacementInstrumentation(t *testing.T) {
+	t.Run("eligible replacement", func(t *testing.T) {
+		server, logs := newDirectObservabilityServer(true)
+		defer stopDirectWorkers(server)
+		oldPeer := &net.UDPAddr{IP: net.ParseIP("192.0.2.30"), Port: 26000}
+		newPeer := &net.UDPAddr{IP: net.ParseIP("192.0.2.30"), Port: 26001}
+		server.getWorker(oldPeer)
+		server.getWorker(newPeer)
+
+		if got := metricInt64(t, server.stats.snapshot(), "same_ip_replacements"); got != 1 {
+			t.Fatalf("same_ip_replacements = %d, want 1", got)
+		}
+		records := parseJSONLogRecords(t, logs.String())
+		candidate := findJSONLogRecord(t, records, "same-IP session replacement candidate", nil)
+		assertJSONField(t, candidate, "old_peer", oldPeer.String())
+		assertJSONField(t, candidate, "new_peer", newPeer.String())
+		assertJSONField(t, candidate, "old_source_port", oldPeer.Port)
+		assertJSONField(t, candidate, "new_source_port", newPeer.Port)
+		assertJSONField(t, candidate, "write_active", false)
+		assertJSONField(t, candidate, "eligible", true)
+		assertJSONField(t, candidate, "reason", "no_active_write")
+		findJSONLogRecord(t, records, "replacing stale session for IP", func(record map[string]any) bool {
+			return record["reason"] == "no_active_write" && record["eligible"] == true
+		})
+	})
+
+	t.Run("recent active write is retained", func(t *testing.T) {
+		server, logs := newDirectObservabilityServer(true)
+		defer stopDirectWorkers(server)
+		oldPeer := &net.UDPAddr{IP: net.ParseIP("192.0.2.31"), Port: 26100}
+		newPeer := &net.UDPAddr{IP: net.ParseIP("192.0.2.31"), Port: 26101}
+		oldWorker := server.getWorker(oldPeer)
+		oldWorker.state.Mu.Lock()
+		oldWorker.state.WriteActive = true
+		oldWorker.state.LastActivity = time.Now()
+		oldWorker.state.Mu.Unlock()
+		server.getWorker(newPeer)
+
+		if got := metricInt64(t, server.stats.snapshot(), "same_ip_replacements"); got != 0 {
+			t.Fatalf("same_ip_replacements = %d, want 0", got)
+		}
+		records := parseJSONLogRecords(t, logs.String())
+		candidate := findJSONLogRecord(t, records, "same-IP session replacement candidate", nil)
+		assertJSONField(t, candidate, "old_peer", oldPeer.String())
+		assertJSONField(t, candidate, "new_peer", newPeer.String())
+		assertJSONField(t, candidate, "write_active", true)
+		assertJSONField(t, candidate, "eligible", false)
+		assertJSONField(t, candidate, "reason", "active_write_recent")
+		for _, record := range records {
+			if record["message"] == "replacing stale session for IP" {
+				t.Fatalf("recent active-write session was reported as replaced: %#v", record)
+			}
+		}
+	})
+}

--- a/native/ps2servers-edge/internal/udpfs/operations.go
+++ b/native/ps2servers-edge/internal/udpfs/operations.go
@@ -14,9 +14,12 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"unicode"
+	"unicode/utf8"
 )
 
 func (s *Server) handleMessage(st *session.State, p []byte) {
+	s.logRequest(st, p)
 	// Counters are incremented at dispatch so one request counts once,
 	// regardless of how a handler exits. WriteData is not counted separately:
 	// a write is one operation however many chunks carry it, which is how the
@@ -55,6 +58,75 @@ func (s *Server) handleMessage(st *session.State, p []byte) {
 		s.cfg.Log.Debug("unknown UDPFS opcode", map[string]any{"peer": st.Peer, "opcode": p[0]})
 	}
 }
+
+// logRequest emits only decoded request metadata. In particular, READ logs the
+// handle and requested byte count, never returned file data, and OPEN includes
+// a path only when it is valid UTF-8 without log-control characters.
+func (s *Server) logRequest(st *session.State, p []byte) {
+	if !s.cfg.Log.Verbose || len(p) == 0 {
+		return
+	}
+	opcode := protocol.MessageType(p[0])
+	fields := map[string]any{"peer": inboundPeerString(st.Peer), "opcode": p[0]}
+	switch opcode {
+	case protocol.OpenRequest:
+		fields["operation"] = "OPEN"
+		if len(p) >= 8 {
+			fields["is_dir"] = p[1] != 0
+			fields["flags"] = binary.LittleEndian.Uint16(p[2:4])
+			if path, err := cString(p[8:]); err == nil {
+				if safe, ok := safePathForLog(path); ok {
+					fields["path"] = safe
+				} else {
+					fields["path_omitted"] = true
+				}
+			}
+		}
+	case protocol.CloseRequest:
+		fields["operation"] = "CLOSE"
+	case protocol.ReadRequest:
+		fields["operation"] = "READ"
+		if len(p) >= 12 {
+			fields["handle"] = int32(binary.LittleEndian.Uint32(p[4:8]))
+			fields["size"] = binary.LittleEndian.Uint32(p[8:12])
+		}
+	case protocol.WriteRequest:
+		fields["operation"] = "WRITE"
+	case protocol.WriteData:
+		fields["operation"] = "WRITE_DATA"
+	case protocol.BReadRequest:
+		fields["operation"] = "BREAD"
+	case protocol.BWriteRequest:
+		fields["operation"] = "BWRITE"
+	case protocol.SeekRequest:
+		fields["operation"] = "LSEEK"
+	case protocol.DReadRequest:
+		fields["operation"] = "DREAD"
+	case protocol.GetStatRequest:
+		fields["operation"] = "GETSTAT"
+	default:
+		fields["operation"] = "UNKNOWN"
+	}
+	s.cfg.Log.Debug("UDPFS request", fields)
+}
+
+func safePathForLog(path string) (string, bool) {
+	if !utf8.ValidString(path) {
+		return "", false
+	}
+	for _, r := range path {
+		if unicode.IsControl(r) || unicode.In(r, unicode.Cf, unicode.Zl, unicode.Zp) {
+			return "", false
+		}
+	}
+	const maxRunes = 256
+	if utf8.RuneCountInString(path) > maxRunes {
+		runes := []rune(path)
+		path = string(runes[:maxRunes]) + "..."
+	}
+	return path, true
+}
+
 func cString(b []byte) (string, error) {
 	if idx := bytes.IndexByte(b, 0); idx >= 0 {
 		b = b[:idx]

--- a/native/ps2servers-edge/internal/udpfs/server.go
+++ b/native/ps2servers-edge/internal/udpfs/server.go
@@ -315,6 +315,16 @@ func (s *Server) readLoop(conn *net.UDPConn, which session.Socket) {
 				continue
 			}
 		}
+		// Under --metrics, record the datagram; under --verbose, describe it
+		// before it can be queued behind another peer's work. This is the
+		// closest observable boundary to the kernel receive: if the trace never
+		// appears after a console-side reset, no UDPFS datagram reached Edge.
+		if s.cfg.MetricsPeriod > 0 {
+			s.stats.recordRX(which, n, peer, buf[:n])
+		}
+		if s.cfg.Log.Verbose {
+			s.cfg.Log.Debug("UDP RX", receivedDatagramTraceFields(conn, which, peer, buf[:n], n))
+		}
 		pkt := append([]byte(nil), buf[:n]...)
 		select {
 		case s.incoming <- inbound{pkt, peer, which}:
@@ -374,6 +384,7 @@ func (s *Server) getWorker(peer *net.UDPAddr) *peerWorker {
 	if !peer.IP.IsLoopback() {
 		var oldKey string
 		var oldWorker *peerWorker
+		var replacementFields map[string]any
 		now := time.Now()
 		for k, w := range s.sessions {
 			if w.state != nil && w.state.Peer != nil && w.state.Peer.IP.Equal(peer.IP) {
@@ -381,15 +392,36 @@ func (s *Server) getWorker(peer *net.UDPAddr) *peerWorker {
 				quiet := now.Sub(w.state.LastActivity)
 				writeActive := w.state.WriteActive
 				w.state.Mu.Unlock()
-				if !writeActive || quiet > time.Second {
+				eligible := !writeActive || quiet > sessionReplaceQuiet
+				reason := "active_write_recent"
+				if !writeActive {
+					reason = "no_active_write"
+				} else if eligible {
+					reason = "active_write_quiet_over_1s"
+				}
+				candidateFields := map[string]any{
+					"ip":              peerIP,
+					"old_peer":        k,
+					"new_peer":        key,
+					"old_source_port": w.state.Peer.Port,
+					"new_source_port": peer.Port,
+					"quiet":           quiet.String(),
+					"write_active":    writeActive,
+					"eligible":        eligible,
+					"reason":          reason,
+				}
+				s.cfg.Log.Debug("same-IP session replacement candidate", candidateFields)
+				if eligible {
 					oldKey = k
 					oldWorker = w
+					replacementFields = candidateFields
 					break
 				}
 			}
 		}
 		if oldWorker != nil {
-			s.cfg.Log.Info("replacing stale session for IP", map[string]any{"ip": peerIP, "old_peer": oldKey, "new_peer": key})
+			s.cfg.Log.Info("replacing stale session for IP", replacementFields)
+			s.stats.sameIPReplacements.Add(1)
 			delete(s.sessions, oldKey)
 			oldWorker.state.Mu.Lock()
 			oldWorker.state.Close()
@@ -414,6 +446,13 @@ func (s *Server) getWorker(peer *net.UDPAddr) *peerWorker {
 	st.ReleaseWriter = s.releaseWriter
 	w := &peerWorker{state: st, queue: make(chan inbound, 256), done: make(chan struct{})}
 	s.sessions[key] = w
+	s.cfg.Log.Debug("session created", map[string]any{
+		"peer":                key,
+		"ip":                  peerIP,
+		"source_port":         peer.Port,
+		"profile":             st.Profile,
+		"configured_protocol": s.cfg.ProtocolMode,
+	})
 	s.wg.Add(1)
 	go s.worker(w)
 	return w
@@ -432,7 +471,10 @@ func (s *Server) worker(w *peerWorker) {
 func (s *Server) dispatch(in inbound) {
 	h, err := protocol.ParseHeader(in.packet)
 	if err != nil {
-		s.cfg.Log.Debug("dropping malformed datagram", map[string]any{"peer": in.peer, "error": err})
+		s.stats.malformedDatagrams.Add(1)
+		s.cfg.Log.Debug("dropping malformed datagram", map[string]any{
+			"peer": inboundPeerString(in.peer), "socket": in.socket, "bytes": len(in.packet), "error": err,
+		})
 		return
 	}
 	switch h.Type {
@@ -465,6 +507,64 @@ func (s *Server) dispatch(in inbound) {
 			s.cfg.Log.Warn("peer queue full", map[string]any{"peer": in.peer})
 		}
 	default:
-		s.cfg.Log.Debug("unknown packet type", map[string]any{"peer": in.peer, "type": h.Type})
+		s.cfg.Log.Debug("unknown packet type", map[string]any{
+			"peer": inboundPeerString(in.peer), "socket": in.socket, "bytes": len(in.packet), "type": h.Type, "sequence": h.Sequence,
+		})
 	}
+}
+
+// datagramTraceFields extracts transport and protocol headers only. On a sent
+// packet, HeaderWords is the wire-level proof that the payload begins with an
+// application header; continuation data with HeaderWords == 0 is never treated
+// as an opcode, even when its first content byte happens to equal one.
+func datagramTraceFields(conn *net.UDPConn, which session.Socket, peer *net.UDPAddr, packet []byte, bytes int) map[string]any {
+	local := ""
+	if conn != nil && conn.LocalAddr() != nil {
+		local = conn.LocalAddr().String()
+	}
+	peerString := ""
+	if peer != nil {
+		peerString = peer.String()
+	}
+	fields := map[string]any{
+		"socket": which,
+		"local":  local,
+		"peer":   peerString,
+		"bytes":  bytes,
+	}
+	h, err := protocol.ParseHeader(packet)
+	if err != nil {
+		return fields
+	}
+	fields["type"] = h.Type
+	fields["sequence"] = h.Sequence
+	if h.Type != protocol.Data {
+		return fields
+	}
+	_, dh, payload, err := protocol.ParseDataPacket(packet)
+	if err != nil {
+		return fields
+	}
+	fields["ack"] = dh.AckSequence
+	fields["flags"] = dh.Flags
+	fields["header_words"] = dh.HeaderWords
+	fields["data_bytes"] = dh.DataBytes
+	if dh.HeaderWords > 0 && len(payload) > 0 {
+		fields["opcode"] = payload[0]
+	}
+	return fields
+}
+
+// receivedDatagramTraceFields adds the request opcode for an inbound DATA
+// payload. The receive path hands every non-empty payload to handleMessage,
+// where byte zero is the UDPFS opcode even though clients encode request bytes
+// under DataBytes rather than HeaderWords. Keeping this receive-only prevents
+// outgoing ISO/save continuation bytes from being exposed as fake opcodes.
+func receivedDatagramTraceFields(conn *net.UDPConn, which session.Socket, peer *net.UDPAddr, packet []byte, bytes int) map[string]any {
+	fields := datagramTraceFields(conn, which, peer, packet, bytes)
+	h, _, payload, err := protocol.ParseDataPacket(packet)
+	if err == nil && h.Type == protocol.Data && len(payload) > 0 {
+		fields["opcode"] = payload[0]
+	}
+	return fields
 }


### PR DESCRIPTION
## What

- Add verbose `UDP RX` / `UDP TX` header traces at the socket boundary, including endpoint, socket, packet type, sequence, ACK/flags, lengths, and safe request opcode metadata.
- Extend periodic metrics with per-socket RX/TX datagram and byte counts, send errors, malformed packets, sequence decisions, same-IP replacements, and coherent `last_rx_*` state.
- Add safe application-request logs for OPEN and READ without dumping ISO/save payloads.
- Document the complete Edge CLI/environment/UCI map, OpenWrt service commands, and a controlled NHDDL-to-Neutrino handoff trace procedure.

## Why

The A5-V11 report proves that Edge can serve the router and that NHDDL can discover and negotiate UDPFS, but the Ethernet link then goes down during the Neutrino handoff and no later filesystem operation appears. Existing logs begin after protocol milestones, so they cannot distinguish process-boundary silence from a datagram that arrived and was rejected by parsing, sequence handling, or session replacement.

This change instruments the earliest observable Edge boundary. It can prove whether a later datagram reached either UDP socket and how Edge classified it. It deliberately does not claim to explain a PS2-side link failure before a packet reaches the process.

## Safety and impact

- No UDPFS wire behavior, retry policy, pacing, session eligibility, filesystem result, or default option changes.
- Packet traces remain gated by existing `--verbose`; raw transport counters and `last_rx_*` updates remain gated by existing `--metrics`.
- No packet payload is dumped. TX continuation data cannot be mislabeled as an opcode, and logged OPEN paths reject control/format characters and are length-limited.
- Concurrent discovery/data observations use monotonic publication so `last_rx_*` cannot regress to an older packet.
- Existing marker text is preserved for operators and scripts.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `go test -race ./internal/udpfs -count=1`
- `python -m unittest discover tests` — 464 passed, 4 skipped
- UDPFS pathguard, compression, and multiclient self-tests
- release-compliance check
- Go formatting and staged diff checks

## Related

- Companion RiptOPL NBD modal-underlay PR: https://github.com/NathanNeurotic/Open-PS2-Loader/pull/341


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed UDPFS transport, negotiation, session, and request diagnostics.
  * Added metrics for datagrams, bytes, errors, malformed packets, sequence issues, session replacements, and latest packet details.
  * Added safe verbose tracing that omits sensitive or unsafe path and payload data.

* **Documentation**
  * Added comprehensive OpenWrt operations and troubleshooting guidance.
  * Linked to OpenWrt command references and NHDDL-to-Neutrino diagnostic procedures.

* **Tests**
  * Added coverage for metrics, tracing, malformed packets, sequence handling, redaction, and session replacement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->