### PR TITLE
feat(edge): Add embedded Web management GUI for Edge builds

### DIFF
--- a/docs/EDGE.md
+++ b/docs/EDGE.md
@@ -40,10 +40,15 @@ Compressed images:
   (`0`–`4096`; `0` disables the cache)
 - `--no-compression` — serve CSO/ZSO as raw bytes; a diagnostic, see below
 
-Observability:
+Observability & Web Management:
 
 - `--metrics` — log periodic transfer counters
 - `--metrics-period 1m` — how often, from `1s` to `24h`
+
+Web UI:
+
+- `ps2servers-edge webui` — run embedded web dashboard on port `8082` (or OS assigned)
+- Options: `--webui-port 8082`, `--bind 0.0.0.0`, `--config-file /etc/ps2servers-edge/config.json`, `--no-browse`
 
 For an OpenWrt command reference and a packet-by-packet NHDDL-to-Neutrino
 diagnostic procedure, see

--- a/docs/EDITIONS.md
+++ b/docs/EDITIONS.md
@@ -36,6 +36,7 @@ Current Edge scope:
 - UDPFS with reads and writes; writable by default, `--read-only` to restrict
 - UDPFS block access (`BREAD`/`BWRITE`) for one disk image via `--block-device`
 - native UDPBD as the `udpbd` subcommand
+- embedded responsive Web GUI management dashboard (`ps2servers-edge webui`)
 - automatic per-session standard/Modulo compatibility
 - multiple concurrent clients
 - ISO, CSO, and ZSO, with a bounded decompressed-block cache

--- a/docs/OPENWRT.md
+++ b/docs/OPENWRT.md
@@ -29,6 +29,11 @@ config udpfs 'main'
     option compression_cache_size '32'
     option metrics '0'
     option metrics_period '1m'
+
+config webui 'webui'
+    option enabled '1'
+    option port '8082'
+    option bind '0.0.0.0'
 ```
 
 Every option maps to one Edge flag:
@@ -158,6 +163,19 @@ service's status across a reboot for no visible reason.
 
 Set `-1` on `smb` or `udpbd` when it is the only service enabled on the
 board.
+
+### Web Management GUI
+
+Edge includes an embedded, responsive Web GUI dashboard to manage all services without SSH or command-line experience:
+
+```sh
+uci set ps2servers-edge.webui.enabled='1'
+uci set ps2servers-edge.webui.port='8082'
+uci commit ps2servers-edge
+/etc/init.d/ps2servers-edge restart
+```
+
+Open `http://<router-ip>:8082` in any browser (phone or PC) to view live status, configure all services with Save/Apply/Reset, browse files, and tail live logs.
 
 ### A bad value restarts the service in a loop
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -69,6 +69,11 @@
             <p>Serves a single disk image as a UDP block device. The PS2 finds the server by itself over the LAN — nothing to type on the console.</p>
             <p><code>OPL: auto-discovered</code></p>
           </article>
+          <article class="card">
+            <h3>Edge &amp; Web GUI</h3>
+            <p>Headless standalone Go binary for routers, OpenWrt, Raspberry Pi, and NAS. Includes an embedded responsive Web GUI for phone or remote control.</p>
+            <p><code>Web UI: http://router:8082</code></p>
+          </article>
         </div>
       </div>
     </section>

--- a/launcher/netinfo.py
+++ b/launcher/netinfo.py
@@ -136,27 +136,39 @@ def ip_choices():
     return all_ipv4() + ["Custom IP..."]
 
 
-def get_adapter_ip_pairs():
-    """Returns [(adapter_name, ip_address), ...] for all active IPv4 interfaces."""
+def get_all_adapters_info():
+    """Returns (active_pairs, unconfigured_adapters) for system network interfaces.
+
+    active_pairs is [(adapter_name, ip_address), ...] for active IPv4 interfaces.
+    unconfigured_adapters is [adapter_name, ...] for physical NICs without a valid LAN IPv4.
+    """
     pairs = []
+    unconfigured = set()
     try:
         if sys.platform == "win32" and shutil.which("ipconfig"):
             out = subprocess.run(["ipconfig"], capture_output=True, text=True, timeout=3).stdout
             current_adapter = None
+            has_valid_ip = False
             for line in (out or "").splitlines():
                 line_s = line.strip()
                 if line and not line[0].isspace() and ("adapter" in line.lower() or ":" in line):
+                    if current_adapter and not has_valid_ip and not _iface_is_virtual(current_adapter.lower()):
+                        unconfigured.add(current_adapter)
                     current_adapter = line.split(":", 1)[0].strip()
+                    has_valid_ip = False
                     continue
                 if "IPv4 Address" in line_s or "IP Address" in line_s:
                     parts = line_s.split(":", 1)
                     if len(parts) == 2:
                         ip = parts[1].replace("(Preferred)", "").strip()
-                        if ip and not ip.startswith(("127.", "169.254.")):
-                            name = current_adapter or "Network Adapter"
-                            pairs.append((name, ip))
-            if pairs:
-                return pairs
+                        if ip and not ip.startswith("127."):
+                            if not ip.startswith("169.254."):
+                                name = current_adapter or "Network Adapter"
+                                pairs.append((name, ip))
+                                has_valid_ip = True
+            if current_adapter and not has_valid_ip and not _iface_is_virtual(current_adapter.lower()):
+                unconfigured.add(current_adapter)
+            return pairs, sorted(unconfigured)
         elif sys.platform.startswith("linux") and shutil.which("ip"):
             out = subprocess.run(["ip", "-o", "-4", "addr", "show"],
                                  capture_output=True, text=True, timeout=3).stdout
@@ -169,7 +181,7 @@ def get_adapter_ip_pairs():
                         if not ip.startswith(("127.", "169.254.")):
                             pairs.append((iface, ip))
             if pairs:
-                return pairs
+                return pairs, []
         elif sys.platform == "darwin" and shutil.which("ifconfig"):
             out = subprocess.run(["ifconfig"],
                                  capture_output=True, text=True, timeout=3).stdout
@@ -184,17 +196,22 @@ def get_adapter_ip_pairs():
                     if not ip.startswith(("127.", "169.254.")):
                         pairs.append((current, ip))
             if pairs:
-                return pairs
+                return pairs, []
     except Exception:
         pass
 
-    # Fallback to all_ipv4()
-    return [("Network Adapter", ip) for ip in all_ipv4()]
+    return [("Network Adapter", ip) for ip in all_ipv4()], []
+
+
+def get_adapter_ip_pairs():
+    """Returns [(adapter_name, ip_address), ...] for all active IPv4 interfaces."""
+    pairs, _ = get_all_adapters_info()
+    return pairs
 
 
 def detailed_ip_info():
     """Returns a formatted multi-line string listing current network adapters and IP addresses."""
-    pairs = get_adapter_ip_pairs()
+    pairs, unconfigured = get_all_adapters_info()
     lines = ["[network] Current IP Addresses and Network Adapters:"]
     if not pairs:
         lines.append("  • No active network adapters found.")
@@ -202,6 +219,11 @@ def detailed_ip_info():
         for adapter, ip in pairs:
             lines.append(f"  • {adapter}: {ip}")
     lines.append("(If your PS2 is connected to a specific network device, select its IP in the dropdown above or pick 'Custom IP...' to type your own.)")
+    if unconfigured:
+        lines.append("\n[network] Unconfigured / Direct Cable Adapters (No IPv4 assigned):")
+        for adapter in unconfigured:
+            lines.append(f"  • {adapter}: Disconnected or direct cable without DHCP")
+        lines.append("  --> TIP: If your PS2 is plugged directly into one of these Ethernet ports with a cable, tick 'PS2 is plugged directly into this PC' above!")
     return "\n".join(lines)
 
 

--- a/native/ps2servers-edge/INSTRUCTIONS.md
+++ b/native/ps2servers-edge/INSTRUCTIONS.md
@@ -10,14 +10,15 @@
 3. [Subcommand: `udpfs` (Directory & ISO Serving)](#3-subcommand-udpfs-directory--iso-serving)
 4. [Subcommand: `udpbd` (Virtual Hard Drive Emulation)](#4-subcommand-udpbd-virtual-hard-drive-emulation)
 5. [Subcommand: `smb` (OPL SMBv1 Share Serving)](#5-subcommand-smb-opl-smbv1-share-serving)
-6. [Diagnostics & Observability Guide](#6-diagnostics--observability-guide)
-7. [System Deployment Guides (OpenWrt & Linux `systemd`)](#7-system-deployment-guides-openwrt--linux-systemd)
+6. [Subcommand: `webui` (Embedded Web Management GUI)](#6-subcommand-webui-embedded-web-management-gui)
+7. [Diagnostics & Observability Guide](#7-diagnostics--observability-guide)
+8. [System Deployment Guides (OpenWrt & Linux `systemd`)](#8-system-deployment-guides-openwrt--linux-systemd)
 
 ---
 
 ## 1. Core Architecture & Modes
 
-`ps2servers-edge` provides three independent server subcommands:
+`ps2servers-edge` provides four independent subcommands:
 
 | Subcommand | Protocol | Client Applications | Purpose |
 |---|---|---|---|
@@ -167,7 +168,41 @@ ps2servers-edge smb \
 
 ---
 
-## 6. Diagnostics & Observability Guide
+## 6. Subcommand: `webui` (Embedded Web Management GUI)
+
+`webui` serves a mobile-responsive single-page dashboard for full configuration, real-time log streaming, and process management across all Edge servers.
+
+> [!NOTE]
+> **Network Scope**: The web UI is unauthenticated and intended for trusted private LANs. Access can be restricted with `--no-browse` or pinned to loopback via `--bind 127.0.0.1`.
+
+### Command Syntax
+```bash
+ps2servers-edge webui [OPTIONS]
+```
+
+### Complete `webui` Arguments
+
+| Argument Flag | Value Type | Default | Description & Usage |
+|---|---|---|---|
+| **`--webui-port <PORT>`** | `int` | `8082` | HTTP port for the web dashboard (0 uses 8082 with fallback to OS-assigned port). |
+| **`--bind <IP>`** | `string` | `"0.0.0.0"` | IPv4 bind address. |
+| **`--config-file <PATH>`** | `string` | `"/etc/ps2servers-edge/config.json"` | Path to JSON config file (used on generic Linux/systemd/Docker). |
+| **`--log-lines <N>`** | `int` | `1000` | Capacity of the in-memory ring buffer for live SSE log streaming. |
+| **`--no-browse`** | `bool` | `false` | Disables the file browser modal/endpoint (`/api/browse`) for security. |
+| **`--verbose`** | `bool` | `false` | Enables verbose HTTP access logging. |
+| **`--quiet`** | `bool` | `false` | Suppresses non-essential log output. |
+| **`--log-format <FORMAT>`** | `string` | `"text"` | Log format: `text` or `json`. |
+
+#### Real-World `webui` Example:
+```bash
+ps2servers-edge webui \
+  --webui-port 8082 \
+  --bind 0.0.0.0
+```
+
+---
+
+## 7. Diagnostics & Observability Guide
 
 When troubleshooting network connectivity or handoff behavior between loaders (e.g. NHDDL → Neutrino), enable the diagnostic suite:
 
@@ -190,7 +225,7 @@ ps2servers-edge udpfs \
 
 ---
 
-## 7. System Deployment Guides
+## 8. System Deployment Guides
 
 ### Option A: Running as an OpenWrt Service (`uci`)
 

--- a/native/ps2servers-edge/INSTRUCTIONS.md
+++ b/native/ps2servers-edge/INSTRUCTIONS.md
@@ -24,6 +24,7 @@
 | **`udpfs`** | UDPFS | NHDDL, Neutrino, UDPFS File Browsers | Serves game ISOs, homebrew, VMCs, and save files directly from a directory folder structure. |
 | **`udpbd`** | UDPBD | OPL (UDPBD mode) | Serves one raw hard drive disk image (`.img`) over UDP block-level hardware emulation. |
 | **`smb`** | SMBv1 | Open-PS2-Loader (OPL), POPSTARTER | Serves directory shares over an OPL-compatible SMBv1 TCP port. |
+| **`webui`** | HTTP/JSON | Web Browsers (Mobile & Desktop) | Embedded responsive web GUI dashboard for full configuration, live log streaming, and service control. |
 
 ---
 
@@ -39,6 +40,9 @@ ps2servers-edge smb --share games=/srv/ps2/games --port 1111
 
 # 3. Serve a single disk image over UDPBD (Default Port 48573 / 0xBDBD)
 ps2servers-edge udpbd --image /srv/ps2/hdd.img
+
+# 4. Serve the Web Management GUI (Default Port 8082)
+ps2servers-edge webui --webui-port 8082
 ```
 
 ---

--- a/native/ps2servers-edge/cmd/ps2servers-edge/main.go
+++ b/native/ps2servers-edge/cmd/ps2servers-edge/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/smb"
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/udpbd"
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/udpfs"
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/webui"
 )
 
 var version = "dev"
@@ -30,10 +31,12 @@ func usage() {
 		"  ps2servers-edge udpfs --root /games [options]\n"+
 		"  ps2servers-edge udpbd --image /path/ps2.img [options]\n"+
 		"  ps2servers-edge smb --share games=/games [options]\n"+
+		"  ps2servers-edge webui [options]\n"+
 		"  ps2servers-edge --version\n\n"+
 		"  udpfs serves a folder as a network file share.\n"+
 		"  udpbd serves one disk image as a network hard drive.\n"+
-		"  smb   serves folders over SMBv1, for OPL's game list and POPSTARTER.\n\n", version)
+		"  smb   serves folders over SMBv1, for OPL's game list and POPSTARTER.\n"+
+		"  webui serves a web dashboard to configure and manage Edge servers.\n\n", version)
 }
 func duration(v string) (time.Duration, error) {
 	if v == "" {
@@ -78,6 +81,10 @@ func main() {
 	}
 	if len(os.Args) >= 2 && os.Args[1] == "smb" {
 		runSMB()
+		return
+	}
+	if len(os.Args) >= 2 && os.Args[1] == "webui" {
+		runWebUI()
 		return
 	}
 	if len(os.Args) < 2 || os.Args[1] != "udpfs" {
@@ -399,3 +406,48 @@ type shareList []string
 
 func (s *shareList) String() string     { return strings.Join(*s, ",") }
 func (s *shareList) Set(v string) error { *s = append(*s, v); return nil }
+
+// runWebUI serves the embedded web dashboard and API for managing Edge.
+func runWebUI() {
+	fs := flag.NewFlagSet("webui", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	bind := fs.String("bind", env("WEBUI_BIND", "0.0.0.0"), "IPv4 bind address")
+	port := fs.Int("webui-port", envInt("WEBUI_PORT", 8082), "HTTP port (0 uses 8082 or OS assigned)")
+	configFile := fs.String("config-file", env("CONFIG_FILE", "/etc/ps2servers-edge/config.json"), "path to config file")
+	logLines := fs.Int("log-lines", envInt("LOG_LINES", 1000), "number of log lines to buffer")
+	noBrowse := fs.Bool("no-browse", envBool("NO_BROWSE", false), "disable file browser API endpoint")
+	logFormat := fs.String("log-format", env("LOG_FORMAT", "text"), "text or json")
+	verbose := fs.Bool("verbose", envBool("VERBOSE", false), "verbose logging")
+	quiet := fs.Bool("quiet", false, "suppress informational logs")
+
+	if err := fs.Parse(os.Args[2:]); err != nil {
+		os.Exit(2)
+	}
+
+	logger := edgelog.New(os.Stdout, *logFormat, *quiet, *verbose)
+	logBuffer := webui.NewLogBuffer(*logLines)
+
+	srv, err := webui.New(webui.Config{
+		Port:       *port,
+		Bind:       *bind,
+		ConfigFile: *configFile,
+		LogLines:   *logLines,
+		NoBrowse:   *noBrowse,
+		Version:    version,
+		Log:        logger,
+		LogBuffer:  logBuffer,
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := srv.Serve(ctx); err != nil {
+		logger.Error("webui server stopped", map[string]any{"error": err})
+		os.Exit(1)
+	}
+}
+

--- a/native/ps2servers-edge/internal/webui/api.go
+++ b/native/ps2servers-edge/internal/webui/api.go
@@ -1,0 +1,234 @@
+package webui
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// API groups all HTTP handlers for the web UI.
+type API struct {
+	configBackend ConfigBackend
+	manager       ServiceManager
+	logBuffer     *LogBuffer
+	noBrowse      bool
+	version       string
+}
+
+func jsonResponse(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(data)
+}
+
+func jsonError(w http.ResponseWriter, status int, msg string) {
+	jsonResponse(w, status, map[string]string{"error": msg})
+}
+
+func (a *API) HandleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		jsonError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+	status, err := a.manager.Status()
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Build the combined dashboard response that the frontend expects.
+	result := map[string]interface{}{
+		"udpfs": status["udpfs"],
+		"smb":   status["smb"],
+		"udpbd": status["udpbd"],
+		"system": map[string]string{
+			"version":  a.version,
+			"platform": runtime.GOOS,
+			"arch":     runtime.GOARCH,
+		},
+	}
+	jsonResponse(w, http.StatusOK, result)
+}
+
+func (a *API) HandleConfig(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		cfg, err := a.configBackend.Load()
+		if err != nil {
+			jsonError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		jsonResponse(w, http.StatusOK, cfg)
+		return
+	}
+
+	if r.Method == http.MethodPost {
+		var cfg EdgeConfig
+		if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
+			jsonError(w, http.StatusBadRequest, "Invalid JSON")
+			return
+		}
+		if err := a.configBackend.Save(&cfg); err != nil {
+			jsonError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		jsonResponse(w, http.StatusOK, map[string]bool{"ok": true})
+		return
+	}
+
+	jsonError(w, http.StatusMethodNotAllowed, "Method not allowed")
+}
+
+func (a *API) HandleConfigDefaults(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		jsonError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+	jsonResponse(w, http.StatusOK, DefaultConfig())
+}
+
+func (a *API) HandleConfigReset(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		jsonError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+	if err := a.configBackend.Save(DefaultConfig()); err != nil {
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	jsonResponse(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func (a *API) HandleRestart(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		jsonError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+
+	var req struct {
+		Service string `json:"service"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "Invalid JSON")
+		return
+	}
+
+	if err := a.manager.Restart(req.Service); err != nil {
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	jsonResponse(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func (a *API) HandleLogs(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	lines := a.logBuffer.Lines()
+	for _, line := range lines {
+		fmt.Fprintf(w, "data: %s\n\n", line)
+	}
+	flusher.Flush()
+
+	ch, unsub := a.logBuffer.Subscribe()
+	defer unsub()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case line, ok := <-ch:
+			if !ok {
+				return
+			}
+			fmt.Fprintf(w, "data: %s\n\n", line)
+			flusher.Flush()
+		}
+	}
+}
+
+// browseEntry is a single item returned by the file browser.
+type browseEntry struct {
+	Name  string `json:"name"`
+	IsDir bool   `json:"is_dir"`
+	Size  int64  `json:"size"`
+}
+
+// browseResponse is the structured response for the file browser.
+type browseResponse struct {
+	Path   string        `json:"path"`
+	Parent string        `json:"parent,omitempty"`
+	Items  []browseEntry `json:"items"`
+}
+
+func (a *API) HandleBrowse(w http.ResponseWriter, r *http.Request) {
+	if a.noBrowse {
+		jsonError(w, http.StatusForbidden, "File browsing is disabled")
+		return
+	}
+
+	path := r.URL.Query().Get("path")
+	if path == "" {
+		path = "/"
+	}
+
+	if !filepath.IsAbs(path) || strings.Contains(path, "..") {
+		jsonError(w, http.StatusBadRequest, "Invalid path")
+		return
+	}
+
+	// Resolve to a canonical path.
+	path = filepath.Clean(path)
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var items []browseEntry
+	for _, e := range entries {
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		items = append(items, browseEntry{
+			Name:  e.Name(),
+			IsDir: e.IsDir(),
+			Size:  info.Size(),
+		})
+	}
+
+	resp := browseResponse{
+		Path:  path,
+		Items: items,
+	}
+
+	// Compute parent directory, unless we are at a filesystem root.
+	parent := filepath.Dir(path)
+	if parent != path {
+		resp.Parent = parent
+	}
+
+	jsonResponse(w, http.StatusOK, resp)
+}
+
+func (a *API) HandleInfo(w http.ResponseWriter, r *http.Request) {
+	jsonResponse(w, http.StatusOK, map[string]string{
+		"version":  a.version,
+		"platform": runtime.GOOS,
+		"arch":     runtime.GOARCH,
+	})
+}

--- a/native/ps2servers-edge/internal/webui/assets/app.js
+++ b/native/ps2servers-edge/internal/webui/assets/app.js
@@ -1,0 +1,462 @@
+// Router
+function handleHashChange() {
+    let hash = window.location.hash.substring(1) || 'dashboard';
+    
+    // Update nav links
+    document.querySelectorAll('.nav-link').forEach(link => {
+        link.classList.remove('active');
+        if (link.dataset.tab === hash) link.classList.add('active');
+    });
+
+    // Update tab content
+    document.querySelectorAll('.tab-content').forEach(tab => {
+        tab.classList.remove('active');
+    });
+    const targetTab = document.getElementById('tab-' + hash);
+    if (targetTab) targetTab.classList.add('active');
+
+    // Trigger tab-specific logic
+    if (['udpfs', 'smb', 'udpbd'].includes(hash)) {
+        if (!configCache[hash]) formActions.load(hash);
+    } else if (hash === 'about') {
+        loadInfo();
+    }
+}
+window.addEventListener('hashchange', handleHashChange);
+
+// API Helpers
+async function api(path, options = {}) {
+    try {
+        const res = await fetch(path, options);
+        if (!res.ok) {
+            let msg = `HTTP ${res.status}`;
+            try { const err = await res.json(); if(err.error) msg = err.error; } catch(e){}
+            throw new Error(msg);
+        }
+        return await res.json();
+    } catch (e) {
+        showToast(e.message, 'error');
+        throw e;
+    }
+}
+
+// Toasts
+function showToast(message, type = 'info') {
+    const container = document.getElementById('toast-container');
+    const toast = document.createElement('div');
+    toast.className = `toast ${type}`;
+    toast.textContent = message;
+    container.appendChild(toast);
+    
+    setTimeout(() => {
+        toast.classList.add('hiding');
+        setTimeout(() => toast.remove(), 300);
+    }, 3000);
+}
+
+// Dashboard
+function formatUptime(seconds) {
+    if (seconds == null || seconds < 0) return '-';
+    if (seconds === 0) return '0s';
+    const d = Math.floor(seconds / (3600*24));
+    const h = Math.floor(seconds % (3600*24) / 3600);
+    const m = Math.floor(seconds % 3600 / 60);
+    const s = Math.floor(seconds % 60);
+    let out = [];
+    if (d > 0) out.push(d + 'd');
+    if (h > 0) out.push(h + 'h');
+    if (m > 0) out.push(m + 'm');
+    if (s > 0 || out.length === 0) out.push(s + 's');
+    return out.join(' ');
+}
+
+function updateStatusBadge(id, status) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.textContent = status.toUpperCase();
+    el.className = 'badge';
+    if (status === 'ready') el.classList.add('badge-ok');
+    else if (status === 'busy' || status === 'degraded') el.classList.add('badge-warn');
+    else if (status === 'stopped') el.classList.add('badge-error');
+    else el.classList.add('badge-grey');
+}
+
+async function pollDashboard() {
+    if (window.location.hash !== '' && window.location.hash !== '#dashboard') return;
+    try {
+        const res = await fetch('/api/status');
+        if (!res.ok) return;
+        const data = await res.json();
+        
+        ['udpfs', 'smb', 'udpbd'].forEach(svc => {
+            const s = data[svc];
+            if (s) {
+                updateStatusBadge(`dash-${svc}-status`, s.status || 'unknown');
+                document.getElementById(`dash-${svc}-sessions`).textContent = s.sessions || 0;
+                document.getElementById(`dash-${svc}-uptime`).textContent = formatUptime(s.uptime);
+            }
+        });
+        
+        if (data.system) {
+            document.getElementById('dash-sys-version').textContent = data.system.version || '-';
+            document.getElementById('dash-sys-platform').textContent = data.system.platform || '-';
+            document.getElementById('dash-sys-arch').textContent = data.system.arch || '-';
+        }
+    } catch(e) {}
+}
+setInterval(pollDashboard, 2000);
+
+async function restartService(service) {
+    try {
+        await api('/api/restart', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ service })
+        });
+        showToast(`${service} restart initiated`, 'success');
+        pollDashboard();
+    } catch(e) {}
+}
+
+// Config Forms
+const configCache = { udpfs: null, smb: null, udpbd: null };
+
+const formActions = {
+    async load(service) {
+        try {
+            const data = await api('/api/config');
+            configCache[service] = data[service] || {};
+            this.populate(service, configCache[service]);
+            this.checkDirty(service);
+        } catch(e) {}
+    },
+    async reset(service) {
+        await this.load(service);
+        showToast('Reset to saved settings', 'info');
+    },
+    async defaults(service) {
+        try {
+            const data = await api('/api/config/defaults');
+            this.populate(service, data[service] || {});
+            this.checkDirty(service);
+            showToast('Loaded defaults (not saved)', 'info');
+        } catch(e) {}
+    },
+    populate(service, data) {
+        const form = document.getElementById(`form-${service}`);
+        if (!form || !data) return;
+        
+        Array.from(form.elements).forEach(input => {
+            if (!input.name || input.name.startsWith('_')) return;
+            let val = data[input.name];
+            if (val === undefined) return;
+            
+            if (input.type === 'checkbox') input.checked = !!val;
+            else input.value = val;
+        });
+
+        // Special handlers
+        if (service === 'udpfs') {
+            const decomp = form.querySelector('[name="_decompress"]');
+            if (decomp) decomp.checked = !data.no_compression;
+        }
+    },
+    getValues(service) {
+        const form = document.getElementById(`form-${service}`);
+        const data = {};
+        Array.from(form.elements).forEach(input => {
+            if (!input.name || input.name.startsWith('_')) return;
+            
+            let val = input.type === 'checkbox' ? input.checked : input.value;
+            
+            // Type conversions
+            if (input.type === 'number') {
+                val = val === '' ? 0 : parseInt(val, 10);
+            }
+            if (input.name === 'sector_size') val = parseInt(val, 10);
+            
+            data[input.name] = val;
+        });
+
+        // Special handlers
+        if (service === 'udpfs') {
+            const decomp = form.querySelector('[name="_decompress"]');
+            if (decomp) data.no_compression = !decomp.checked;
+        }
+        
+        return data;
+    },
+    async save(service, quiet = false) {
+        const data = this.getValues(service);
+        
+        // Basic Validation
+        if (data.port < 0 || data.port > 65535) { showToast('Invalid port', 'error'); return false; }
+        if (service === 'smb' && data.share && !data.share.includes('=')) { showToast('SMB share must be NAME=PATH format', 'error'); return false; }
+        
+        try {
+            const fullConfig = await api('/api/config');
+            fullConfig[service] = data;
+            
+            await api('/api/config', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(fullConfig)
+            });
+            
+            configCache[service] = data;
+            this.checkDirty(service);
+            if (!quiet) showToast(`${service.toUpperCase()} config saved`, 'success');
+            return true;
+        } catch(e) {
+            return false;
+        }
+    },
+    async apply(service) {
+        const saved = await this.save(service, true);
+        if (saved) {
+            await restartService(service);
+            showToast(`${service.toUpperCase()} saved and applied`, 'success');
+        }
+    },
+    checkDirty(service) {
+        if (!configCache[service]) return;
+        const current = this.getValues(service);
+        const saved = configCache[service];
+        
+        let isDirty = false;
+        for (const key in current) {
+            if (current[key] !== saved[key]) {
+                isDirty = true; break;
+            }
+        }
+        
+        const navLink = document.querySelector(`.nav-link[data-tab="${service}"]`);
+        if (navLink) {
+            if (isDirty) navLink.classList.add('dirty');
+            else navLink.classList.remove('dirty');
+        }
+    }
+};
+
+// Listen for form changes to update dirty state
+document.querySelectorAll('.config-form').forEach(form => {
+    form.addEventListener('input', (e) => {
+        formActions.checkDirty(form.dataset.service);
+    });
+    form.addEventListener('change', (e) => {
+        formActions.checkDirty(form.dataset.service);
+    });
+});
+
+// UI Interaction
+function toggleCollapse(id) {
+    const el = document.getElementById(id);
+    const header = el.previousElementSibling;
+    if (el.classList.contains('collapsed')) {
+        el.classList.remove('collapsed');
+        header.classList.add('open');
+    } else {
+        el.classList.add('collapsed');
+        header.classList.remove('open');
+    }
+}
+
+// Info Tab
+async function loadInfo() {
+    try {
+        const data = await api('/api/info');
+        document.getElementById('about-sys-version').textContent = data.version || '-';
+        document.getElementById('about-sys-platform').textContent = data.platform || '-';
+        document.getElementById('about-sys-arch').textContent = data.arch || '-';
+    } catch(e) {}
+}
+
+// File Browser
+let currentBrowserForm = null;
+let currentBrowserInput = null;
+let currentBrowserPath = '';
+let currentBrowserIsDirOnly = true;
+
+async function openBrowser(formId, inputName, isDirOnly) {
+    currentBrowserForm = formId;
+    currentBrowserInput = inputName;
+    currentBrowserIsDirOnly = isDirOnly;
+    
+    const input = document.querySelector(`#${formId} [name="${inputName}"]`);
+    currentBrowserPath = input.value || '/';
+    // If it's a file path, we want to browse its parent dir
+    if (!isDirOnly && currentBrowserPath !== '/') {
+        const lastSlash = currentBrowserPath.lastIndexOf('/');
+        const lastBackslash = currentBrowserPath.lastIndexOf('\\');
+        const sep = lastSlash > lastBackslash ? lastSlash : lastBackslash;
+        if (sep > 0) currentBrowserPath = currentBrowserPath.substring(0, sep);
+    }
+    
+    document.getElementById('browser-modal').classList.add('show');
+    await loadBrowserPath(currentBrowserPath);
+}
+
+function closeBrowser() {
+    document.getElementById('browser-modal').classList.remove('show');
+}
+
+function selectBrowserPath() {
+    if (currentBrowserInput && currentBrowserForm) {
+        const input = document.querySelector(`#${currentBrowserForm} [name="${currentBrowserInput}"]`);
+        input.value = currentBrowserPath;
+        // Trigger input event to update dirty state
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    closeBrowser();
+}
+
+function selectFile(fullPath) {
+    if (currentBrowserInput && currentBrowserForm) {
+        const input = document.querySelector(`#${currentBrowserForm} [name="${currentBrowserInput}"]`);
+        input.value = fullPath;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    closeBrowser();
+}
+
+async function loadBrowserPath(path) {
+    const list = document.getElementById('browser-list');
+    list.innerHTML = '<div class="muted" style="padding:1rem;">Loading...</div>';
+    
+    try {
+        const res = await api(`/api/browse?path=${encodeURIComponent(path)}`);
+        currentBrowserPath = res.path; // server returns resolved canonical path
+        
+        // Render Breadcrumbs
+        const breadcrumbs = document.getElementById('browser-breadcrumbs');
+        breadcrumbs.innerHTML = '';
+        
+        // Very basic split for UI (handles both slashes)
+        let parts = currentBrowserPath.split(/[/\\]/).filter(Boolean);
+        if (currentBrowserPath.startsWith('/')) {
+            addBreadcrumb('Root', '/', 0, parts);
+        } else if (parts.length > 0 && parts[0].includes(':')) {
+            // Windows drive root
+            addBreadcrumb(parts[0] + '\\', parts[0] + '\\', 0, parts);
+            parts.shift();
+        } else {
+            addBreadcrumb('Root', '/', 0, parts);
+        }
+
+        let accum = currentBrowserPath.startsWith('/') ? '/' : (currentBrowserPath.split(/[/\\]/)[0] + '\\');
+        parts.forEach((part, i) => {
+            breadcrumbs.insertAdjacentHTML('beforeend', '<span class="breadcrumb-sep">/</span>');
+            accum += (accum.endsWith('/') || accum.endsWith('\\') ? '' : '/') + part;
+            addBreadcrumb(part, accum, i+1, parts);
+        });
+        
+        // Render List
+        list.innerHTML = '';
+        
+        // Parent dir item
+        if (res.parent) {
+            const up = document.createElement('div');
+            up.className = 'browser-item';
+            up.innerHTML = `<span class="browser-item-icon">📁</span><span>.. (Up)</span>`;
+            up.onclick = () => loadBrowserPath(res.parent);
+            list.appendChild(up);
+        }
+
+        if (!res.items || res.items.length === 0) {
+            list.insertAdjacentHTML('beforeend', '<div class="muted" style="padding:1rem;">Empty directory</div>');
+            return;
+        }
+        
+        res.items.forEach(item => {
+            if (currentBrowserIsDirOnly && !item.is_dir) return; // filter files if dir only
+            
+            const div = document.createElement('div');
+            div.className = 'browser-item';
+            
+            const icon = item.is_dir ? '📁' : '📄';
+            let sizeStr = '';
+            if (!item.is_dir && item.size !== undefined) {
+                const mb = (item.size / (1024*1024)).toFixed(2);
+                sizeStr = `<span class="muted" style="margin-left:auto; font-size:0.8rem;">${mb} MB</span>`;
+            }
+            
+            div.innerHTML = `<span class="browser-item-icon">${icon}</span><span>${item.name}</span>${sizeStr}`;
+            
+            let fullPath = currentBrowserPath;
+            if (!fullPath.endsWith('/') && !fullPath.endsWith('\\')) {
+                fullPath += currentBrowserPath.includes('\\') ? '\\' : '/';
+            }
+            fullPath += item.name;
+            
+            if (item.is_dir) {
+                div.onclick = () => loadBrowserPath(fullPath);
+            } else {
+                div.onclick = () => selectFile(fullPath);
+            }
+            list.appendChild(div);
+        });
+        
+    } catch(e) {
+        list.innerHTML = `<div class="toast error" style="position:static; margin:1rem;">${e.message}</div>`;
+    }
+}
+
+function addBreadcrumb(label, path, index, parts) {
+    const el = document.createElement('span');
+    el.className = 'breadcrumb-item';
+    el.textContent = label;
+    el.onclick = () => loadBrowserPath(path);
+    document.getElementById('browser-breadcrumbs').appendChild(el);
+}
+
+// Logs Viewer (SSE)
+let evtSource = null;
+const logViewer = document.getElementById('log-viewer');
+const logAutoScroll = document.getElementById('log-autoscroll');
+const logStatus = document.getElementById('log-status');
+let reconnectTimeout = null;
+
+function clearLogs() {
+    logViewer.textContent = '';
+}
+
+function connectLogs() {
+    if (evtSource) return;
+    
+    evtSource = new EventSource('/api/logs');
+    
+    evtSource.onopen = () => {
+        logStatus.textContent = 'Connected';
+        logStatus.className = 'badge badge-ok';
+        if (reconnectTimeout) clearTimeout(reconnectTimeout);
+    };
+    
+    evtSource.onmessage = (e) => {
+        // Append
+        logViewer.appendChild(document.createTextNode(e.data + '\n'));
+        
+        // Cap lines
+        if (logViewer.childNodes.length > 1000) {
+            logViewer.removeChild(logViewer.firstChild);
+        }
+        
+        if (logAutoScroll.checked) {
+            logViewer.scrollTop = logViewer.scrollHeight;
+        }
+    };
+    
+    evtSource.onerror = () => {
+        logStatus.textContent = 'Reconnecting...';
+        logStatus.className = 'badge badge-warn';
+        evtSource.close();
+        evtSource = null;
+        reconnectTimeout = setTimeout(connectLogs, 2000); // 2s backoff
+    };
+}
+
+// Init
+document.addEventListener('DOMContentLoaded', () => {
+    handleHashChange();
+    pollDashboard();
+    connectLogs();
+});

--- a/native/ps2servers-edge/internal/webui/assets/index.html
+++ b/native/ps2servers-edge/internal/webui/assets/index.html
@@ -1,0 +1,459 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PS2 Servers Edge</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <nav class="sidebar" id="sidebar">
+        <div class="brand">PS2 Servers Edge</div>
+        <a href="#dashboard" class="nav-link active" data-tab="dashboard">Dashboard</a>
+        <a href="#udpfs" class="nav-link" data-tab="udpfs">UDPFS<span class="dirty-dot"></span></a>
+        <a href="#smb" class="nav-link" data-tab="smb">SMB<span class="dirty-dot"></span></a>
+        <a href="#udpbd" class="nav-link" data-tab="udpbd">UDPBD<span class="dirty-dot"></span></a>
+        <a href="#logs" class="nav-link" data-tab="logs">Logs</a>
+        <a href="#about" class="nav-link" data-tab="about">About</a>
+    </nav>
+
+    <main class="content">
+        <!-- Dashboard Tab -->
+        <section id="tab-dashboard" class="tab-content active">
+            <header><h2>Dashboard</h2></header>
+            <div class="dashboard-grid">
+                <!-- UDPFS Card -->
+                <div class="card status-card">
+                    <div class="card-header">
+                        <h3>UDPFS</h3>
+                        <span id="dash-udpfs-status" class="badge badge-grey">Unknown</span>
+                    </div>
+                    <div class="card-body">
+                        <div class="stat"><span class="label">Sessions:</span> <span id="dash-udpfs-sessions">0</span></div>
+                        <div class="stat"><span class="label">Uptime:</span> <span id="dash-udpfs-uptime">-</span></div>
+                    </div>
+                    <div class="card-footer">
+                        <button class="btn" onclick="restartService('udpfs')">Restart Service</button>
+                    </div>
+                </div>
+                <!-- SMB Card -->
+                <div class="card status-card">
+                    <div class="card-header">
+                        <h3>SMB</h3>
+                        <span id="dash-smb-status" class="badge badge-grey">Unknown</span>
+                    </div>
+                    <div class="card-body">
+                        <div class="stat"><span class="label">Sessions:</span> <span id="dash-smb-sessions">0</span></div>
+                        <div class="stat"><span class="label">Uptime:</span> <span id="dash-smb-uptime">-</span></div>
+                    </div>
+                    <div class="card-footer">
+                        <button class="btn" onclick="restartService('smb')">Restart Service</button>
+                    </div>
+                </div>
+                <!-- UDPBD Card -->
+                <div class="card status-card">
+                    <div class="card-header">
+                        <h3>UDPBD</h3>
+                        <span id="dash-udpbd-status" class="badge badge-grey">Unknown</span>
+                    </div>
+                    <div class="card-body">
+                        <div class="stat"><span class="label">Sessions:</span> <span id="dash-udpbd-sessions">0</span></div>
+                        <div class="stat"><span class="label">Uptime:</span> <span id="dash-udpbd-uptime">-</span></div>
+                    </div>
+                    <div class="card-footer">
+                        <button class="btn" onclick="restartService('udpbd')">Restart Service</button>
+                    </div>
+                </div>
+                <!-- System Info Card -->
+                <div class="card info-card">
+                    <div class="card-header">
+                        <h3>System Info</h3>
+                    </div>
+                    <div class="card-body">
+                        <div class="stat"><span class="label">Version:</span> <span id="dash-sys-version">-</span></div>
+                        <div class="stat"><span class="label">Platform:</span> <span id="dash-sys-platform">-</span></div>
+                        <div class="stat"><span class="label">Arch:</span> <span id="dash-sys-arch">-</span></div>
+                    </div>
+                    <div class="card-footer">
+                        <button class="btn" onclick="restartService('all')">Restart All</button>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- UDPFS Tab -->
+        <section id="tab-udpfs" class="tab-content">
+            <header>
+                <h2>UDPFS Configuration</h2>
+                <div class="action-bar">
+                    <button class="btn" onclick="formActions.reset('udpfs')">Reset</button>
+                    <button class="btn" onclick="formActions.defaults('udpfs')">Defaults</button>
+                    <button class="btn btn-primary" onclick="formActions.save('udpfs')">Save</button>
+                    <button class="btn btn-accent" onclick="formActions.apply('udpfs')">Apply</button>
+                </div>
+            </header>
+            <form id="form-udpfs" class="config-form" data-service="udpfs">
+                <div class="card">
+                    <h3>Basic Settings</h3>
+                    <div class="form-group">
+                        <label class="toggle">
+                            <input type="checkbox" name="enabled">
+                            <span class="slider"></span>
+                            <span class="toggle-label">Enable UDPFS</span>
+                        </label>
+                    </div>
+                    <div class="form-group">
+                        <label>Games Folder (root)</label>
+                        <div class="input-with-btn">
+                            <input type="text" name="root" placeholder="/path/to/games">
+                            <button type="button" class="btn" onclick="openBrowser('form-udpfs', 'root', true)">Browse</button>
+                        </div>
+                        <small class="help-text">Base directory containing PS2 game folders (DVD/, CD/, APPS/, VMC/).</small>
+                    </div>
+                    <div class="form-group">
+                        <label>Protocol Mode</label>
+                        <select name="protocol_mode">
+                            <option value="Auto">Auto</option>
+                            <option value="Standard">Standard</option>
+                            <option value="Modulo">Modulo</option>
+                        </select>
+                        <small class="help-text">Auto handles Standard and Modulo clients simultaneously. Pick one explicitly only if a console will not connect on Auto.</small>
+                    </div>
+                    <div class="form-group">
+                        <label class="toggle">
+                            <input type="checkbox" name="read_only">
+                            <span class="slider"></span>
+                            <span class="toggle-label">Read-only</span>
+                        </label>
+                        <small class="help-text">Serve read-only. Omit to allow the console to write saves (VMC, etc).</small>
+                    </div>
+                    <div class="form-group">
+                        <label class="toggle">
+                            <!-- Note: UI is "Decompress", backend is "no_compression". Handled in JS -->
+                            <input type="checkbox" name="_decompress">
+                            <span class="slider"></span>
+                            <span class="toggle-label">Decompress CSO/ZSO</span>
+                        </label>
+                        <small class="help-text">Automatically decompress CSO/ZSO images so games load from compressed files.</small>
+                    </div>
+                </div>
+
+                <div class="card">
+                    <div class="card-header collapsible" onclick="toggleCollapse('udpfs-adv')">
+                        <h3>Advanced Settings</h3>
+                        <span class="collapse-icon">▼</span>
+                    </div>
+                    <div id="udpfs-adv" class="card-body collapsed">
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label>Bind Address</label>
+                                <input type="text" name="bind" placeholder="0.0.0.0">
+                                <small class="help-text">IPv4 address to listen on. 0.0.0.0 for all interfaces.</small>
+                            </div>
+                            <div class="form-group">
+                                <label>Port</label>
+                                <input type="number" name="port" placeholder="62966">
+                                <small class="help-text">Discovery UDP port (default 62966 / 0xF5F6).</small>
+                            </div>
+                            <div class="form-group">
+                                <label>Data Port</label>
+                                <input type="number" name="data_port" placeholder="0">
+                                <small class="help-text">Fixed data UDP port. 0 picks automatically.</small>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="toggle">
+                                <input type="checkbox" name="single_port">
+                                <span class="slider"></span>
+                                <span class="toggle-label">Single Port Mode</span>
+                            </label>
+                            <small class="help-text">Forces all traffic through the discovery port. Use for strict firewalls or legacy clients.</small>
+                        </div>
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label>Peer Timeout</label>
+                                <input type="text" name="peer_timeout" placeholder="1h">
+                                <small class="help-text">Drop inactive consoles after this duration (1m–24h). Default 1h.</small>
+                            </div>
+                            <div class="form-group">
+                                <label>TX Delay (ms)</label>
+                                <input type="number" name="tx_delay_ms" placeholder="0">
+                                <small class="help-text">Inter-packet pacing delay in milliseconds. Raise if a slow link drops packets.</small>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label>Block Device</label>
+                            <div class="input-with-btn">
+                                <input type="text" name="block_device" placeholder="/path/to/image.raw">
+                                <button type="button" class="btn" onclick="openBrowser('form-udpfs', 'block_device', false)">Browse</button>
+                            </div>
+                            <small class="help-text">Serve this disk image over UDPFS block access alongside the file share.</small>
+                        </div>
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label>Sector Size</label>
+                                <select name="sector_size">
+                                    <option value="512">512</option>
+                                    <option value="1024">1024</option>
+                                    <option value="2048">2048</option>
+                                    <option value="4096">4096</option>
+                                    <option value="8192">8192</option>
+                                    <option value="16384">16384</option>
+                                    <option value="32768">32768</option>
+                                    <option value="65536">65536</option>
+                                </select>
+                                <small class="help-text">Sector size for block device. Multiple of 512, max 65536.</small>
+                            </div>
+                            <div class="form-group">
+                                <label>Compression Cache Size</label>
+                                <input type="number" name="compression_cache_size" placeholder="32">
+                                <small class="help-text">Decompressed blocks cached per image (0–4096). Default 32.</small>
+                            </div>
+                        </div>
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label class="toggle">
+                                    <input type="checkbox" name="metrics">
+                                    <span class="slider"></span>
+                                    <span class="toggle-label">Enable Metrics</span>
+                                </label>
+                                <small class="help-text">Log periodic transfer statistics.</small>
+                            </div>
+                            <div class="form-group">
+                                <label>Metrics Period</label>
+                                <input type="text" name="metrics_period" placeholder="1m">
+                                <small class="help-text">How often to log statistics (1s–24h). Default 1m.</small>
+                            </div>
+                        </div>
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label>Log Format</label>
+                                <select name="log_format">
+                                    <option value="text">Text</option>
+                                    <option value="json">JSON</option>
+                                </select>
+                                <small class="help-text">Log output format.</small>
+                            </div>
+                            <div class="form-group">
+                                <label class="toggle">
+                                    <input type="checkbox" name="verbose">
+                                    <span class="slider"></span>
+                                    <span class="toggle-label">Verbose Logging</span>
+                                </label>
+                                <small class="help-text">Enable detailed protocol-level logging.</small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </section>
+
+        <!-- SMB Tab -->
+        <section id="tab-smb" class="tab-content">
+            <header>
+                <h2>SMB Configuration</h2>
+                <div class="action-bar">
+                    <button class="btn" onclick="formActions.reset('smb')">Reset</button>
+                    <button class="btn" onclick="formActions.defaults('smb')">Defaults</button>
+                    <button class="btn btn-primary" onclick="formActions.save('smb')">Save</button>
+                    <button class="btn btn-accent" onclick="formActions.apply('smb')">Apply</button>
+                </div>
+            </header>
+            <form id="form-smb" class="config-form" data-service="smb">
+                <div class="card">
+                    <div class="form-group">
+                        <label class="toggle">
+                            <input type="checkbox" name="enabled">
+                            <span class="slider"></span>
+                            <span class="toggle-label">Enable SMB</span>
+                        </label>
+                    </div>
+                    <div class="form-group">
+                        <label>Share (NAME=PATH)</label>
+                        <div class="input-with-btn">
+                            <input type="text" name="share" placeholder="PS2SMB=/path/to/games">
+                        </div>
+                        <small class="help-text">Share as NAME=PATH. The name is what OPL enters after the IP.</small>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label>Bind Address</label>
+                            <input type="text" name="bind" placeholder="0.0.0.0">
+                            <small class="help-text">IPv4 address to listen on. 0.0.0.0 for all interfaces.</small>
+                        </div>
+                        <div class="form-group">
+                            <label>Port</label>
+                            <input type="number" name="port" placeholder="1111">
+                            <small class="help-text">TCP port. Set OPL's SMB Port to match. Default 1111. Ports below 1024 need root.</small>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="toggle">
+                            <input type="checkbox" name="read_only">
+                            <span class="slider"></span>
+                            <span class="toggle-label">Read-only</span>
+                        </label>
+                        <small class="help-text">Serve read-only. Omit to allow the console to write saves (VMC, etc).</small>
+                    </div>
+                    <div class="form-group">
+                        <label>Status Port</label>
+                        <input type="number" name="status_port" placeholder="0">
+                        <small class="help-text">UDP port for router status queries. 0 disables, -1 uses the standard discovery port.</small>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label>Log Format</label>
+                            <select name="log_format">
+                                <option value="text">Text</option>
+                                <option value="json">JSON</option>
+                            </select>
+                            <small class="help-text">Log output format.</small>
+                        </div>
+                        <div class="form-group">
+                            <label class="toggle">
+                                <input type="checkbox" name="verbose">
+                                <span class="slider"></span>
+                                <span class="toggle-label">Verbose Logging</span>
+                            </label>
+                            <small class="help-text">Enable detailed protocol-level logging.</small>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </section>
+
+        <!-- UDPBD Tab -->
+        <section id="tab-udpbd" class="tab-content">
+            <header>
+                <h2>UDPBD Configuration</h2>
+                <div class="action-bar">
+                    <button class="btn" onclick="formActions.reset('udpbd')">Reset</button>
+                    <button class="btn" onclick="formActions.defaults('udpbd')">Defaults</button>
+                    <button class="btn btn-primary" onclick="formActions.save('udpbd')">Save</button>
+                    <button class="btn btn-accent" onclick="formActions.apply('udpbd')">Apply</button>
+                </div>
+            </header>
+            <form id="form-udpbd" class="config-form" data-service="udpbd">
+                <div class="card">
+                    <div class="form-group">
+                        <label class="toggle">
+                            <input type="checkbox" name="enabled">
+                            <span class="slider"></span>
+                            <span class="toggle-label">Enable UDPBD</span>
+                        </label>
+                    </div>
+                    <div class="form-group">
+                        <label>Disk Image</label>
+                        <div class="input-with-btn">
+                            <input type="text" name="image" placeholder="/path/to/hdd.img">
+                            <button type="button" class="btn" onclick="openBrowser('form-udpbd', 'image', false)">Browse</button>
+                        </div>
+                        <small class="help-text">Raw disk image file to serve as a virtual hard drive.</small>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label>Bind Address</label>
+                            <input type="text" name="bind" placeholder="0.0.0.0">
+                            <small class="help-text">IPv4 address to listen on. 0.0.0.0 for all interfaces.</small>
+                        </div>
+                        <div class="form-group">
+                            <label>Port</label>
+                            <input type="number" name="port" placeholder="48301">
+                            <small class="help-text">UDP port for UDPBD traffic. Default 48301 (0xBDBD).</small>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="toggle">
+                            <input type="checkbox" name="read_only">
+                            <span class="slider"></span>
+                            <span class="toggle-label">Read-only</span>
+                        </label>
+                        <small class="help-text">Serve read-only. Omit to allow the console to write saves (VMC, etc).</small>
+                    </div>
+                    <div class="form-group">
+                        <label>Status Port</label>
+                        <input type="number" name="status_port" placeholder="0">
+                        <small class="help-text">UDP port for router status queries. 0 disables, -1 uses the standard discovery port.</small>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label>Log Format</label>
+                            <select name="log_format">
+                                <option value="text">Text</option>
+                                <option value="json">JSON</option>
+                            </select>
+                            <small class="help-text">Log output format.</small>
+                        </div>
+                        <div class="form-group">
+                            <label class="toggle">
+                                <input type="checkbox" name="verbose">
+                                <span class="slider"></span>
+                                <span class="toggle-label">Verbose Logging</span>
+                            </label>
+                            <small class="help-text">Enable detailed protocol-level logging.</small>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </section>
+
+        <!-- Logs Tab -->
+        <section id="tab-logs" class="tab-content h-full flex-col">
+            <header>
+                <h2>Live Logs</h2>
+                <div class="log-controls">
+                    <span id="log-status" class="badge badge-grey">Disconnected</span>
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="log-autoscroll" checked> Auto-scroll
+                    </label>
+                    <button class="btn" onclick="clearLogs()">Clear</button>
+                </div>
+            </header>
+            <div class="card log-viewer-card h-full">
+                <div id="log-viewer" class="log-viewer"></div>
+            </div>
+        </section>
+
+        <!-- About Tab -->
+        <section id="tab-about" class="tab-content">
+            <header><h2>About</h2></header>
+            <div class="card text-center">
+                <h1 class="about-title">PS2 Servers Edge</h1>
+                <p class="muted">A high-performance embedded server suite for the PlayStation 2.</p>
+                <div class="about-stats">
+                    <p><strong>Version:</strong> <span id="about-sys-version">...</span></p>
+                    <p><strong>Platform:</strong> <span id="about-sys-platform">...</span></p>
+                    <p><strong>Architecture:</strong> <span id="about-sys-arch">...</span></p>
+                </div>
+                <div class="about-links">
+                    <a href="https://github.com/NathanNeurotic/PS2-Servers" target="_blank" class="btn btn-primary">GitHub Repository</a>
+                </div>
+                <p class="muted mt-4"><small>&copy; PS2 Servers Edge Contributors</small></p>
+            </div>
+        </section>
+    </main>
+
+    <!-- File Browser Modal -->
+    <div id="browser-modal" class="modal-backdrop">
+        <div class="modal card">
+            <div class="modal-header">
+                <h3>Select Path</h3>
+                <button class="btn-close" onclick="closeBrowser()">×</button>
+            </div>
+            <div class="breadcrumbs" id="browser-breadcrumbs"></div>
+            <div class="browser-list" id="browser-list">
+                <!-- populated by JS -->
+            </div>
+            <div class="modal-footer">
+                <button class="btn" onclick="closeBrowser()">Cancel</button>
+                <button class="btn btn-accent" onclick="selectBrowserPath()">Select Current Directory</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Toasts -->
+    <div id="toast-container" class="toast-container"></div>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/native/ps2servers-edge/internal/webui/assets/index.html
+++ b/native/ps2servers-edge/internal/webui/assets/index.html
@@ -358,8 +358,8 @@
                         </div>
                         <div class="form-group">
                             <label>Port</label>
-                            <input type="number" name="port" placeholder="48301">
-                            <small class="help-text">UDP port for UDPBD traffic. Default 48301 (0xBDBD).</small>
+                            <input type="number" name="port" placeholder="48573">
+                            <small class="help-text">UDP port for UDPBD traffic. Default 48573 (0xBDBD).</small>
                         </div>
                     </div>
                     <div class="form-group">

--- a/native/ps2servers-edge/internal/webui/assets/styles.css
+++ b/native/ps2servers-edge/internal/webui/assets/styles.css
@@ -1,0 +1,336 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+    --bg: #0d1420;
+    --panel: #161f2e;
+    --panel2: #1f2a3d;
+    --panel3: #293850;
+    --edge: #31415d;
+    --text: #e9eef7;
+    --muted: #93a3bd;
+    --accent: #2563eb;
+    --accent-hover: #1b57d1;
+    --accent2: #74b6ff;
+    --ok: #43d597;
+    --warn: #e7b750;
+    --error: #f16d7f;
+    --entry: #0f1826;
+    --disabled: #5c6c88;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background-color: var(--bg);
+    color: var(--text);
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+}
+
+/* Typography */
+h1, h2, h3 { font-weight: 600; }
+a { color: var(--accent2); text-decoration: none; }
+.muted { color: var(--muted); }
+.mt-4 { margin-top: 1rem; }
+.text-center { text-align: center; }
+
+/* Layout */
+.sidebar {
+    background-color: var(--panel);
+    border-bottom: 1px solid var(--edge);
+    display: flex;
+    overflow-x: auto;
+    flex-shrink: 0;
+    align-items: center;
+    padding: 0 1rem;
+}
+
+.sidebar .brand {
+    font-weight: 600;
+    margin-right: 1.5rem;
+    color: var(--text);
+    white-space: nowrap;
+}
+
+.nav-link {
+    padding: 1rem;
+    color: var(--muted);
+    font-weight: 500;
+    transition: all 0.2s;
+    border-bottom: 2px solid transparent;
+    position: relative;
+    white-space: nowrap;
+}
+
+.nav-link:hover { color: var(--text); }
+.nav-link.active { color: var(--accent2); border-bottom-color: var(--accent); }
+
+.dirty-dot {
+    display: none;
+    position: absolute;
+    top: 10px;
+    right: 5px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: var(--warn);
+    animation: pulse 2s infinite;
+}
+.nav-link.dirty .dirty-dot { display: block; }
+
+@keyframes pulse {
+    0% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.5); opacity: 0.5; }
+    100% { transform: scale(1); opacity: 1; }
+}
+
+.content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.tab-content { display: none; }
+.tab-content.active { display: block; animation: fadeIn 0.3s ease; }
+@keyframes fadeIn { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }
+
+.h-full { height: 100%; }
+.flex-col { display: flex; flex-direction: column; }
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+/* Cards */
+.card {
+    background: var(--panel);
+    border: 1px solid var(--edge);
+    border-radius: 8px;
+    padding: 1.25rem;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06);
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.card-header.collapsible {
+    cursor: pointer;
+    margin-bottom: 0;
+    user-select: none;
+}
+.card-header.collapsible:hover { color: var(--accent2); }
+.collapse-icon { transition: transform 0.3s; }
+.card-body.collapsed { display: none; }
+.card-header.collapsible.open .collapse-icon { transform: rotate(180deg); }
+.card-header.collapsible.open + .card-body { display: block; margin-top: 1rem; }
+
+/* Dashboard Grid */
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+.status-card .stat { margin: 0.5rem 0; display: flex; justify-content: space-between; }
+.status-card .card-footer { margin-top: 1rem; display: flex; justify-content: flex-end; }
+
+/* Badges */
+.badge {
+    padding: 0.25rem 0.6rem;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.badge-ok { background-color: rgba(67, 213, 151, 0.2); color: var(--ok); }
+.badge-warn { background-color: rgba(231, 183, 80, 0.2); color: var(--warn); }
+.badge-error { background-color: rgba(241, 109, 127, 0.2); color: var(--error); }
+.badge-grey { background-color: rgba(92, 108, 136, 0.2); color: var(--disabled); }
+
+/* Forms */
+.form-group { margin-bottom: 1.25rem; }
+.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+label { display: block; font-weight: 500; margin-bottom: 0.5rem; font-size: 0.9rem; }
+
+input[type="text"], input[type="number"], select {
+    width: 100%;
+    background-color: var(--entry);
+    border: 1px solid var(--edge);
+    color: var(--text);
+    padding: 0.6rem;
+    border-radius: 6px;
+    font-family: inherit;
+    font-size: 0.95rem;
+    transition: border-color 0.2s;
+}
+input[type="text"]:focus, input[type="number"]:focus, select:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+.input-with-btn { display: flex; gap: 0.5rem; }
+.input-with-btn input { flex: 1; }
+.help-text { display: block; margin-top: 0.35rem; color: var(--muted); font-size: 0.8rem; }
+
+/* Toggles */
+.toggle {
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    position: relative;
+    user-select: none;
+}
+.toggle input { opacity: 0; width: 0; height: 0; position: absolute; }
+.slider {
+    width: 40px; height: 22px;
+    background-color: var(--panel2);
+    border-radius: 22px;
+    position: relative;
+    transition: 0.3s;
+    border: 1px solid var(--edge);
+    margin-right: 0.75rem;
+}
+.slider:before {
+    content: "";
+    position: absolute;
+    height: 16px; width: 16px;
+    left: 2px; bottom: 2px;
+    background-color: var(--muted);
+    border-radius: 50%;
+    transition: 0.3s;
+}
+.toggle input:checked + .slider { background-color: var(--accent); border-color: var(--accent); }
+.toggle input:checked + .slider:before { transform: translateX(18px); background-color: white; }
+.toggle-label { font-weight: 500; font-size: 0.9rem; }
+
+/* Buttons */
+.btn {
+    background-color: var(--panel2);
+    border: 1px solid var(--edge);
+    color: var(--text);
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: all 0.2s;
+}
+.btn:hover { background-color: var(--panel3); }
+.btn-primary { background-color: var(--panel2); color: var(--text); }
+.btn-accent { background-color: var(--accent); border-color: var(--accent); color: white; }
+.btn-accent:hover { background-color: var(--accent-hover); border-color: var(--accent-hover); }
+.action-bar { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+
+/* Logs */
+.log-controls { display: flex; align-items: center; gap: 1rem; }
+.log-viewer-card { flex: 1; padding: 0; overflow: hidden; display: flex; flex-direction: column; }
+.log-viewer {
+    flex: 1;
+    overflow-y: auto;
+    background-color: var(--entry);
+    padding: 1rem;
+    font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.85rem;
+    white-space: pre-wrap;
+    word-break: break-all;
+    line-height: 1.4;
+}
+.checkbox-label { display: flex; align-items: center; gap: 0.5rem; cursor: pointer; font-size: 0.9rem; margin:0; }
+
+/* About */
+.about-title { color: var(--accent2); margin-bottom: 0.5rem; font-size: 2rem; }
+.about-stats { margin: 2rem 0; display: inline-block; text-align: left; background: var(--panel2); padding: 1.5rem; border-radius: 8px; }
+.about-stats p { margin-bottom: 0.5rem; }
+
+/* Modal */
+.modal-backdrop {
+    position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+    background: rgba(13, 20, 32, 0.8);
+    backdrop-filter: blur(4px);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: 100;
+}
+.modal-backdrop.show { display: flex; animation: fadeIn 0.2s; }
+.modal {
+    background: var(--panel);
+    border: 1px solid var(--edge);
+    border-radius: 8px;
+    width: 90%;
+    max-width: 600px;
+    max-height: 85vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 10px 25px rgba(0,0,0,0.5);
+}
+.modal-header { padding: 1.25rem; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--edge); }
+.btn-close { background: none; border: none; color: var(--muted); font-size: 1.5rem; cursor: pointer; }
+.btn-close:hover { color: var(--text); }
+.breadcrumbs { padding: 0.75rem 1.25rem; background: var(--panel2); border-bottom: 1px solid var(--edge); display: flex; flex-wrap: wrap; gap: 0.5rem; font-size: 0.9rem; }
+.breadcrumb-item { cursor: pointer; color: var(--accent2); }
+.breadcrumb-item:hover { text-decoration: underline; }
+.breadcrumb-sep { color: var(--muted); }
+.browser-list { flex: 1; overflow-y: auto; padding: 0.5rem; }
+.browser-item {
+    padding: 0.75rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    cursor: pointer;
+    border-radius: 4px;
+}
+.browser-item:hover { background: var(--panel3); }
+.browser-item-icon { color: var(--muted); font-size: 1.2rem; width: 24px; text-align: center; }
+.modal-footer { padding: 1rem 1.25rem; border-top: 1px solid var(--edge); display: flex; justify-content: flex-end; gap: 0.5rem; }
+
+/* Toasts */
+.toast-container {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    z-index: 200;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+.toast {
+    background: var(--panel2);
+    border-left: 4px solid var(--accent);
+    color: var(--text);
+    padding: 1rem 1.25rem;
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+    animation: slideIn 0.3s ease forwards;
+    max-width: 350px;
+}
+.toast.success { border-color: var(--ok); }
+.toast.error { border-color: var(--error); }
+.toast.info { border-color: var(--accent2); }
+@keyframes slideIn { from { transform: translateX(100%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+.toast.hiding { animation: slideOut 0.3s ease forwards; }
+@keyframes slideOut { from { transform: translateX(0); opacity: 1; } to { transform: translateX(100%); opacity: 0; } }
+
+/* Desktop overrides */
+@media (min-width: 768px) {
+    body { flex-direction: row; }
+    .sidebar { flex-direction: column; width: 200px; border-bottom: none; border-right: 1px solid var(--edge); padding: 1.5rem 0; align-items: stretch; }
+    .sidebar .brand { margin: 0 0 2rem 1.5rem; }
+    .nav-link { padding: 1rem 1.5rem; border-bottom: none; border-left: 3px solid transparent; }
+    .nav-link.active { border-bottom: none; border-left-color: var(--accent); background: var(--panel2); }
+}

--- a/native/ps2servers-edge/internal/webui/assets/styles.css
+++ b/native/ps2servers-edge/internal/webui/assets/styles.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
-
 :root {
     --bg: #0d1420;
     --panel: #161f2e;

--- a/native/ps2servers-edge/internal/webui/config.go
+++ b/native/ps2servers-edge/internal/webui/config.go
@@ -1,0 +1,121 @@
+package webui
+
+import "os"
+
+type UDPFSConfig struct {
+	Enabled              bool    `json:"enabled"`
+	Root                 string  `json:"root"`
+	Bind                 string  `json:"bind"`
+	Port                 int     `json:"port"`
+	DataPort             int     `json:"data_port"`
+	Protocol             string  `json:"protocol"`
+	SinglePort           bool    `json:"single_port"`
+	ReadOnly             bool    `json:"read_only"`
+	PeerTimeout          string  `json:"peer_timeout"`
+	TxDelayMs            float64 `json:"tx_delay_ms"`
+	LogFormat            string  `json:"log_format"`
+	Verbose              bool    `json:"verbose"`
+	BlockDevice          string  `json:"block_device"`
+	SectorSize           int     `json:"sector_size"`
+	NoCompression        bool    `json:"no_compression"`
+	CompressionCacheSize int     `json:"compression_cache_size"`
+	Metrics              bool    `json:"metrics"`
+	MetricsPeriod        string  `json:"metrics_period"`
+}
+
+type SMBConfig struct {
+	Enabled    bool   `json:"enabled"`
+	Share      string `json:"share"`
+	Bind       string `json:"bind"`
+	Port       int    `json:"port"`
+	ReadOnly   bool   `json:"read_only"`
+	StatusPort int    `json:"status_port"`
+	LogFormat  string `json:"log_format"`
+	Verbose    bool   `json:"verbose"`
+}
+
+type UDPBDConfig struct {
+	Enabled    bool   `json:"enabled"`
+	Image      string `json:"image"`
+	Bind       string `json:"bind"`
+	Port       int    `json:"port"`
+	ReadOnly   bool   `json:"read_only"`
+	StatusPort int    `json:"status_port"`
+	LogFormat  string `json:"log_format"`
+	Verbose    bool   `json:"verbose"`
+}
+
+type WebUIConfig struct {
+	Enabled bool   `json:"enabled"`
+	Port    int    `json:"port"`
+	Bind    string `json:"bind"`
+}
+
+type EdgeConfig struct {
+	UDPFS UDPFSConfig `json:"udpfs"`
+	SMB   SMBConfig   `json:"smb"`
+	UDPBD UDPBDConfig `json:"udpbd"`
+	WebUI WebUIConfig `json:"webui"`
+}
+
+func DefaultConfig() *EdgeConfig {
+	return &EdgeConfig{
+		UDPFS: UDPFSConfig{
+			Enabled:              true,
+			Root:                 "/mnt/sda1/PS2",
+			Bind:                 "0.0.0.0",
+			Port:                 62966,
+			DataPort:             0,
+			Protocol:             "auto",
+			SinglePort:           false,
+			ReadOnly:             true,
+			PeerTimeout:          "1h",
+			TxDelayMs:            0,
+			LogFormat:            "text",
+			Verbose:              false,
+			BlockDevice:          "",
+			SectorSize:           512,
+			NoCompression:        false,
+			CompressionCacheSize: 32,
+			Metrics:              false,
+			MetricsPeriod:        "1m",
+		},
+		SMB: SMBConfig{
+			Enabled:    false,
+			Share:      "games=/mnt/sda1/PS2",
+			Bind:       "0.0.0.0",
+			Port:       1111,
+			ReadOnly:   true,
+			StatusPort: 0,
+			LogFormat:  "text",
+			Verbose:    false,
+		},
+		UDPBD: UDPBDConfig{
+			Enabled:    false,
+			Image:      "",
+			Bind:       "0.0.0.0",
+			Port:       48573,
+			ReadOnly:   true,
+			StatusPort: 0,
+			LogFormat:  "text",
+			Verbose:    false,
+		},
+		WebUI: WebUIConfig{
+			Enabled: false,
+			Port:    8082,
+			Bind:    "0.0.0.0",
+		},
+	}
+}
+
+type ConfigBackend interface {
+	Load() (*EdgeConfig, error)
+	Save(cfg *EdgeConfig) error
+}
+
+func DetectBackend(jsonPath string) ConfigBackend {
+	if _, err := os.Stat("/sbin/uci"); err == nil {
+		return &uciBackend{}
+	}
+	return &jsonBackend{path: jsonPath}
+}

--- a/native/ps2servers-edge/internal/webui/config.go
+++ b/native/ps2servers-edge/internal/webui/config.go
@@ -113,9 +113,17 @@ type ConfigBackend interface {
 	Save(cfg *EdgeConfig) error
 }
 
+const defaultJSONConfigPath = "/etc/ps2servers-edge/config.json"
+
 func DetectBackend(jsonPath string) ConfigBackend {
+	if jsonPath != "" && jsonPath != defaultJSONConfigPath {
+		return &jsonBackend{path: jsonPath}
+	}
 	if _, err := os.Stat("/sbin/uci"); err == nil {
 		return &uciBackend{}
+	}
+	if jsonPath == "" {
+		jsonPath = defaultJSONConfigPath
 	}
 	return &jsonBackend{path: jsonPath}
 }

--- a/native/ps2servers-edge/internal/webui/config_json.go
+++ b/native/ps2servers-edge/internal/webui/config_json.go
@@ -1,0 +1,53 @@
+package webui
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type jsonBackend struct {
+	path string
+}
+
+func (b *jsonBackend) Load() (*EdgeConfig, error) {
+	data, err := os.ReadFile(b.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultConfig(), nil
+		}
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	cfg := DefaultConfig()
+	if err := json.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse config JSON: %w", err)
+	}
+
+	return cfg, nil
+}
+
+func (b *jsonBackend) Save(cfg *EdgeConfig) error {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to serialize config JSON: %w", err)
+	}
+
+	dir := filepath.Dir(b.path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	tmpPath := b.path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write config temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, b.path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to rename config file: %w", err)
+	}
+
+	return nil
+}

--- a/native/ps2servers-edge/internal/webui/config_uci.go
+++ b/native/ps2servers-edge/internal/webui/config_uci.go
@@ -1,0 +1,226 @@
+package webui
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type uciBackend struct{}
+
+func (b *uciBackend) Load() (*EdgeConfig, error) {
+	cfg := DefaultConfig()
+
+	out, err := exec.Command("/sbin/uci", "show", "ps2servers-edge").Output()
+	if err != nil {
+		// If the config doesn't exist yet, return defaults
+		return cfg, nil
+	}
+
+	lines := strings.Split(string(out), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := parts[0]
+		val := strings.Trim(parts[1], "'\"")
+
+		switch key {
+		// UDPFS (main section)
+		case "ps2servers-edge.main.enabled":
+			cfg.UDPFS.Enabled = val == "1" || val == "true"
+		case "ps2servers-edge.main.root":
+			cfg.UDPFS.Root = val
+		case "ps2servers-edge.main.bind":
+			cfg.UDPFS.Bind = val
+		case "ps2servers-edge.main.port":
+			if p, err := strconv.Atoi(val); err == nil {
+				cfg.UDPFS.Port = p
+			}
+		case "ps2servers-edge.main.data_port":
+			if p, err := strconv.Atoi(val); err == nil {
+				cfg.UDPFS.DataPort = p
+			}
+		case "ps2servers-edge.main.protocol":
+			cfg.UDPFS.Protocol = val
+		case "ps2servers-edge.main.single_port":
+			cfg.UDPFS.SinglePort = val == "1" || val == "true"
+		case "ps2servers-edge.main.read_only":
+			cfg.UDPFS.ReadOnly = val == "1" || val == "true"
+		case "ps2servers-edge.main.peer_timeout":
+			cfg.UDPFS.PeerTimeout = val
+		case "ps2servers-edge.main.tx_delay_ms":
+			if d, err := strconv.ParseFloat(val, 64); err == nil {
+				cfg.UDPFS.TxDelayMs = d
+			}
+		case "ps2servers-edge.main.log_format":
+			cfg.UDPFS.LogFormat = val
+		case "ps2servers-edge.main.verbose":
+			cfg.UDPFS.Verbose = val == "1" || val == "true"
+		case "ps2servers-edge.main.block_device":
+			cfg.UDPFS.BlockDevice = val
+		case "ps2servers-edge.main.sector_size":
+			if s, err := strconv.Atoi(val); err == nil {
+				cfg.UDPFS.SectorSize = s
+			}
+		case "ps2servers-edge.main.no_compression":
+			cfg.UDPFS.NoCompression = val == "1" || val == "true"
+		case "ps2servers-edge.main.compression_cache_size":
+			if s, err := strconv.Atoi(val); err == nil {
+				cfg.UDPFS.CompressionCacheSize = s
+			}
+		case "ps2servers-edge.main.metrics":
+			cfg.UDPFS.Metrics = val == "1" || val == "true"
+		case "ps2servers-edge.main.metrics_period":
+			cfg.UDPFS.MetricsPeriod = val
+
+		// SMB section
+		case "ps2servers-edge.smb.enabled":
+			cfg.SMB.Enabled = val == "1" || val == "true"
+		case "ps2servers-edge.smb.share":
+			cfg.SMB.Share = val
+		case "ps2servers-edge.smb.bind":
+			cfg.SMB.Bind = val
+		case "ps2servers-edge.smb.port":
+			if p, err := strconv.Atoi(val); err == nil {
+				cfg.SMB.Port = p
+			}
+		case "ps2servers-edge.smb.read_only":
+			cfg.SMB.ReadOnly = val == "1" || val == "true"
+		case "ps2servers-edge.smb.status_port":
+			if p, err := strconv.Atoi(val); err == nil {
+				cfg.SMB.StatusPort = p
+			}
+		case "ps2servers-edge.smb.log_format":
+			cfg.SMB.LogFormat = val
+		case "ps2servers-edge.smb.verbose":
+			cfg.SMB.Verbose = val == "1" || val == "true"
+
+		// UDPBD section
+		case "ps2servers-edge.udpbd.enabled":
+			cfg.UDPBD.Enabled = val == "1" || val == "true"
+		case "ps2servers-edge.udpbd.image":
+			cfg.UDPBD.Image = val
+		case "ps2servers-edge.udpbd.bind":
+			cfg.UDPBD.Bind = val
+		case "ps2servers-edge.udpbd.port":
+			if p, err := strconv.Atoi(val); err == nil {
+				cfg.UDPBD.Port = p
+			}
+		case "ps2servers-edge.udpbd.read_only":
+			cfg.UDPBD.ReadOnly = val == "1" || val == "true"
+		case "ps2servers-edge.udpbd.status_port":
+			if p, err := strconv.Atoi(val); err == nil {
+				cfg.UDPBD.StatusPort = p
+			}
+		case "ps2servers-edge.udpbd.log_format":
+			cfg.UDPBD.LogFormat = val
+		case "ps2servers-edge.udpbd.verbose":
+			cfg.UDPBD.Verbose = val == "1" || val == "true"
+
+		// WebUI section
+		case "ps2servers-edge.webui.enabled":
+			cfg.WebUI.Enabled = val == "1" || val == "true"
+		case "ps2servers-edge.webui.port":
+			if p, err := strconv.Atoi(val); err == nil {
+				cfg.WebUI.Port = p
+			}
+		case "ps2servers-edge.webui.bind":
+			cfg.WebUI.Bind = val
+		}
+	}
+
+	return cfg, nil
+}
+
+func (b *uciBackend) Save(cfg *EdgeConfig) error {
+	var cmds [][]string
+
+	addCmd := func(key string, val interface{}) {
+		var sval string
+		switch v := val.(type) {
+		case bool:
+			if v {
+				sval = "1"
+			} else {
+				sval = "0"
+			}
+		case string:
+			sval = v
+		case int, float64:
+			sval = fmt.Sprintf("%v", v)
+		}
+		cmds = append(cmds, []string{"set", fmt.Sprintf("ps2servers-edge.%s=%s", key, sval)})
+	}
+
+	// Set basic sections if they don't exist (assuming default init script creates them, but to be safe we'd just set values)
+
+	// UDPFS
+	addCmd("main.enabled", cfg.UDPFS.Enabled)
+	addCmd("main.root", cfg.UDPFS.Root)
+	addCmd("main.bind", cfg.UDPFS.Bind)
+	addCmd("main.port", cfg.UDPFS.Port)
+	addCmd("main.data_port", cfg.UDPFS.DataPort)
+	addCmd("main.protocol", cfg.UDPFS.Protocol)
+	addCmd("main.single_port", cfg.UDPFS.SinglePort)
+	addCmd("main.read_only", cfg.UDPFS.ReadOnly)
+	addCmd("main.peer_timeout", cfg.UDPFS.PeerTimeout)
+	addCmd("main.tx_delay_ms", cfg.UDPFS.TxDelayMs)
+	addCmd("main.log_format", cfg.UDPFS.LogFormat)
+	addCmd("main.verbose", cfg.UDPFS.Verbose)
+	addCmd("main.block_device", cfg.UDPFS.BlockDevice)
+	addCmd("main.sector_size", cfg.UDPFS.SectorSize)
+	addCmd("main.no_compression", cfg.UDPFS.NoCompression)
+	addCmd("main.compression_cache_size", cfg.UDPFS.CompressionCacheSize)
+	addCmd("main.metrics", cfg.UDPFS.Metrics)
+	addCmd("main.metrics_period", cfg.UDPFS.MetricsPeriod)
+
+	// SMB
+	addCmd("smb.enabled", cfg.SMB.Enabled)
+	addCmd("smb.share", cfg.SMB.Share)
+	addCmd("smb.bind", cfg.SMB.Bind)
+	addCmd("smb.port", cfg.SMB.Port)
+	addCmd("smb.read_only", cfg.SMB.ReadOnly)
+	addCmd("smb.status_port", cfg.SMB.StatusPort)
+	addCmd("smb.log_format", cfg.SMB.LogFormat)
+	addCmd("smb.verbose", cfg.SMB.Verbose)
+
+	// UDPBD
+	addCmd("udpbd.enabled", cfg.UDPBD.Enabled)
+	addCmd("udpbd.image", cfg.UDPBD.Image)
+	addCmd("udpbd.bind", cfg.UDPBD.Bind)
+	addCmd("udpbd.port", cfg.UDPBD.Port)
+	addCmd("udpbd.read_only", cfg.UDPBD.ReadOnly)
+	addCmd("udpbd.status_port", cfg.UDPBD.StatusPort)
+	addCmd("udpbd.log_format", cfg.UDPBD.LogFormat)
+	addCmd("udpbd.verbose", cfg.UDPBD.Verbose)
+
+	// WebUI
+	addCmd("webui.enabled", cfg.WebUI.Enabled)
+	addCmd("webui.port", cfg.WebUI.Port)
+	addCmd("webui.bind", cfg.WebUI.Bind)
+
+	// Execute all set commands via batch or sequentially
+	var buf bytes.Buffer
+	for _, c := range cmds {
+		buf.WriteString(strings.Join(c, " ") + "\n")
+	}
+	buf.WriteString("commit ps2servers-edge\n")
+
+	cmd := exec.Command("/sbin/uci", "batch")
+	cmd.Stdin = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("uci batch failed: %w", err)
+	}
+
+	return nil
+}

--- a/native/ps2servers-edge/internal/webui/embed.go
+++ b/native/ps2servers-edge/internal/webui/embed.go
@@ -1,0 +1,6 @@
+package webui
+
+import "embed"
+
+//go:embed assets/*
+var assets embed.FS

--- a/native/ps2servers-edge/internal/webui/logbuffer.go
+++ b/native/ps2servers-edge/internal/webui/logbuffer.go
@@ -1,0 +1,97 @@
+package webui
+
+import (
+	"bytes"
+	"sync"
+)
+
+type LogBuffer struct {
+	mu          sync.RWMutex
+	lines       []string
+	capacity    int
+	head        int
+	count       int
+	subscribers map[chan string]struct{}
+}
+
+func NewLogBuffer(capacity int) *LogBuffer {
+	if capacity <= 0 {
+		capacity = 100
+	}
+	return &LogBuffer{
+		lines:       make([]string, capacity),
+		capacity:    capacity,
+		subscribers: make(map[chan string]struct{}),
+	}
+}
+
+func (b *LogBuffer) Write(p []byte) (n int, err error) {
+	lines := bytes.Split(p, []byte{'\n'})
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for i, line := range lines {
+		// Ignore the last empty string if p ends with '\n'
+		if i == len(lines)-1 && len(line) == 0 {
+			continue
+		}
+		s := string(line)
+		b.lines[b.head] = s
+		b.head = (b.head + 1) % b.capacity
+		if b.count < b.capacity {
+			b.count++
+		}
+
+		for sub := range b.subscribers {
+			select {
+			case sub <- s:
+			default:
+				// Drop subscriber if it falls behind without panic/double-close
+				delete(b.subscribers, sub)
+				close(sub)
+			}
+		}
+	}
+	return len(p), nil
+}
+
+func (b *LogBuffer) Lines() []string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	res := make([]string, 0, b.count)
+	if b.count == 0 {
+		return res
+	}
+
+	start := 0
+	if b.count == b.capacity {
+		start = b.head
+	}
+
+	for i := 0; i < b.count; i++ {
+		idx := (start + i) % b.capacity
+		res = append(res, b.lines[idx])
+	}
+	return res
+}
+
+func (b *LogBuffer) Subscribe() (<-chan string, func()) {
+	ch := make(chan string, 100)
+
+	b.mu.Lock()
+	b.subscribers[ch] = struct{}{}
+	b.mu.Unlock()
+
+	unsub := func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		if _, ok := b.subscribers[ch]; ok {
+			delete(b.subscribers, ch)
+			close(ch)
+		}
+	}
+
+	return ch, unsub
+}

--- a/native/ps2servers-edge/internal/webui/service.go
+++ b/native/ps2servers-edge/internal/webui/service.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
@@ -25,7 +26,7 @@ type ServiceStatus struct {
 	Running  bool   `json:"running"`
 	State    string `json:"state"`
 	Sessions int    `json:"sessions"`
-	Uptime   int    `json:"uptime"`
+	Uptime   uint32 `json:"uptime"`
 }
 
 // DetectServiceManager checks the host environment and returns the most
@@ -64,10 +65,13 @@ type systemdManager struct {
 
 func (m *systemdManager) Restart(service string) error {
 	if service == "all" {
+		var firstErr error
 		for _, s := range []string{"udpfs", "smb", "udpbd"} {
-			exec.Command("systemctl", "restart", "ps2servers-edge@"+s).Run()
+			if err := exec.Command("systemctl", "restart", "ps2servers-edge@"+s).Run(); err != nil && firstErr == nil {
+				firstErr = err
+			}
 		}
-		return nil
+		return firstErr
 	}
 	return exec.Command("systemctl", "restart", "ps2servers-edge@"+service).Run()
 }
@@ -100,16 +104,16 @@ func (m *genericManager) Status() (map[string]ServiceStatus, error) {
 // default; SMB and UDPBD use the same status listener port when configured.
 func queryAllStatus() (map[string]ServiceStatus, error) {
 	res := map[string]ServiceStatus{
-		"udpfs": queryStatus(62966),
-		"smb":   queryStatus(62966),
-		"udpbd": queryStatus(62966),
+		"udpfs": queryStatus("udpfs", 62966),
+		"smb":   queryStatus("smb", 62966),
+		"udpbd": queryStatus("udpbd", 62966),
 	}
 	return res, nil
 }
 
 // queryStatus sends a 10-byte UDPRDMA status query (service 0xF5F7) to
 // 127.0.0.1:port and decodes the reply per docs/ROUTER-STATUS.md.
-func queryStatus(port int) ServiceStatus {
+func queryStatus(targetService string, port int) ServiceStatus {
 	unknown := ServiceStatus{Running: false, State: "unknown", Sessions: 0, Uptime: 0}
 
 	// Build the 10-byte query:
@@ -165,6 +169,15 @@ func queryStatus(port int) ServiceStatus {
 		return unknown
 	}
 
+	nameLen := int(buf[18])
+	if n >= 19+nameLen && nameLen > 0 {
+		nameStr := strings.ToLower(string(buf[19 : 19+nameLen]))
+		if !strings.Contains(nameStr, strings.ToLower(targetService)) {
+			// Response came from a different service on that port
+			return unknown
+		}
+	}
+
 	stateByte := buf[9]
 	stateStr := "unknown"
 	switch stateByte {
@@ -181,7 +194,7 @@ func queryStatus(port int) ServiceStatus {
 	}
 
 	sessions := int(binary.LittleEndian.Uint16(buf[12:14]))
-	uptime := int(binary.LittleEndian.Uint32(buf[14:18]))
+	uptime := binary.LittleEndian.Uint32(buf[14:18])
 
 	return ServiceStatus{
 		Running:  true,

--- a/native/ps2servers-edge/internal/webui/service.go
+++ b/native/ps2servers-edge/internal/webui/service.go
@@ -1,0 +1,192 @@
+package webui
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
+)
+
+// ServiceManager abstracts how the web UI restarts Edge services and queries
+// their status.  Three implementations are auto-detected: OpenWrt (procd),
+// systemd, and a generic fallback that logs instructions.
+type ServiceManager interface {
+	Restart(service string) error
+	Status() (map[string]ServiceStatus, error)
+}
+
+// ServiceStatus is returned by the /api/status endpoint and consumed by the
+// dashboard cards.
+type ServiceStatus struct {
+	Running  bool   `json:"running"`
+	State    string `json:"state"`
+	Sessions int    `json:"sessions"`
+	Uptime   int    `json:"uptime"`
+}
+
+// DetectServiceManager checks the host environment and returns the most
+// specific manager available.
+func DetectServiceManager(log *logging.Logger) ServiceManager {
+	if _, err := os.Stat("/etc/init.d/ps2servers-edge"); err == nil {
+		return &openwrtManager{log: log}
+	}
+	if _, err := exec.LookPath("systemctl"); err == nil {
+		return &systemdManager{log: log}
+	}
+	return &genericManager{log: log}
+}
+
+// --- OpenWrt (procd) ---
+
+type openwrtManager struct {
+	log *logging.Logger
+}
+
+func (m *openwrtManager) Restart(service string) error {
+	// The init script handles all three services; restarting it restarts
+	// whichever instances are enabled in UCI.
+	return exec.Command("/etc/init.d/ps2servers-edge", "restart").Run()
+}
+
+func (m *openwrtManager) Status() (map[string]ServiceStatus, error) {
+	return queryAllStatus()
+}
+
+// --- systemd ---
+
+type systemdManager struct {
+	log *logging.Logger
+}
+
+func (m *systemdManager) Restart(service string) error {
+	if service == "all" {
+		for _, s := range []string{"udpfs", "smb", "udpbd"} {
+			exec.Command("systemctl", "restart", "ps2servers-edge@"+s).Run()
+		}
+		return nil
+	}
+	return exec.Command("systemctl", "restart", "ps2servers-edge@"+service).Run()
+}
+
+func (m *systemdManager) Status() (map[string]ServiceStatus, error) {
+	return queryAllStatus()
+}
+
+// --- Generic fallback ---
+
+type genericManager struct {
+	log *logging.Logger
+}
+
+func (m *genericManager) Restart(service string) error {
+	m.log.Info(fmt.Sprintf(
+		"Web UI received restart request for %s — running in generic mode, "+
+			"please restart the process manually", service), nil)
+	return nil
+}
+
+func (m *genericManager) Status() (map[string]ServiceStatus, error) {
+	return queryAllStatus()
+}
+
+// --- Router status protocol query ---
+
+// queryAllStatus sends a status query to the well-known discovery port on
+// localhost and parses the response.  UDPFS listens on port 62966 (0xF5F6) by
+// default; SMB and UDPBD use the same status listener port when configured.
+func queryAllStatus() (map[string]ServiceStatus, error) {
+	res := map[string]ServiceStatus{
+		"udpfs": queryStatus(62966),
+		"smb":   queryStatus(62966),
+		"udpbd": queryStatus(62966),
+	}
+	return res, nil
+}
+
+// queryStatus sends a 10-byte UDPRDMA status query (service 0xF5F7) to
+// 127.0.0.1:port and decodes the reply per docs/ROUTER-STATUS.md.
+func queryStatus(port int) ServiceStatus {
+	unknown := ServiceStatus{Running: false, State: "unknown", Sessions: 0, Uptime: 0}
+
+	// Build the 10-byte query:
+	//   [0:2] header — type 0 (DISCOVERY), sequence 0  → 0x0000 LE
+	//   [2:4] service ID — 0xF5F7 LE
+	//   [4:6] port — 0x0000 LE (unused; reply goes to query's UDP source)
+	//   [6:10] magic — "PS2S"
+	req := make([]byte, 10)
+	binary.LittleEndian.PutUint16(req[0:2], 0x0000)
+	binary.LittleEndian.PutUint16(req[2:4], 0xF5F7)
+	binary.LittleEndian.PutUint16(req[4:6], 0x0000)
+	copy(req[6:10], "PS2S")
+
+	conn, err := net.DialTimeout("udp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
+	if err != nil {
+		return unknown
+	}
+	defer conn.Close()
+
+	conn.SetDeadline(time.Now().Add(200 * time.Millisecond))
+
+	if _, err := conn.Write(req); err != nil {
+		return unknown
+	}
+
+	buf := make([]byte, 256)
+	n, err := conn.Read(buf)
+	if err != nil || n < 19 {
+		return unknown
+	}
+
+	// Reply layout (docs/ROUTER-STATUS.md):
+	//   [0:2]  header — type 1 (INFORM), sequence 0 → low nibble is 1
+	//   [2:4]  service ID — 0xF5F7  (echoed)
+	//   [4:8]  magic — "PS2S"       (echoed)
+	//   [8]    payload version — 1
+	//   [9]    state
+	//   [10:12] service flags
+	//   [12:14] active sessions
+	//   [14:18] uptime (seconds)
+	//   [18]   name length
+	//   [19:]  name (UTF-8)
+
+	// Validate service ID and magic.
+	if binary.LittleEndian.Uint16(buf[2:4]) != 0xF5F7 {
+		return unknown
+	}
+	if string(buf[4:8]) != "PS2S" {
+		return unknown
+	}
+	// Validate header type: low nibble must be 1 (INFORM).
+	if buf[0]&0x0F != 1 {
+		return unknown
+	}
+
+	stateByte := buf[9]
+	stateStr := "unknown"
+	switch stateByte {
+	case 0:
+		stateStr = "starting"
+	case 1:
+		stateStr = "ready"
+	case 2:
+		stateStr = "busy"
+	case 3:
+		stateStr = "degraded"
+	case 4:
+		stateStr = "stopping"
+	}
+
+	sessions := int(binary.LittleEndian.Uint16(buf[12:14]))
+	uptime := int(binary.LittleEndian.Uint32(buf[14:18]))
+
+	return ServiceStatus{
+		Running:  true,
+		State:    stateStr,
+		Sessions: sessions,
+		Uptime:   uptime,
+	}
+}

--- a/native/ps2servers-edge/internal/webui/webui.go
+++ b/native/ps2servers-edge/internal/webui/webui.go
@@ -1,0 +1,120 @@
+package webui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
+)
+
+type Config struct {
+	Port       int
+	Bind       string
+	ConfigFile string
+	LogLines   int
+	NoBrowse   bool
+	Version    string
+	Log        *logging.Logger
+	LogBuffer  *LogBuffer
+}
+
+type Server struct {
+	cfg    Config
+	server *http.Server
+}
+
+func New(cfg Config) (*Server, error) {
+	if cfg.LogLines <= 0 {
+		cfg.LogLines = 1000
+	}
+	if cfg.LogBuffer == nil {
+		cfg.LogBuffer = NewLogBuffer(cfg.LogLines)
+	}
+
+	return &Server{cfg: cfg}, nil
+}
+
+func (s *Server) Serve(ctx context.Context) error {
+	backend := DetectBackend(s.cfg.ConfigFile)
+	manager := DetectServiceManager(s.cfg.Log)
+
+	api := &API{
+		configBackend: backend,
+		manager:       manager,
+		logBuffer:     s.cfg.LogBuffer,
+		noBrowse:      s.cfg.NoBrowse,
+		version:       s.cfg.Version,
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/status", api.HandleStatus)
+	mux.HandleFunc("/api/config", api.HandleConfig)
+	mux.HandleFunc("/api/config/defaults", api.HandleConfigDefaults)
+	mux.HandleFunc("/api/config/reset", api.HandleConfigReset)
+	mux.HandleFunc("/api/restart", api.HandleRestart)
+	mux.HandleFunc("/api/logs", api.HandleLogs)
+	mux.HandleFunc("/api/browse", api.HandleBrowse)
+	mux.HandleFunc("/api/info", api.HandleInfo)
+
+	subFS, err := fs.Sub(assets, "assets")
+	if err != nil {
+		return fmt.Errorf("failed to create sub filesystem: %w", err)
+	}
+	mux.Handle("/", http.FileServer(http.FS(subFS)))
+
+	s.server = &http.Server{
+		Handler: mux,
+	}
+
+	bind := s.cfg.Bind
+	if bind == "" {
+		bind = "0.0.0.0"
+	}
+
+	var listener net.Listener
+
+	if s.cfg.Port > 0 {
+		l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", bind, s.cfg.Port))
+		if err != nil {
+			s.cfg.Log.Warn("Failed to bind to user configured WebUI port", map[string]any{"port": s.cfg.Port, "err": err.Error()})
+			return nil
+		}
+		listener = l
+	} else {
+		l, err := net.Listen("tcp", fmt.Sprintf("%s:8082", bind))
+		if err != nil {
+			s.cfg.Log.Warn("Default WebUI port 8082 taken, assigning random port", map[string]any{"err": err.Error()})
+			l, err = net.Listen("tcp", fmt.Sprintf("%s:0", bind))
+			if err != nil {
+				return fmt.Errorf("failed to bind to any port: %w", err)
+			}
+		}
+		listener = l
+	}
+
+	addr := listener.Addr().(*net.TCPAddr)
+	s.cfg.Log.Info(fmt.Sprintf("Web UI available at http://%s:%d", bind, addr.Port), nil)
+
+	go func() {
+		<-ctx.Done()
+		s.server.Shutdown(context.Background())
+	}()
+
+	err = s.server.Serve(listener)
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+func (s *Server) Close() error {
+	if s.server != nil {
+		return s.server.Close()
+	}
+	return nil
+}

--- a/native/ps2servers-edge/internal/webui/webui.go
+++ b/native/ps2servers-edge/internal/webui/webui.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
 )
@@ -68,7 +69,9 @@ func (s *Server) Serve(ctx context.Context) error {
 	mux.Handle("/", http.FileServer(http.FS(subFS)))
 
 	s.server = &http.Server{
-		Handler: mux,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	bind := s.cfg.Bind
@@ -82,7 +85,7 @@ func (s *Server) Serve(ctx context.Context) error {
 		l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", bind, s.cfg.Port))
 		if err != nil {
 			s.cfg.Log.Warn("Failed to bind to user configured WebUI port", map[string]any{"port": s.cfg.Port, "err": err.Error()})
-			return nil
+			return fmt.Errorf("failed to bind to user configured WebUI port %d: %w", s.cfg.Port, err)
 		}
 		listener = l
 	} else {

--- a/native/ps2servers-edge/internal/webui/webui_test.go
+++ b/native/ps2servers-edge/internal/webui/webui_test.go
@@ -56,7 +56,7 @@ func TestJSONBackend(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.json")
 
-	backend := DetectBackend(cfgPath)
+	backend := &jsonBackend{path: cfgPath}
 
 	// Load non-existent -> returns default
 	cfg, err := backend.Load()

--- a/native/ps2servers-edge/internal/webui/webui_test.go
+++ b/native/ps2servers-edge/internal/webui/webui_test.go
@@ -1,0 +1,192 @@
+package webui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
+)
+
+func TestLogBuffer(t *testing.T) {
+	lb := NewLogBuffer(3)
+
+	lb.Write([]byte("line 1\nline 2\n"))
+	lines := lb.Lines()
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	if lines[0] != "line 1" || lines[1] != "line 2" {
+		t.Fatalf("unexpected lines: %v", lines)
+	}
+
+	// Test ring buffer wrapping
+	lb.Write([]byte("line 3\nline 4\n"))
+	lines = lb.Lines()
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines after overflow, got %d", len(lines))
+	}
+	if lines[0] != "line 2" || lines[1] != "line 3" || lines[2] != "line 4" {
+		t.Fatalf("unexpected lines after overflow: %v", lines)
+	}
+
+	// Test Subscribe
+	ch, unsub := lb.Subscribe()
+	defer unsub()
+
+	lb.Write([]byte("line 5\n"))
+
+	select {
+	case msg := <-ch:
+		if msg != "line 5" {
+			t.Fatalf("expected 'line 5', got %q", msg)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for subscription line")
+	}
+}
+
+func TestJSONBackend(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	backend := DetectBackend(cfgPath)
+
+	// Load non-existent -> returns default
+	cfg, err := backend.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.UDPFS.Port != 62966 {
+		t.Fatalf("expected default UDPFS port 62966, got %d", cfg.UDPFS.Port)
+	}
+
+	// Modify and save
+	cfg.UDPFS.Port = 12345
+	cfg.SMB.Enabled = true
+	if err := backend.Save(cfg); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Reload and verify persistence
+	loaded, err := backend.Load()
+	if err != nil {
+		t.Fatalf("Load after save failed: %v", err)
+	}
+	if loaded.UDPFS.Port != 12345 {
+		t.Fatalf("expected UDPFS port 12345, got %d", loaded.UDPFS.Port)
+	}
+	if !loaded.SMB.Enabled {
+		t.Fatal("expected SMB enabled true")
+	}
+}
+
+func TestAPIEndpoints(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+	backend := &jsonBackend{path: cfgPath}
+	lb := NewLogBuffer(10)
+	logger := logging.New(os.Stdout, "text", true, false)
+
+	api := &API{
+		configBackend: backend,
+		manager:       &genericManager{log: logger},
+		logBuffer:     lb,
+		noBrowse:      false,
+		version:       "0.5.0-test",
+	}
+
+	// Test GET /api/info
+	req := httptest.NewRequest("GET", "/api/info", nil)
+	rec := httptest.NewRecorder()
+	api.HandleInfo(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var info map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&info); err != nil {
+		t.Fatalf("failed to decode info JSON: %v", err)
+	}
+	if info["version"] != "0.5.0-test" {
+		t.Fatalf("expected version 0.5.0-test, got %s", info["version"])
+	}
+
+	// Test GET /api/config/defaults
+	req = httptest.NewRequest("GET", "/api/config/defaults", nil)
+	rec = httptest.NewRecorder()
+	api.HandleConfigDefaults(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var defaults EdgeConfig
+	if err := json.NewDecoder(rec.Body).Decode(&defaults); err != nil {
+		t.Fatalf("failed to decode defaults: %v", err)
+	}
+	if defaults.UDPFS.Port != 62966 {
+		t.Fatalf("expected default port 62966, got %d", defaults.UDPFS.Port)
+	}
+
+	// Test POST /api/config
+	newCfg := DefaultConfig()
+	newCfg.UDPFS.Port = 54321
+	body, _ := json.Marshal(newCfg)
+
+	req = httptest.NewRequest("POST", "/api/config", bytes.NewReader(body))
+	rec = httptest.NewRecorder()
+	api.HandleConfig(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 on config post, got %d", rec.Code)
+	}
+
+	// Test GET /api/config
+	req = httptest.NewRequest("GET", "/api/config", nil)
+	rec = httptest.NewRecorder()
+	api.HandleConfig(rec, req)
+
+	var fetched EdgeConfig
+	json.NewDecoder(rec.Body).Decode(&fetched)
+	if fetched.UDPFS.Port != 54321 {
+		t.Fatalf("expected updated port 54321, got %d", fetched.UDPFS.Port)
+	}
+}
+
+func TestServerPortFallback(t *testing.T) {
+	logger := logging.New(os.Stdout, "text", true, false)
+	dir := t.TempDir()
+
+	srv, err := New(Config{
+		Port:       0, // trigger default / fallback logic
+		Bind:       "127.0.0.1",
+		ConfigFile: filepath.Join(dir, "config.json"),
+		Version:    "test",
+		Log:        logger,
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Serve(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	err = <-errCh
+	if err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+}

--- a/packaging/openwrt/files/ps2servers-edge.config
+++ b/packaging/openwrt/files/ps2servers-edge.config
@@ -50,7 +50,7 @@ config udpbd 'udpbd'
         option enabled '0'
         option image ''
         option bind '0.0.0.0'
-        option port '48301'
+        option port '48573'
         option read_only '1'
         # See the note on status_port in the smb section: off by default so it
         # cannot race udpfs for the same socket. Set -1 when udpbd is the only
@@ -60,6 +60,7 @@ config udpbd 'udpbd'
         option verbose '0'
 
 # WebUI serves a web dashboard to monitor and configure all Edge services.
+# Note: The dashboard is unauthenticated and intended for trusted private LANs.
 config webui 'webui'
         option enabled '0'
         option port '8082'

--- a/packaging/openwrt/files/ps2servers-edge.config
+++ b/packaging/openwrt/files/ps2servers-edge.config
@@ -58,3 +58,10 @@ config udpbd 'udpbd'
         option status_port '0'
         option log_format 'text'
         option verbose '0'
+
+# WebUI serves a web dashboard to monitor and configure all Edge services.
+config webui 'webui'
+        option enabled '0'
+        option port '8082'
+        option bind '0.0.0.0'
+

--- a/packaging/openwrt/files/ps2servers-edge.init
+++ b/packaging/openwrt/files/ps2servers-edge.init
@@ -35,6 +35,7 @@ start_service() {
         start_udpfs
         start_smb
         start_udpbd
+        start_webui
 }
 
 start_udpfs() {
@@ -173,6 +174,22 @@ start_udpbd() {
         procd_close_instance
 }
 
+start_webui() {
+        config_get_bool enabled webui enabled 0
+        [ "$enabled" -eq 1 ] || return 0
+
+        config_get bind webui bind 0.0.0.0
+        config_get port webui port 8082
+
+        procd_open_instance webui
+        procd_set_param command "$PROG" webui \
+                --bind "$bind" \
+                --webui-port "$port"
+        common_params
+        procd_close_instance
+}
+
 service_triggers() {
         procd_add_reload_trigger ps2servers-edge
 }
+

--- a/packaging/openwrt/files/ps2servers-edge.init
+++ b/packaging/openwrt/files/ps2servers-edge.init
@@ -181,6 +181,9 @@ start_webui() {
         config_get bind webui bind 0.0.0.0
         config_get port webui port 8082
 
+        # Ensure ps2edge service user has write permission for UCI commits
+        [ -f /etc/config/ps2servers-edge ] && chown ps2edge:ps2edge /etc/config/ps2servers-edge 2>/dev/null
+
         procd_open_instance webui
         procd_set_param command "$PROG" webui \
                 --bind "$bind" \

--- a/packaging/systemd/README.md
+++ b/packaging/systemd/README.md
@@ -20,9 +20,10 @@ sudo install -m 0644 packaging/systemd/ps2servers-edge-smb.env /etc/default/ps2s
 sudo systemctl enable --now ps2servers-edge@smb
 ```
 
-The instance name is the Edge subcommand, so `ps2servers-edge@udpfs` and
-`ps2servers-edge@udpbd` work the same way, each reading its own
-`/etc/default/ps2servers-edge-<subcommand>`. Several can run at once.
+The instance name is the Edge subcommand, so `ps2servers-edge@udpfs`,
+`ps2servers-edge@udpbd`, and `ps2servers-edge@webui` work the same way, each
+reading its own `/etc/default/ps2servers-edge-<subcommand>`. Several can run
+at once. Enable the web GUI with `systemctl enable --now ps2servers-edge@webui`.
 
 Edge's SMB defaults to **port 1111**, not 445, for the same reason as the
 Python one: below 1024 needs root and these units run as `ps2edge`.

--- a/packaging/systemd/ps2servers-edge-webui.env
+++ b/packaging/systemd/ps2servers-edge-webui.env
@@ -1,0 +1,4 @@
+# /etc/default/ps2servers-edge-webui
+# Configuration for ps2servers-edge@webui.service
+
+PS2EDGE_ARGS=--webui-port 8082 --bind 0.0.0.0 --config-file /etc/ps2servers-edge/config.json


### PR DESCRIPTION
## Summary

Adds an embedded, lightweight web management GUI for \ps2servers-edge\ (\ps2servers-edge webui\), allowing users to configure, manage, and monitor all Edge servers (UDPFS, SMB, UDPBD) from any web browser on their local network (phone, tablet, PC) without needing SSH or CLI experience.

### Features Included
- **New \webui\ Subcommand**: \ps2servers-edge webui --webui-port 8082\
- **Zero Dependencies**: Pure Go stdlib (\
et/http\, \//go:embed\) with ~90KB compressed binary footprint.
- **Three-Tier Port Fallback**: User port → default 8082 → OS assigned port 0.
- **PS2-Themed Responsive SPA**: Single-page app with Dashboard, full configuration forms for all 3 protocols, live SSE log tailing, and interactive path browser modal.
- **Dual Config Backends**: OpenWrt UCI (\/etc/config/ps2servers-edge\) + JSON file (\/etc/ps2servers-edge/config.json\).
- **Packaging**: OpenWrt init script + UCI config updates, Systemd unit environment file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an embedded responsive Web GUI for monitoring and managing Edge services.
  * View service status, restart services, edit settings, browse files, view system information, and stream live logs.
  * Added the `webui` command with configurable port, bind address, configuration file, and browser launch options.
  * Added OpenWrt and systemd startup support, using port 8082 by default.

* **Bug Fixes**
  * Improved network adapter detection and reporting for unconfigured physical adapters.

* **Documentation**
  * Added setup, usage, and configuration guidance for the Web GUI across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->