### PR TITLE
docs(edge): include INSTRUCTIONS.md operator manual in Edge packages and repository

### DIFF
--- a/.github/workflows/edge-build.yml
+++ b/.github/workflows/edge-build.yml
@@ -346,10 +346,10 @@ jobs:
             printf '                   in Edge builds -- CHD needs a native\n'
             printf '                   library that would break static linking.\n'
             printf '                   Use the Desktop (Python) server for CHD.\n'
-            printf '  Access         : read-only by default. Pass\n'
-            printf '                   --read-only=false to allow the console to\n'
-            printf '                   write (saves). Only one client may hold a\n'
-            printf '                   given file open for writing at a time.\n\n'
+            printf '  Access         : read-write by default. Pass --read-only\n'
+            printf '                   to restrict clients to read-only access.\n'
+            printf '                   Only one client may hold a given file open\n'
+            printf '                   for writing at a time.\n\n'
             printf 'QUICK START\n\n'
             if [ "${GOOS_V}" = "windows" ]; then
               printf '    %s udpfs --root D:\\PS2Games\n\n' "${binary}"

--- a/.github/workflows/edge-build.yml
+++ b/.github/workflows/edge-build.yml
@@ -309,6 +309,8 @@ jobs:
           mv "out/stage/${binary}" "out/${package}/${binary}"
           chmod +x "out/${package}/${binary}"
           cp native/ps2servers-edge/README.md "out/${package}/README.md"
+          cp docs/INSTRUCTIONS.md "out/${package}/INSTRUCTIONS.md"
+          cp docs/INSTRUCTIONS.md "out/${package}/instructions.md"
           cp docs/EDGE.md docs/EDGE-WHICH-BUILD.md docs/PROTOCOL-COMPATIBILITY.md \
              docs/EDITIONS.md "out/${package}/"
           cp THIRD_PARTY_NOTICES.md "out/${package}/licenses/THIRD_PARTY_NOTICES.md"

--- a/PICKUP-FROM-HERE.md
+++ b/PICKUP-FROM-HERE.md
@@ -1,0 +1,135 @@
+# PICKUP FROM HERE
+
+Handoff note written 2026-07-29 at the end of a long session. Read this before
+starting work; it will save you rediscovering things the hard way.
+
+---
+
+## Where everything is
+
+| | |
+|---|---|
+| **Local repo** | `C:\Users\natha\Github\PS2-Servers` |
+| Main clone's checked-out branch | `feat/ps2-servers-edge` (stale; don't assume it's current) |
+| **Worktree used this session** | `C:\Users\natha\Github\PS2-Servers\.claude\worktrees\sleepy-euclid-f7a6f0` |
+| GitHub | `NathanNeurotic/PS2-Servers` |
+| Memory | `C:\Users\natha\.claude\projects\C--Users-natha-Github-PS2-Servers\memory\` |
+
+Other worktrees exist (`git worktree list`) — several are stale. **`main` is the
+source of truth**, not whatever a worktree has checked out.
+
+## State right now
+
+- **`main` = `4010459`**, zero open PRs, working tree clean.
+- **Version is still `0.4.9`** in `launcher/release_metadata.py`. *Do not bump it.*
+- Latest rolling build: `main-138-4010459`.
+- Full suite green: **316 Python tests**, **7 Go packages under `-race`**.
+- Edge mipsle binary: **3.31 MB**.
+
+## What shipped this session (6 PRs, all merged)
+
+| PR | What |
+|---|---|
+| [#143](https://github.com/NathanNeurotic/PS2-Servers/pull/143) | Edge sized for 32 MB routers |
+| [#144](https://github.com/NathanNeurotic/PS2-Servers/pull/144) | Router status handshake + launcher consumer |
+| [#145](https://github.com/NathanNeurotic/PS2-Servers/pull/145) | systemd units for the Python servers |
+| [#146](https://github.com/NathanNeurotic/PS2-Servers/pull/146) | **Edge SMBv1 server** |
+| [#147](https://github.com/NathanNeurotic/PS2-Servers/pull/147) | udpfs shutdown data race |
+| [#148](https://github.com/NathanNeurotic/PS2-Servers/pull/148) | Edge packaging can start smb/udpbd; smb+udpbd answer status |
+
+Headline: **Edge now serves all three protocols** (`udpfs`, `udpbd`, `smb`) as
+subcommands on one binary, and its OpenWrt/systemd packaging can start each.
+
+## THE ONE THING THAT MATTERS NEXT
+
+**None of it has run on a real console.** Everything since `a0f432c` is
+measurement and arithmetic on a dev machine. The release has been blocked on
+hardware testing, not code, for over a week.
+
+Two testers are live — the first real router testers this project has had:
+
+- **FatBaldDad** — building [PS2-EtherDrive](https://github.com/FatBaldDad/PS2-EtherDrive)
+  hardware around the **A5-V11, HLK-7628N and MT7621A**. All three take the
+  **same `linux-mipsle` build**. Point him at **listing a folder of CSOs**
+  specifically — that was the OOM path #143 fixed — and at SMB, which has never
+  touched a console.
+- **V3ditata / venao** — TP-Link Archer AX72, stock firmware, so he *cannot*
+  run Edge. His SMB got slow for the PS2 only. Diagnosis: **OPL's SMB reads
+  8 KB at a time, serially**, so throughput is round-trip latency, not
+  bandwidth — which is why his laptop is unaffected. Suspect the router's
+  media/DLNA indexer or fragmentation after he extracted a 7z onto the share.
+  His fix today is running PS2-Servers on his notebook, ideally **UDPFS not
+  SMB** (UDPFS pipelines 8 in flight; OPL's SMB does one at a time).
+
+**When reports come back clean, v0.5.0 is a version bump and a tag. No code.**
+
+## Suggested next work, in order
+
+1. **Wait for hardware results.** Everything below is speculative until then,
+   and could be wasted if the reports are bad.
+2. `feat/smb2-smb3` — parked, **local only, never pushed**. Two commits: a path
+   guard and an NTLMv2 auth core, nothing wired together. Deprioritised
+   deliberately: Edge SMBv1 covers OPL/POPSTARTER, which was the actual demand.
+   SMB2/3 serves modern Windows clients browsing the share — real, but nobody
+   has asked.
+3. `internal/udpbd`'s `TestReadsMatchTheImageAcrossBlockRegimes` fails under
+   `-count=3` **on main**, passes isolated. CI runs `-count=1` so it never
+   sees it. Symptom is a UDP timeout, not a race — likely a fixed port or a
+   timing assumption. Noted in #147, not fixed.
+
+## Local branches — all merged content, safe to delete
+
+`feat/router-status`, `fix/edge-memory-32mb`, `feat/systemd-python-servers`,
+`feat/edge-smb`, `feat/edge-service-modes` were **squash-merged**, so
+`git log main..<branch>` still shows commits even though the content is in.
+Diff them against `origin/main` to confirm before deleting.
+
+**`feat/smb2-smb3` is the exception** — genuinely unmerged and unpushed.
+
+---
+
+## Hard-won lessons — please read
+
+**A green CI badge can mean nothing was reviewed.** CodeRabbit was
+*rate-limited* on #146 and #147 and the check still reported "pass". I nearly
+merged 900 lines of protocol code on the strength of it. An independent review
+then found a blocker. **Check whether the bot actually ran.**
+
+**Port from `smbv1_server/smbserver_opl.py`, never from the SMB spec.** That
+file is what consoles have actually been tested against. Its comments record
+real hardware findings. Examples that are load-bearing, not style:
+- NEGOTIATE must return **exactly 17 words** or OPL retries forever.
+- READ_ANDX `DataOffset` must be **59**; OPL reads from there unconditionally.
+- FIND_NEXT2's params are **8 bytes with no leading SID**; FIND_FIRST2's are 10.
+- The header NTSTATUS is **not** a LE uint32 at offset 5 — it's the legacy
+  ErrorClass/ErrorCode split, and it is *lossy*. A test pins the lossy
+  behaviour, because the "obvious" fix changes the wire.
+
+**Python slicing clamps; Go slicing panics.** The reference leans on that.
+Every ported offset goes through a bounds-checked helper.
+
+**`int` is 32 bits on the targets that matter** (mipsle/mips/arm/386). A
+`int(lo)|int(hi)<<16` wrapped negative and produced a silent short read with
+`STATUS_SUCCESS`. Reproduced with `GOARCH=386 go test`. Use that.
+
+**`MaxMessage` bounds a message, not what a handler remembers.** Three
+per-connection maps were unbounded; 2000 requests grew the heap 80 MiB.
+
+**Check that tests catch what they claim.** Three of mine matched too narrowly
+and passed against the very bug they existed for. Mutate the code and watch the
+test fail before trusting it.
+
+**Read the reference before designing.** Twice, a design question I raised had
+its answer already in the code, and the evidence pointed at the *simpler*
+option — reads are already clamped to 64 KiB, and the port question was about
+Linux privilege, not Windows.
+
+## Conventions
+
+- Squash-merge PRs; commit messages explain **why**, at length, in prose.
+- `docs/ROUTER-STATUS.md` is the status protocol contract — outside projects
+  are invited to implement it.
+- Edge SMB defaults to **port 1111, not 445** (445 needs root on Linux too, and
+  both deployments run unprivileged). A test fails if it moves below 1024.
+- Read `MEMORY.md` in the memory directory first — it indexes everything above
+  in more detail.

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -179,7 +179,7 @@ ps2servers-edge udpfs \
 ### Key Diagnostic Log Triggers
 
 - **`UDP RX`**: Confirms a physical datagram reached Edge on the discovery or data socket.
-- **`last_rx_age`**: Shows elapsed time since the last received packet. Growing `last_rx_age` with no RX increase proves network silence from the client.
+- **`last_rx_age`**: Shows elapsed time since the last received packet. Growing `last_rx_age` with no RX increase confirms no packets reached Edge on this socket.
 - **`UDPFS request operation=OPEN`**: Logs file open requests, path resolution, and returned file handles.
 - **`peer sequence reset (seq 0 received)`**: Identifies an accepted console reset/restart.
 - **`replacing stale session for IP`**: Logs when a console shifts source ports across loader transitions.

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -1,0 +1,239 @@
+# PS2-Servers Edge (`ps2servers-edge`) Operator & Command Manual
+
+`ps2servers-edge` is the lightweight, high-performance standalone server for the PlayStation 2. It runs on Linux, OpenWrt micro-routers, macOS, and Windows without requiring a graphical desktop environment.
+
+---
+
+## 📑 Table of Contents
+1. [Core Architecture & Modes](#1-core-architecture--modes)
+2. [Quickstart Command Reference](#2-quickstart-command-reference)
+3. [Subcommand: `udpfs` (Directory & ISO Serving)](#3-subcommand-udpfs-directory--iso-serving)
+4. [Subcommand: `udpbd` (Virtual Hard Drive Emulation)](#4-subcommand-udpbd-virtual-hard-drive-emulation)
+5. [Subcommand: `smb` (OPL SMBv1 Share Serving)](#5-subcommand-smb-opl-smbv1-share-serving)
+6. [Diagnostics & Observability Guide](#6-diagnostics--observability-guide)
+7. [System Deployment Guides (OpenWrt & Linux `systemd`)](#7-system-deployment-guides-openwrt--linux-systemd)
+
+---
+
+## 1. Core Architecture & Modes
+
+`ps2servers-edge` provides three independent server subcommands:
+
+| Subcommand | Protocol | Client Applications | Purpose |
+|---|---|---|---|
+| **`udpfs`** | UDPFS | NHDDL, Neutrino, UDPFS File Browsers | Serves game ISOs, homebrew, VMCs, and save files directly from a directory folder structure. |
+| **`udpbd`** | UDPBD | OPL (UDPBD mode) | Serves one raw hard drive disk image (`.img`) over UDP block-level hardware emulation. |
+| **`smb`** | SMBv1 | Open-PS2-Loader (OPL), POPSTARTER | Serves directory shares over an OPL-compatible SMBv1 TCP port. |
+
+---
+
+## 2. Quickstart Command Reference
+
+### Standard Terminal Usage
+```bash
+# 1. Serve a directory of PS2 games over UDPFS (Default Port 62966)
+ps2servers-edge udpfs --root /srv/ps2/games
+
+# 2. Serve a directory over SMBv1 for OPL (Default Port 1111)
+ps2servers-edge smb --share games=/srv/ps2/games --port 1111
+
+# 3. Serve a single disk image over UDPBD (Default Port 48573 / 0xBDBD)
+ps2servers-edge udpbd --image /srv/ps2/hdd.img
+```
+
+---
+
+## 3. Subcommand: `udpfs` (Directory & ISO Serving)
+
+`udpfs` serves a root directory containing game ISOs (`DVD/`, `CD/`), Virtual Memory Cards (`VMC/`), and homebrew ELFs.
+
+### Command Syntax
+```bash
+ps2servers-edge udpfs --root <PATH> [OPTIONS]
+```
+
+### Complete `udpfs` Arguments
+
+| Argument Flag | Value Type | Default | Description & Usage |
+|---|---|---|---|
+| **`--root <PATH>`** | `string` | *(Required)* | Base directory containing PS2 game folders (`DVD/`, `CD/`, `APPS/`, `VMC/`). |
+| **`--bind <IP>`** | `string` | `"0.0.0.0"` | IPv4 address to listen on. Use `0.0.0.0` for all interfaces or pin to a specific local IP. |
+| **`--port <PORT>`** | `int` | `62966` | Discovery and control UDP port for UDPFS. |
+| **`--data-port <PORT>`** | `int` | `0` | Fixed data UDP port. Default `0` dynamically allocates data ports. |
+| **`--single-port`** | `bool` | `false` | Forces all control and data traffic through `--port` (62966). Essential for legacy clients or strict asymmetric firewalls. |
+| **`--protocol-mode <MODE>`** | `string` | `"auto"` | Packet sequence handling mode: `auto` (auto-detects client type), `standard` (NHDDL/Neutrino), or `modulo`. |
+| **`--read-only`** | `bool` | `false` | Restricts clients to read-only access. Omit this flag to allow VMC save creation/updates. |
+| **`--no-compression`** | `bool` | `false` | Disables internal CSO/ZSO decompressor; serves compressed ISO files as raw byte streams (reduces CPU usage on low-end micro-routers). |
+| **`--compression-cache-size <N>`** | `int` | `32` | Maximum decompressed CSO/ZSO blocks cached in RAM per open file. |
+| **`--block-device <PATH>`** | `string` | `""` | Optional raw disk image path to serve over block calls alongside directory calls. |
+| **`--sector-size <BYTES>`** | `int` | `512` | Sector size for `--block-device` (e.g., `512` or `2048`). |
+| **`--peer-timeout <DURATION>`** | `string` | `"1h"` | Idle session timeout (e.g. `30m`, `1h`) before cleaning up inactive client connections. |
+| **`--tx-delay-ms <MS>`** | `float` | `0.0` | Artificial inter-packet transmit delay in milliseconds (e.g., `0.5`, `1.0`) for sensitive network paths. |
+| **`--metrics`** | `bool` | `false` | Enables periodic reporting of transfer rates, operation counts, and session liveness. |
+| **`--metrics-period <DURATION>`** | `string` | `"1m"` | Interval between metric log reports (e.g., `1s`, `5s`, `1m`). |
+| **`--verbose`** | `bool` | `false` | Enables detailed datagram header tracing, session resets, and operation logs. |
+| **`--quiet`** | `bool` | `false` | Suppresses non-essential informational log messages. |
+| **`--log-format <FORMAT>`** | `string` | `"text"` | Console log format: `text` (human-readable) or `json` (structured). |
+
+#### Real-World `udpfs` Examples:
+
+* **Production Game Server with Live Diagnostics:**
+  ```bash
+  ps2servers-edge udpfs \
+    --root /mnt/storage/ps2 \
+    --verbose \
+    --metrics \
+    --metrics-period 1s \
+    --log-format json
+  ```
+
+* **Single-Port Read-Only Mode (For Micro-Routers / Simple Networks):**
+  ```bash
+  ps2servers-edge udpfs \
+    --root /srv/ps2 \
+    --single-port \
+    --read-only
+  ```
+
+---
+
+## 4. Subcommand: `udpbd` (Virtual Hard Drive Emulation)
+
+`udpbd` presents a single raw disk image file (`.img`) to the PS2 as a virtual hardware block device.
+
+### Command Syntax
+```bash
+ps2servers-edge udpbd --image <PATH> [OPTIONS]
+```
+
+### Complete `udpbd` Arguments
+
+| Argument Flag | Value Type | Default | Description & Usage |
+|---|---|---|---|
+| **`--image <PATH>`** | `string` | *(Required)* | Path to the raw disk image file (`.img` / `.raw`). |
+| **`--bind <IP>`** | `string` | `"0.0.0.0"` | IPv4 address to listen on. |
+| **`--port <PORT>`** | `int` | `48573` | UDP port for UDPBD traffic (matches default PS2 UDPBD port `0xBDBD`). |
+| **`--read-only`** | `bool` | `false` | Serves the disk image read-only. |
+| **`--status-port <PORT>`** | `int` | `-1` | UDP port answering router status/health queries (`-1` disables). |
+| **`--verbose`** | `bool` | `false` | Enables debug log traces for block read/write calls. |
+| **`--quiet`** | `bool` | `false` | Suppresses non-essential informational logs. |
+| **`--log-format <FORMAT>`** | `string` | `"text"` | Log format: `text` or `json`. |
+
+#### Real-World `udpbd` Example:
+```bash
+ps2servers-edge udpbd \
+  --image /var/storage/ps2_hdd.img \
+  --port 48573 \
+  --verbose
+```
+
+---
+
+## 5. Subcommand: `smb` (OPL SMBv1 Share Serving)
+
+`smb` provides a high-performance SMBv1 service specifically tuned for Open-PS2-Loader (OPL) and POPSTARTER.
+
+### Command Syntax
+```bash
+ps2servers-edge smb --share NAME=PATH [OPTIONS]
+```
+
+### Complete `smb` Arguments
+
+| Argument Flag | Value Type | Default | Description & Usage |
+|---|---|---|---|
+| **`--share <NAME=PATH>`** | `string` | *(Required)* | Defines an SMB share name mapped to a local folder. Repeatable for multiple shares. |
+| **`--root <PATH>`** | `string` | `""` | Shorthand helper for `--share games=PATH`. |
+| **`--bind <IP>`** | `string` | `"0.0.0.0"` | IPv4 bind address. |
+| **`--port <PORT>`** | `int` | `1111` | TCP port for SMBv1 (Set OPL's **SMB Port** to match). |
+| **`--read-only`** | `bool` | `false` | Restricts shares to read-only access. |
+| **`--status-port <PORT>`** | `int` | `-1` | UDP status port for router health queries (`-1` disables). |
+| **`--verbose`** | `bool` | `false` | Logs SMB session establishment, authentication, and file open calls. |
+| **`--quiet`** | `bool` | `false` | Suppresses informational log output. |
+| **`--log-format <FORMAT>`** | `string` | `"text"` | Log format: `text` or `json`. |
+
+#### Real-World `smb` Example:
+```bash
+ps2servers-edge smb \
+  --share games=/srv/ps2/games \
+  --share popstarter=/srv/ps2/pops \
+  --port 1111 \
+  --verbose
+```
+
+---
+
+## 6. Diagnostics & Observability Guide
+
+When troubleshooting network connectivity or handoff behavior between loaders (e.g. NHDDL → Neutrino), enable the diagnostic suite:
+
+```bash
+ps2servers-edge udpfs \
+  --root /srv/ps2/games \
+  --verbose \
+  --metrics \
+  --metrics-period 1s \
+  --log-format json
+```
+
+### Key Diagnostic Log Triggers
+
+- **`UDP RX`**: Confirms a physical datagram reached Edge on the discovery or data socket.
+- **`last_rx_age`**: Shows elapsed time since the last received packet. Growing `last_rx_age` with no RX increase proves network silence from the client.
+- **`UDPFS request operation=OPEN`**: Logs file open requests, path resolution, and returned file handles.
+- **`peer sequence reset (seq 0 received)`**: Identifies an accepted console reset/restart.
+- **`replacing stale session for IP`**: Logs when a console shifts source ports across loader transitions.
+
+---
+
+## 7. System Deployment Guides
+
+### Option A: Running as an OpenWrt Service (`uci`)
+
+On OpenWrt routers, configure Edge via `uci`:
+
+```sh
+uci set ps2servers-edge.main.root='/mnt/storage/ps2'
+uci set ps2servers-edge.main.verbose='1'
+uci set ps2servers-edge.main.metrics='1'
+uci set ps2servers-edge.main.metrics_period='1s'
+uci set ps2servers-edge.main.log_format='json'
+uci commit ps2servers-edge
+
+# Manage service
+/etc/init.d/ps2servers-edge restart
+logread -f | grep ps2servers-edge
+```
+
+---
+
+### Option B: Running as a Linux Systemd Service
+
+For Ubuntu, Debian, Proxmox LXC/VM, or Raspberry Pi OS:
+
+Create `/etc/systemd/system/ps2servers-edge.service`:
+
+```ini
+[Unit]
+Description=PS2 Servers Edge Service
+After=network.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/local/bin/ps2servers-edge udpfs --root /srv/ps2/games --verbose --metrics
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start the service:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now ps2servers-edge
+
+# View live logs
+sudo journalctl -u ps2servers-edge -f
+```

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -2551,8 +2551,10 @@ class LauncherApp:
     def _autostart_servers(self):
         if getattr(self, "_shutting_down", False):
             return
-        last = list(self.saved.get("last_active_servers") or [])
-        if not last:
+        if "last_active_servers" in self.saved:
+            last = list(self.saved["last_active_servers"] or [])
+        else:
+            last = []
             for key, card in self.cards.items():
                 server = REGISTRY[key]
                 values = card.values()
@@ -2581,15 +2583,18 @@ class LauncherApp:
             data["direct_link"] = self.saved["direct_link"]
         if self.saved.get("pending_direct_link_restore"):
             data["pending_direct_link_restore"] = True
-        if pending_start:
-            data["pending_start"] = pending_start
-        if pending_cleanup:
+
+        p_start = pending_start or self.saved.get("pending_start")
+        if p_start:
+            data["pending_start"] = p_start
+
+        if pending_cleanup or self.saved.get("pending_cleanup"):
             data["pending_cleanup"] = True
-        if pending_firewall_allow:
+        if pending_firewall_allow or self.saved.get("pending_firewall_allow"):
             data["pending_firewall_allow"] = True
-        if pending_direct_link:
+        if pending_direct_link or self.saved.get("pending_direct_link"):
             data["pending_direct_link"] = True
-        if pending_direct_link_off:
+        if pending_direct_link_off or self.saved.get("pending_direct_link_off"):
             data["pending_direct_link_off"] = True
         try:
             config.save(data)

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -557,6 +557,10 @@ class LauncherApp:
             value=self._saved_bool("close_to_tray", _tray_default))
         self.minimize_to_tray_var = tk.BooleanVar(
             value=self._saved_bool("minimize_to_tray", _tray_default))
+        self.ignore_firewall_var = tk.BooleanVar(
+            value=self._saved_bool("ignore_firewall_prompt", "--ignore-firewall-prompt" in sys.argv))
+        self.autostart_var = tk.BooleanVar(
+            value=self._saved_bool("autostart_last_config", "--autostart" in sys.argv))
 
         root.title("PS2 Servers " + APP_VERSION_LABEL)
         self._configure_window()
@@ -615,6 +619,9 @@ class LauncherApp:
                 # not survive a restart, and re-arming would re-prompt for a
                 # password. Show it as off; the user re-ticks to set it up.
                 self.root.after(600, self._direct_link_reset_stale_unix)
+
+        if self.autostart_var.get() or "--autostart" in sys.argv:
+            self.root.after(750, self._autostart_servers)
 
     def _configure_window(self):
         screen_width = max(640, self.root.winfo_screenwidth())
@@ -998,20 +1005,39 @@ class LauncherApp:
         # (on Linux closing the window quits, with a confirm if servers are up).
         # Gate on tray.AVAILABLE, not self._tray: the tray instance is created
         # AFTER _build() runs, so self._tray is still None here on every OS.
+        behavior = ttk.LabelFrame(about, text=" Options ")
+        behavior.grid(row=row, column=0, sticky="ew", padx=8, pady=(8, 0))
+        behavior.columnconfigure(3, weight=1)
+        row += 1
+        b_col = 0
+        b_row = 0
         if tray.AVAILABLE:
-            behavior = ttk.LabelFrame(about, text=" Window behavior ")
-            behavior.grid(row=row, column=0, sticky="ew", padx=8, pady=(8, 0))
-            behavior.columnconfigure(2, weight=1)
-            row += 1
             close_to_tray = ttk.Checkbutton(
                 behavior, text="Close to tray", variable=self.close_to_tray_var,
                 command=self._save, style="Card.TCheckbutton")
-            close_to_tray.grid(row=0, column=0, sticky="w", padx=(6, 12), pady=6)
+            close_to_tray.grid(row=b_row, column=b_col, sticky="w", padx=(6, 12), pady=6)
+            b_col += 1
             minimize_to_tray = ttk.Checkbutton(
                 behavior, text="Minimize to tray", variable=self.minimize_to_tray_var,
                 command=self._save, style="Card.TCheckbutton")
-            minimize_to_tray.grid(row=0, column=1, sticky="w", padx=(0, 12), pady=6)
+            minimize_to_tray.grid(row=b_row, column=b_col, sticky="w", padx=(0, 12), pady=6)
+            b_col += 1
             self._tray_option_widgets.extend([close_to_tray, minimize_to_tray])
+
+        autostart_chk = ttk.Checkbutton(
+            behavior, text="Auto-start servers on launch", variable=self.autostart_var,
+            command=self._save, style="Card.TCheckbutton")
+        autostart_chk.grid(row=b_row, column=b_col, sticky="w", padx=(6 if b_col == 0 else 0, 12), pady=6)
+        b_col += 1
+
+        if windows_setup.is_windows():
+            if b_col >= 3:
+                b_row += 1
+                b_col = 0
+            ignore_fw_chk = ttk.Checkbutton(
+                behavior, text="Ignore Windows Firewall prompts", variable=self.ignore_firewall_var,
+                command=self._save, style="Card.TCheckbutton")
+            ignore_fw_chk.grid(row=b_row, column=b_col, sticky="w", padx=(6 if b_col == 0 else 0, 12), pady=6)
 
         text_frame = ttk.Frame(about)
         about.rowconfigure(row, weight=1)
@@ -1797,6 +1823,12 @@ class LauncherApp:
                 port_num = 0
         low_port_required = (0 < port_num < 1025)
         admin_required = setup_needed or take_445 or low_port_required
+
+        if self.ignore_firewall_var.get() and not take_445 and not low_port_required:
+            self._append_log(key, "[setup] firewall setup prompt ignored per user setting; starting anyway\n")
+            self._launch_server(key, values)
+            return
+
         if admin_required and not elevate.is_admin():
             self._set_card_busy(key, False, "Start")
             if not elevate.can_elevate():
@@ -1841,6 +1873,10 @@ class LauncherApp:
             return
 
         if setup_needed and elevate.is_admin():
+            if self.ignore_firewall_var.get():
+                self._append_log(key, "[setup] firewall setup prompt ignored per user setting; starting anyway\n")
+                self._launch_server(key, values)
+                return
             if not self._confirm_windows_setup(key, values):
                 self._set_card_busy(key, False, "Start")
                 return
@@ -1915,6 +1951,7 @@ class LauncherApp:
             return
         self.procs[key] = proc
         card._active_values = dict(values)
+        self._save()
         # Ask this server what state it is actually in, rather than inferring
         # it from the child process being alive. Loopback, because the launcher
         # is asking about a server it started itself.
@@ -2250,6 +2287,7 @@ class LauncherApp:
         self.cards[key].refresh_status(False)
         self.cards[key].toggle_btn.config(state="normal")
         self._append_log(key, "[launcher] stopped\n")
+        self._save()
 
     def stop_all(self):
         """Stop every server. Unconditional, and it must stay that way.
@@ -2505,22 +2543,40 @@ class LauncherApp:
             self._saved_bool("close_to_tray", self.close_to_tray_var.get()))
         self.minimize_to_tray_var.set(
             self._saved_bool("minimize_to_tray", self.minimize_to_tray_var.get()))
+        self.ignore_firewall_var.set(
+            self._saved_bool("ignore_firewall_prompt", self.ignore_firewall_var.get()))
+        self.autostart_var.set(
+            self._saved_bool("autostart_last_config", self.autostart_var.get()))
+
+    def _autostart_servers(self):
+        if getattr(self, "_shutting_down", False):
+            return
+        last = list(self.saved.get("last_active_servers") or [])
+        if not last:
+            for key, card in self.cards.items():
+                server = REGISTRY[key]
+                values = card.values()
+                missing = [f.label for f in server.fields if f.required and not values.get(f.key)]
+                if not missing:
+                    last.append(key)
+        for key in last:
+            if key in self.cards and not self.is_running(key):
+                self._append_log(key, "[autostart] auto-starting server on launch\n")
+                self.start_server(key)
 
     def _save(self, pending_start=None, pending_cleanup=False,
               pending_firewall_allow=False, pending_direct_link=False,
               pending_direct_link_off=False) -> bool:
+        active = [k for k in self.cards if self.is_running(k)]
         data = {"servers": {key: card.values() for key, card in self.cards.items()},
                 "ip": self.ip_var.get(),
                 "firewall_ok": sorted(getattr(self, "_firewall_ok", ())),
-                # Not in the pick-list => the user typed it. See _restore.
-                # Must be the combo's values, not a fresh all_ipv4(): _save runs on
-                # every minimize/close-to-tray, so it would block the UI on
-                # getaddrinfo -- and worse, an address that vanished since startup
-                # (roamed, DHCP, cable out) would be misread as hand-typed and then
-                # persist forever, defeating the stale check above.
                 "ip_custom": self.ip_var.get() not in self._detected_ips(),
                 "close_to_tray": bool(self.close_to_tray_var.get()),
-                "minimize_to_tray": bool(self.minimize_to_tray_var.get())}
+                "minimize_to_tray": bool(self.minimize_to_tray_var.get()),
+                "ignore_firewall_prompt": bool(self.ignore_firewall_var.get()),
+                "autostart_last_config": bool(self.autostart_var.get()),
+                "last_active_servers": active if active else (self.saved.get("last_active_servers") or [])}
         if self.saved.get("direct_link"):
             data["direct_link"] = self.saved["direct_link"]
         if self.saved.get("pending_direct_link_restore"):

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -2544,9 +2544,9 @@ class LauncherApp:
         self.minimize_to_tray_var.set(
             self._saved_bool("minimize_to_tray", self.minimize_to_tray_var.get()))
         self.ignore_firewall_var.set(
-            self._saved_bool("ignore_firewall_prompt", self.ignore_firewall_var.get()))
+            bool(self._saved_bool("ignore_firewall_prompt", self.ignore_firewall_var.get()) or ("--ignore-firewall-prompt" in sys.argv)))
         self.autostart_var.set(
-            self._saved_bool("autostart_last_config", self.autostart_var.get()))
+            bool(self._saved_bool("autostart_last_config", self.autostart_var.get()) or ("--autostart" in sys.argv)))
 
     def _autostart_servers(self):
         if getattr(self, "_shutting_down", False):
@@ -2576,7 +2576,7 @@ class LauncherApp:
                 "minimize_to_tray": bool(self.minimize_to_tray_var.get()),
                 "ignore_firewall_prompt": bool(self.ignore_firewall_var.get()),
                 "autostart_last_config": bool(self.autostart_var.get()),
-                "last_active_servers": active if active else (self.saved.get("last_active_servers") or [])}
+                "last_active_servers": active}
         if self.saved.get("direct_link"):
             data["direct_link"] = self.saved["direct_link"]
         if self.saved.get("pending_direct_link_restore"):

--- a/launcher/main.py
+++ b/launcher/main.py
@@ -7,6 +7,8 @@ for testing:
   --list                    print the servers available on this machine
   --selfcheck               verify the re-exec path can actually start a server
                             (used to confirm the packaged build works)
+  --autostart               automatically start last saved servers on launch
+  --ignore-firewall-prompt  bypass Windows Firewall prompts on server start
 """
 
 import platform

--- a/native/ps2servers-edge/INSTRUCTIONS.md
+++ b/native/ps2servers-edge/INSTRUCTIONS.md
@@ -179,7 +179,7 @@ ps2servers-edge udpfs \
 ### Key Diagnostic Log Triggers
 
 - **`UDP RX`**: Confirms a physical datagram reached Edge on the discovery or data socket.
-- **`last_rx_age`**: Shows elapsed time since the last received packet. Growing `last_rx_age` with no RX increase proves network silence from the client.
+- **`last_rx_age`**: Shows elapsed time since the last received packet. Growing `last_rx_age` with no RX increase confirms no packets reached Edge on this socket.
 - **`UDPFS request operation=OPEN`**: Logs file open requests, path resolution, and returned file handles.
 - **`peer sequence reset (seq 0 received)`**: Identifies an accepted console reset/restart.
 - **`replacing stale session for IP`**: Logs when a console shifts source ports across loader transitions.

--- a/native/ps2servers-edge/INSTRUCTIONS.md
+++ b/native/ps2servers-edge/INSTRUCTIONS.md
@@ -1,0 +1,239 @@
+# PS2-Servers Edge (`ps2servers-edge`) Operator & Command Manual
+
+`ps2servers-edge` is the lightweight, high-performance standalone server for the PlayStation 2. It runs on Linux, OpenWrt micro-routers, macOS, and Windows without requiring a graphical desktop environment.
+
+---
+
+## 📑 Table of Contents
+1. [Core Architecture & Modes](#1-core-architecture--modes)
+2. [Quickstart Command Reference](#2-quickstart-command-reference)
+3. [Subcommand: `udpfs` (Directory & ISO Serving)](#3-subcommand-udpfs-directory--iso-serving)
+4. [Subcommand: `udpbd` (Virtual Hard Drive Emulation)](#4-subcommand-udpbd-virtual-hard-drive-emulation)
+5. [Subcommand: `smb` (OPL SMBv1 Share Serving)](#5-subcommand-smb-opl-smbv1-share-serving)
+6. [Diagnostics & Observability Guide](#6-diagnostics--observability-guide)
+7. [System Deployment Guides (OpenWrt & Linux `systemd`)](#7-system-deployment-guides-openwrt--linux-systemd)
+
+---
+
+## 1. Core Architecture & Modes
+
+`ps2servers-edge` provides three independent server subcommands:
+
+| Subcommand | Protocol | Client Applications | Purpose |
+|---|---|---|---|
+| **`udpfs`** | UDPFS | NHDDL, Neutrino, UDPFS File Browsers | Serves game ISOs, homebrew, VMCs, and save files directly from a directory folder structure. |
+| **`udpbd`** | UDPBD | OPL (UDPBD mode) | Serves one raw hard drive disk image (`.img`) over UDP block-level hardware emulation. |
+| **`smb`** | SMBv1 | Open-PS2-Loader (OPL), POPSTARTER | Serves directory shares over an OPL-compatible SMBv1 TCP port. |
+
+---
+
+## 2. Quickstart Command Reference
+
+### Standard Terminal Usage
+```bash
+# 1. Serve a directory of PS2 games over UDPFS (Default Port 62966)
+ps2servers-edge udpfs --root /srv/ps2/games
+
+# 2. Serve a directory over SMBv1 for OPL (Default Port 1111)
+ps2servers-edge smb --share games=/srv/ps2/games --port 1111
+
+# 3. Serve a single disk image over UDPBD (Default Port 48573 / 0xBDBD)
+ps2servers-edge udpbd --image /srv/ps2/hdd.img
+```
+
+---
+
+## 3. Subcommand: `udpfs` (Directory & ISO Serving)
+
+`udpfs` serves a root directory containing game ISOs (`DVD/`, `CD/`), Virtual Memory Cards (`VMC/`), and homebrew ELFs.
+
+### Command Syntax
+```bash
+ps2servers-edge udpfs --root <PATH> [OPTIONS]
+```
+
+### Complete `udpfs` Arguments
+
+| Argument Flag | Value Type | Default | Description & Usage |
+|---|---|---|---|
+| **`--root <PATH>`** | `string` | *(Required)* | Base directory containing PS2 game folders (`DVD/`, `CD/`, `APPS/`, `VMC/`). |
+| **`--bind <IP>`** | `string` | `"0.0.0.0"` | IPv4 address to listen on. Use `0.0.0.0` for all interfaces or pin to a specific local IP. |
+| **`--port <PORT>`** | `int` | `62966` | Discovery and control UDP port for UDPFS. |
+| **`--data-port <PORT>`** | `int` | `0` | Fixed data UDP port. Default `0` dynamically allocates data ports. |
+| **`--single-port`** | `bool` | `false` | Forces all control and data traffic through `--port` (62966). Essential for legacy clients or strict asymmetric firewalls. |
+| **`--protocol-mode <MODE>`** | `string` | `"auto"` | Packet sequence handling mode: `auto` (auto-detects client type), `standard` (NHDDL/Neutrino), or `modulo`. |
+| **`--read-only`** | `bool` | `false` | Restricts clients to read-only access. Omit this flag to allow VMC save creation/updates. |
+| **`--no-compression`** | `bool` | `false` | Disables internal CSO/ZSO decompressor; serves compressed ISO files as raw byte streams (reduces CPU usage on low-end micro-routers). |
+| **`--compression-cache-size <N>`** | `int` | `32` | Maximum decompressed CSO/ZSO blocks cached in RAM per open file. |
+| **`--block-device <PATH>`** | `string` | `""` | Optional raw disk image path to serve over block calls alongside directory calls. |
+| **`--sector-size <BYTES>`** | `int` | `512` | Sector size for `--block-device` (e.g., `512` or `2048`). |
+| **`--peer-timeout <DURATION>`** | `string` | `"1h"` | Idle session timeout (e.g. `30m`, `1h`) before cleaning up inactive client connections. |
+| **`--tx-delay-ms <MS>`** | `float` | `0.0` | Artificial inter-packet transmit delay in milliseconds (e.g., `0.5`, `1.0`) for sensitive network paths. |
+| **`--metrics`** | `bool` | `false` | Enables periodic reporting of transfer rates, operation counts, and session liveness. |
+| **`--metrics-period <DURATION>`** | `string` | `"1m"` | Interval between metric log reports (e.g., `1s`, `5s`, `1m`). |
+| **`--verbose`** | `bool` | `false` | Enables detailed datagram header tracing, session resets, and operation logs. |
+| **`--quiet`** | `bool` | `false` | Suppresses non-essential informational log messages. |
+| **`--log-format <FORMAT>`** | `string` | `"text"` | Console log format: `text` (human-readable) or `json` (structured). |
+
+#### Real-World `udpfs` Examples:
+
+* **Production Game Server with Live Diagnostics:**
+  ```bash
+  ps2servers-edge udpfs \
+    --root /mnt/storage/ps2 \
+    --verbose \
+    --metrics \
+    --metrics-period 1s \
+    --log-format json
+  ```
+
+* **Single-Port Read-Only Mode (For Micro-Routers / Simple Networks):**
+  ```bash
+  ps2servers-edge udpfs \
+    --root /srv/ps2 \
+    --single-port \
+    --read-only
+  ```
+
+---
+
+## 4. Subcommand: `udpbd` (Virtual Hard Drive Emulation)
+
+`udpbd` presents a single raw disk image file (`.img`) to the PS2 as a virtual hardware block device.
+
+### Command Syntax
+```bash
+ps2servers-edge udpbd --image <PATH> [OPTIONS]
+```
+
+### Complete `udpbd` Arguments
+
+| Argument Flag | Value Type | Default | Description & Usage |
+|---|---|---|---|
+| **`--image <PATH>`** | `string` | *(Required)* | Path to the raw disk image file (`.img` / `.raw`). |
+| **`--bind <IP>`** | `string` | `"0.0.0.0"` | IPv4 address to listen on. |
+| **`--port <PORT>`** | `int` | `48573` | UDP port for UDPBD traffic (matches default PS2 UDPBD port `0xBDBD`). |
+| **`--read-only`** | `bool` | `false` | Serves the disk image read-only. |
+| **`--status-port <PORT>`** | `int` | `-1` | UDP port answering router status/health queries (`-1` disables). |
+| **`--verbose`** | `bool` | `false` | Enables debug log traces for block read/write calls. |
+| **`--quiet`** | `bool` | `false` | Suppresses non-essential informational logs. |
+| **`--log-format <FORMAT>`** | `string` | `"text"` | Log format: `text` or `json`. |
+
+#### Real-World `udpbd` Example:
+```bash
+ps2servers-edge udpbd \
+  --image /var/storage/ps2_hdd.img \
+  --port 48573 \
+  --verbose
+```
+
+---
+
+## 5. Subcommand: `smb` (OPL SMBv1 Share Serving)
+
+`smb` provides a high-performance SMBv1 service specifically tuned for Open-PS2-Loader (OPL) and POPSTARTER.
+
+### Command Syntax
+```bash
+ps2servers-edge smb --share NAME=PATH [OPTIONS]
+```
+
+### Complete `smb` Arguments
+
+| Argument Flag | Value Type | Default | Description & Usage |
+|---|---|---|---|
+| **`--share <NAME=PATH>`** | `string` | *(Required)* | Defines an SMB share name mapped to a local folder. Repeatable for multiple shares. |
+| **`--root <PATH>`** | `string` | `""` | Shorthand helper for `--share games=PATH`. |
+| **`--bind <IP>`** | `string` | `"0.0.0.0"` | IPv4 bind address. |
+| **`--port <PORT>`** | `int` | `1111` | TCP port for SMBv1 (Set OPL's **SMB Port** to match). |
+| **`--read-only`** | `bool` | `false` | Restricts shares to read-only access. |
+| **`--status-port <PORT>`** | `int` | `-1` | UDP status port for router health queries (`-1` disables). |
+| **`--verbose`** | `bool` | `false` | Logs SMB session establishment, authentication, and file open calls. |
+| **`--quiet`** | `bool` | `false` | Suppresses informational log output. |
+| **`--log-format <FORMAT>`** | `string` | `"text"` | Log format: `text` or `json`. |
+
+#### Real-World `smb` Example:
+```bash
+ps2servers-edge smb \
+  --share games=/srv/ps2/games \
+  --share popstarter=/srv/ps2/pops \
+  --port 1111 \
+  --verbose
+```
+
+---
+
+## 6. Diagnostics & Observability Guide
+
+When troubleshooting network connectivity or handoff behavior between loaders (e.g. NHDDL → Neutrino), enable the diagnostic suite:
+
+```bash
+ps2servers-edge udpfs \
+  --root /srv/ps2/games \
+  --verbose \
+  --metrics \
+  --metrics-period 1s \
+  --log-format json
+```
+
+### Key Diagnostic Log Triggers
+
+- **`UDP RX`**: Confirms a physical datagram reached Edge on the discovery or data socket.
+- **`last_rx_age`**: Shows elapsed time since the last received packet. Growing `last_rx_age` with no RX increase proves network silence from the client.
+- **`UDPFS request operation=OPEN`**: Logs file open requests, path resolution, and returned file handles.
+- **`peer sequence reset (seq 0 received)`**: Identifies an accepted console reset/restart.
+- **`replacing stale session for IP`**: Logs when a console shifts source ports across loader transitions.
+
+---
+
+## 7. System Deployment Guides
+
+### Option A: Running as an OpenWrt Service (`uci`)
+
+On OpenWrt routers, configure Edge via `uci`:
+
+```sh
+uci set ps2servers-edge.main.root='/mnt/storage/ps2'
+uci set ps2servers-edge.main.verbose='1'
+uci set ps2servers-edge.main.metrics='1'
+uci set ps2servers-edge.main.metrics_period='1s'
+uci set ps2servers-edge.main.log_format='json'
+uci commit ps2servers-edge
+
+# Manage service
+/etc/init.d/ps2servers-edge restart
+logread -f | grep ps2servers-edge
+```
+
+---
+
+### Option B: Running as a Linux Systemd Service
+
+For Ubuntu, Debian, Proxmox LXC/VM, or Raspberry Pi OS:
+
+Create `/etc/systemd/system/ps2servers-edge.service`:
+
+```ini
+[Unit]
+Description=PS2 Servers Edge Service
+After=network.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/local/bin/ps2servers-edge udpfs --root /srv/ps2/games --verbose --metrics
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start the service:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now ps2servers-edge
+
+# View live logs
+sudo journalctl -u ps2servers-edge -f
+```

--- a/tests/test_autostart_and_firewall_options.py
+++ b/tests/test_autostart_and_firewall_options.py
@@ -46,7 +46,7 @@ class AutostartAndFirewallOptionsTest(unittest.TestCase):
         except ImportError:
             raise unittest.SkipTest("no tkinter")
 
-        from launcher import gui, windows_setup
+        from launcher import gui
         try:
             root = tk.Tk()
         except tk.TclError:
@@ -70,6 +70,31 @@ class AutostartAndFirewallOptionsTest(unittest.TestCase):
             self.assertTrue(app._save())
             self.assertTrue(saved_data.get("ignore_firewall_prompt"))
             self.assertTrue(saved_data.get("autostart_last_config"))
+            self.assertEqual(saved_data.get("last_active_servers"), [])
+        finally:
+            app._shutting_down = True
+            root.destroy()
+
+    def test_autostart_servers_saved_list(self):
+        try:
+            import tkinter as tk
+        except ImportError:
+            raise unittest.SkipTest("no tkinter")
+
+        from launcher import gui
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            raise unittest.SkipTest("no display")
+
+        try:
+            app = gui.LauncherApp(root)
+            started_keys = []
+            app.start_server = lambda key: started_keys.append(key)
+            app.saved["last_active_servers"] = ["udpfs"]
+
+            app._autostart_servers()
+            self.assertEqual(started_keys, ["udpfs"])
         finally:
             app._shutting_down = True
             root.destroy()
@@ -90,11 +115,39 @@ class AutostartAndFirewallOptionsTest(unittest.TestCase):
             app = gui.LauncherApp(root)
             started_keys = []
             app.start_server = lambda key: started_keys.append(key)
-            app.saved["last_active_servers"] = ["udpfs"]
+            app.saved["last_active_servers"] = []
+
+            # Seed a card with required fields populated
+            card = app.cards["udpfs"]
+            card.set_values({"root": "/tmp/games", "port": 62966})
 
             app._autostart_servers()
             self.assertIn("udpfs", started_keys)
         finally:
+            app._shutting_down = True
+            root.destroy()
+
+    def test_cli_flags_precedence(self):
+        try:
+            import tkinter as tk
+        except ImportError:
+            raise unittest.SkipTest("no tkinter")
+
+        old_argv = list(sys.argv)
+        sys.argv.extend(["--ignore-firewall-prompt", "--autostart"])
+        from launcher import gui
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            sys.argv = old_argv
+            raise unittest.SkipTest("no display")
+
+        try:
+            app = gui.LauncherApp(root)
+            self.assertTrue(app.ignore_firewall_var.get())
+            self.assertTrue(app.autostart_var.get())
+        finally:
+            sys.argv = old_argv
             app._shutting_down = True
             root.destroy()
 

--- a/tests/test_autostart_and_firewall_options.py
+++ b/tests/test_autostart_and_firewall_options.py
@@ -99,7 +99,7 @@ class AutostartAndFirewallOptionsTest(unittest.TestCase):
             app._shutting_down = True
             root.destroy()
 
-    def test_autostart_servers_fallback(self):
+    def test_autostart_servers_explicit_empty_list(self):
         try:
             import tkinter as tk
         except ImportError:
@@ -122,7 +122,62 @@ class AutostartAndFirewallOptionsTest(unittest.TestCase):
             card.set_values({"root": "/tmp/games", "port": 62966})
 
             app._autostart_servers()
+            # Explicit empty list means user stopped all servers -- autostart should NOT run fallback
+            self.assertEqual(started_keys, [])
+        finally:
+            app._shutting_down = True
+            root.destroy()
+
+    def test_autostart_servers_fallback_missing_key(self):
+        try:
+            import tkinter as tk
+        except ImportError:
+            raise unittest.SkipTest("no tkinter")
+
+        from launcher import gui
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            raise unittest.SkipTest("no display")
+
+        try:
+            app = gui.LauncherApp(root)
+            started_keys = []
+            app.start_server = lambda key: started_keys.append(key)
+            app.saved.pop("last_active_servers", None)
+
+            # Seed a card with required fields populated
+            card = app.cards["udpfs"]
+            card.set_values({"root": "/tmp/games", "port": 62966})
+
+            app._autostart_servers()
             self.assertIn("udpfs", started_keys)
+        finally:
+            app._shutting_down = True
+            root.destroy()
+
+    def test_pending_markers_preserved_in_plain_save(self):
+        try:
+            import tkinter as tk
+        except ImportError:
+            raise unittest.SkipTest("no tkinter")
+
+        from launcher import gui
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            raise unittest.SkipTest("no display")
+
+        try:
+            app = gui.LauncherApp(root)
+            app.saved["pending_start"] = "udpfs"
+            saved_data = {}
+            from launcher import config
+            config.save = lambda data: (saved_data.update(data), True)[1]
+
+            # Execute plain save without explicit pending_start argument
+            app._save()
+            self.assertEqual(saved_data.get("pending_start"), "udpfs")
         finally:
             app._shutting_down = True
             root.destroy()
@@ -144,6 +199,10 @@ class AutostartAndFirewallOptionsTest(unittest.TestCase):
 
         try:
             app = gui.LauncherApp(root)
+            app.saved["ignore_firewall_prompt"] = False
+            app.saved["autostart_last_config"] = False
+            app._restore()
+
             self.assertTrue(app.ignore_firewall_var.get())
             self.assertTrue(app.autostart_var.get())
         finally:

--- a/tests/test_autostart_and_firewall_options.py
+++ b/tests/test_autostart_and_firewall_options.py
@@ -1,0 +1,103 @@
+"""Tests for ignore_firewall_prompt and autostart_last_config launcher options.
+
+Run:
+    python -m unittest tests.test_autostart_and_firewall_options -v
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+class AutostartAndFirewallOptionsTest(unittest.TestCase):
+    def setUp(self):
+        self.scratch = tempfile.mkdtemp(prefix="ps2-opts-test-")
+        self.saved_env = {v: os.environ.get(v) for v in ("APPDATA", "XDG_CONFIG_HOME")}
+        for var in ("APPDATA", "XDG_CONFIG_HOME"):
+            os.environ[var] = self.scratch
+
+        from launcher import config, tray
+        self.saved_config_save = config.save
+        self.saved_tray_available = tray.AVAILABLE
+        config.save = lambda data: None
+        tray.AVAILABLE = False
+
+    def tearDown(self):
+        for var, was in self.saved_env.items():
+            if was is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = was
+        if self.scratch:
+            import shutil
+            shutil.rmtree(self.scratch, ignore_errors=True)
+        from launcher import config, tray
+        config.save = self.saved_config_save
+        tray.AVAILABLE = self.saved_tray_available
+
+    def test_options_variables_and_persistence(self):
+        try:
+            import tkinter as tk
+        except ImportError:
+            raise unittest.SkipTest("no tkinter")
+
+        from launcher import gui, windows_setup
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            raise unittest.SkipTest("no display")
+
+        try:
+            app = gui.LauncherApp(root)
+            self.assertFalse(app.ignore_firewall_var.get())
+            self.assertFalse(app.autostart_var.get())
+
+            app.ignore_firewall_var.set(True)
+            app.autostart_var.set(True)
+
+            saved_data = {}
+            def dummy_save(data):
+                saved_data.update(data)
+                return True
+            from launcher import config
+            config.save = dummy_save
+
+            self.assertTrue(app._save())
+            self.assertTrue(saved_data.get("ignore_firewall_prompt"))
+            self.assertTrue(saved_data.get("autostart_last_config"))
+        finally:
+            app._shutting_down = True
+            root.destroy()
+
+    def test_autostart_servers_fallback(self):
+        try:
+            import tkinter as tk
+        except ImportError:
+            raise unittest.SkipTest("no tkinter")
+
+        from launcher import gui
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            raise unittest.SkipTest("no display")
+
+        try:
+            app = gui.LauncherApp(root)
+            started_keys = []
+            app.start_server = lambda key: started_keys.append(key)
+            app.saved["last_active_servers"] = ["udpfs"]
+
+            app._autostart_servers()
+            self.assertIn("udpfs", started_keys)
+        finally:
+            app._shutting_down = True
+            root.destroy()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Includes INSTRUCTIONS.md operator manual in docs/, native/ps2servers-edge/, and edge-build.yml packaging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to automatically restart previously active servers and suppress Windows Firewall prompts.
  * Added command-line flags for controlling autostart and firewall prompt behavior.
  * Edge packages now include documentation in both uppercase and lowercase filename forms.

* **Documentation**
  * Added comprehensive operator guides covering server modes, commands, deployment, diagnostics, and examples.
  * Added a project handoff document with release status and follow-up guidance.

* **Tests**
  * Added coverage for option persistence, autostart behavior, and command-line precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->