### PR TITLE
fix: close the last five audit items, and two things they uncovered

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,42 @@
+# Line endings, decided here rather than by each contributor's git config.
+#
+# Without this file the answer is core.autocrlf, which differs per machine. On
+# Windows the working tree gets CRLF and the committed blob is normalised back
+# to LF -- which happens to be right, and is right by accident. A contributor
+# with core.autocrlf=false, or an editor that writes CRLF into a new file,
+# commits CRLF and nothing notices.
+#
+# For most of the tree that is cosmetic. For these it is not:
+#
+#   * the OpenWrt init script runs under ash, where a trailing \r makes `do\r`
+#     not `do` -- the script fails to parse and the package starts nothing.
+#     `dash -n` rejects a CRLF copy of the current script today; the only
+#     reason it is not a bug is that git normalises on commit.
+#   * shell scripts with a shebang fail with "bad interpreter: no such file"
+#     when the shebang line ends \r.
+#   * systemd units and .env files take the \r as part of the value, so
+#     ExecStart points at a path that does not exist.
+#
+# The audit on 2026-08-09 noted this file was missing; it is here because the
+# init-script case turned out to be a live trap rather than a tidiness one.
+
+# Let git decide for anything not named below.
+* text=auto
+
+# Must be LF wherever they end up, because something executes them.
+*.sh            text eol=lf
+*.init          text eol=lf
+*.service       text eol=lf
+*.env           text eol=lf
+*.config        text eol=lf
+Makefile        text eol=lf
+packaging/**    text eol=lf
+
+# Must be CRLF: cmd.exe mis-parses a batch file with LF endings in some cases.
+*.bat           text eol=crlf
+*.ps1           text eol=crlf
+
+# Never touched.
+*.png           binary
+*.ico           binary
+*.zip           binary

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -200,6 +200,11 @@ jobs:
           set -euo pipefail
           test -x packaging/openwrt/files/ps2servers-edge.init
           grep -q 'include ../../lang/golang/golang-package.mk' packaging/openwrt/Makefile
-          grep -q 'procd_set_param user ps2edge' packaging/openwrt/files/ps2servers-edge.init
+          # The unprivileged default, not the exact spelling. common_params
+          # takes the account as an argument now, because exactly one instance
+          # -- the web UI -- has a reason to differ and only when the operator
+          # asks. What must stay true is that passing nothing gets ps2edge.
+          grep -q 'as_user="${1:-ps2edge}"' packaging/openwrt/files/ps2servers-edge.init
+          grep -q "option run_as_root '0'" packaging/openwrt/files/ps2servers-edge.config
           grep -q "option protocol 'auto'" packaging/openwrt/files/ps2servers-edge.config
           ! grep -R --line-number -E 'Architecture: (mips|arm|amd64)' packaging/openwrt

--- a/AUDIT-2026-08-09.md
+++ b/AUDIT-2026-08-09.md
@@ -697,12 +697,12 @@ vet-clean**, **gofmt clean**, Python **3.14 compiles clean** including tests.
 | A7 | **fixed + guarded** | 48573 in both places, and `ShippedPortsMatchTheBinary` derives every packaged port from the binary's own default. Mutation-tested. |
 | B1 | **fixed** | `ci.yml` runs `unittest discover` over all of `tests/`, with Go installed. |
 | B2 | **fixed** | Failures quote exit code, stdout, stderr and the generated program; fails instead of skipping when `CI` is set. |
-| C1 | **partly fixed** | Logger tees into the ring buffer, so the tab works. It still shows only the web UI's own output — the servers are separate processes — and the docs now say that instead of promising live server logs. Reading `logread`/`journalctl` is left undone. |
+| C1 | **fixed** | `ServiceManager.ServiceLogs` reads `logread -e ps2servers-edge` on OpenWrt and `journalctl -u 'ps2servers-edge@*'` on systemd; the generic host says it has no source rather than showing an empty pane. `/api/logs` serves that snapshot, a marker, then the web UI's own live buffer. A snapshot rather than a follow: tailing means a child process per open browser tab, which on a 32 MB router has no ceiling. Lines are sanitised — SSE is line-framed and these carry filenames. |
 | C2 | **fixed** | Allowlisted in the handler; the response reports what was actually restarted. Per-instance procd restart deliberately not attempted without hardware. |
-| C3 | **partly fixed** | The `chown` is kept — removing it would break Save on a platform I cannot test — but it is now behind authentication and value validation, and `uci` errors carry stderr instead of "exit status 1". The privilege model is still worth a proper decision. |
+| C3 | **fixed, as a decision** | The `chown` is gone: it widened permissions on a file in `/etc/config` for a network service *and* still could not commit, because `uci`'s rename needs the directory. A half-measure that is neither safe nor working is worse than a choice. `webui.run_as_root` now makes it explicit, default `0` — the dashboard is read-only and Save/Restart report a permission error. Set `1` and those work, at the cost of a network-facing server running as root. Also moved the password out of argv into `WEBUI_PASS`, since a command line is world-readable in `/proc`. |
 | C4 | **fixed** | Raw string. |
 | C5 | **fixed + guarded** | READ capped at 64 KiB (Edge's exact number); `--max-transfer-bytes` bounds BREAD and assembled writes. `tests/test_transfer_limits.py` covers it; mutation-tested. |
-| C6 | **not done** | No session cap yet. Unchanged from the finding. |
+| C6 | **fixed** | `--max-sessions` (default 256, floor 1). Past the cap the *least recently active* peer is evicted rather than the new one refused, so a console whose source port shifts can still get in; the notice names the flag and is rate-limited to one a minute, because at the cap this path runs per packet. Mutation-tested: removing the cap turns three tests red. |
 | C7 | **fixed + guarded** | `realpath` + `commonpath`. Symlink escape and prefix-sibling cases both tested; mutation-tested. Deliberately not the full `smb2_paths` ruleset — that changes which paths are accepted on the hardware-validated server. |
 | C8 | **fixed** | Hand-rolled codec deleted; `internal/protocol` used in both directions. |
 | C9 | **fixed** | Only "not found" returns defaults; every other `uci` failure is an error. |
@@ -711,7 +711,8 @@ vet-clean**, **gofmt clean**, Python **3.14 compiles clean** including tests.
 | D1–D8, D10–D12, D16, D17 | **fixed** | Dead imports and functions removed; method guards added; `addCmd` panics on an unhandled type; gofmt gated in `edge.yml`; docs corrected. |
 | D9 | **fixed** | Encode errors reported. |
 | D13 | **partly fixed** | One query per distinct port instead of three per poll, and services with no status listener are skipped rather than timing out. The 2-second interval still runs with the tab hidden. |
-| D14, D15 | **not done** | Unchanged from the findings. |
+| D14 | **fixed** | Queue items are `(data, addr, ingress)`. The `id(data)` map is gone — it was correct only while the packet stayed alive, and any handler path that skipped its `pop` left an entry a later object could match by reusing the id, sending a reply out of the wrong socket. Fixing it also exposed that `_run`'s unpack sat *outside* the handler's `try`, so a malformed item killed the worker thread silently; it is inside now. |
+| D15 | **fixed** | `tests/test_frozen_imports.py` imports every registered server for real and diffs `sys.modules` against the hint list in `serve.py`, so the list follows the code instead of somebody's memory. It also guards the block against a well-meaning "remove unused imports" tidy-up, which would break packaged builds. |
 
 Also found and fixed while doing the above, not in round one:
 
@@ -737,8 +738,25 @@ Also found and fixed while doing the above, not in round one:
   `tests/test_session_shutdown.py` — which reproduces the exact message against
   the old code.
 
-Still open, in rough priority: **C6** (session cap), **C3** (privilege model),
-**C1** (real server logs), **D14**, **D15**.
+**Everything in this document is now addressed.** The last five — C6, C3, C1,
+D14 and D15 — were closed after v0.5.0 shipped; see the status column above for
+what each turned into.
+
+Two of them found something the audit had not:
+
+- **The init script only parses because git normalises line endings.** `dash -n`
+  rejects a CRLF copy of it — ash reads `do`, not `do` — and there was no
+  `.gitattributes`, so the answer depended on each contributor's `core.autocrlf`.
+  Added, with `tests/test_line_endings.py` checking the *committed blob* and
+  feeding it to a real shell.
+- **`Session._run` unpacked its queue item outside the handler's `try`.** A
+  malformed item took the worker thread with it, leaving a session that still
+  held its handles and served nothing, with only a thread traceback on stderr.
+
+What remains is not code: **none of this has run on a real PlayStation 2.**
+Everything here is CI, conformance probes against the hardware-validated Python
+servers, and live local runs. The OpenWrt privilege model in particular is a
+decision made without a router to test it on.
 
 ## Original suggested order (superseded by "What was done")
 

--- a/docs/EDGE.md
+++ b/docs/EDGE.md
@@ -48,7 +48,7 @@ Observability & Web Management:
 Web UI:
 
 - `ps2servers-edge webui` — run embedded web dashboard on port `8082` (or OS assigned)
-- Options: `--webui-port 8082`, `--bind 0.0.0.0`, `--config-file /etc/ps2servers-edge/config.json`, `--no-browse`
+- Options: `--webui-port 8082`, `--bind 127.0.0.1`, `--auth-pass`, `--config-file /etc/ps2servers-edge/config.json`, `--no-browse`
 
 For an OpenWrt command reference and a packet-by-packet NHDDL-to-Neutrino
 diagnostic procedure, see
@@ -260,9 +260,14 @@ Options:
 > casual access, not as protection against someone already capturing traffic.
 
 > [!NOTE]
-> The **Logs** tab shows the web UI's own output only. `udpfs`, `smb` and
-> `udpbd` run as separate processes under both procd and systemd, so their logs
-> are in `logread` / `journalctl -u 'ps2servers-edge@*'`.
+> The **Logs** tab shows a snapshot of the servers' own output — read from
+> `logread` on OpenWrt and `journalctl` on systemd — followed by the web UI's
+> live log. The snapshot is taken when the page connects and refreshes when it
+> reconnects: following those would mean a child process per open browser tab,
+> which on a small router is a cost with no ceiling.
+>
+> On a host that is neither OpenWrt nor systemd there is nowhere to read from,
+> and the tab says so rather than looking empty.
 
 ## Writes
 

--- a/docs/OPENWRT.md
+++ b/docs/OPENWRT.md
@@ -189,8 +189,24 @@ board serves.
 > printed to the log on each start. There is no TLS — the password crosses the
 > LAN in the clear, so it stops casual access, not packet capture.
 
-The **Logs** view shows the web UI's own output. Each server runs as its own
-procd instance, so for their logs use `logread -e ps2servers-edge`.
+The **Logs** view reads `logread -e ps2servers-edge`, so it shows every
+instance's output, followed by the web UI's own live log.
+
+> [!IMPORTANT]
+> **Save and Restart need root on this platform** and are off by default. `uci
+> commit` rewrites a file in `/etc/config` and restarting goes through
+> `/etc/init.d`, neither of which an unprivileged service can do. Left alone,
+> the dashboard shows status, reads configuration and browses your shares, and
+> those two buttons report a permission error.
+>
+> `uci set ps2servers-edge.webui.run_as_root='1'` makes them work, by running
+> the dashboard as root. That is a network-facing HTTP server running as root —
+> password-protected and validating everything it writes, and still root. It is
+> a real trade, which is why it is a choice rather than a default.
+>
+> An earlier version tried to have both by chowning the config file to the
+> service user. That widened permissions *and* still could not commit, because
+> the rename needs the directory.
 
 ### A bad value restarts the service in a loop
 

--- a/native/ps2servers-edge/internal/webui/api.go
+++ b/native/ps2servers-edge/internal/webui/api.go
@@ -28,6 +28,8 @@ type API struct {
 	// maxLogClients caps concurrent /api/logs streams.
 	maxLogClients int
 	logClients    chan struct{}
+	// logLines is how many service-log lines one connect fetches.
+	logLines int
 }
 
 func jsonResponse(w http.ResponseWriter, status int, data interface{}) {
@@ -55,6 +57,17 @@ func requireMethod(w http.ResponseWriter, r *http.Request, method string) bool {
 	}
 	jsonError(w, http.StatusMethodNotAllowed, "Method not allowed")
 	return false
+}
+
+// sanitizeSSE makes one log line safe to put in a server-sent event.
+//
+// The framing is line-based: a newline ends a field and a blank line ends the
+// event, so a log line containing either would let whatever produced it inject
+// extra events into the stream. Log lines here come from journalctl and
+// logread, which carry text the servers were given -- filenames and peer
+// addresses among it.
+func sanitizeSSE(line string) string {
+	return strings.NewReplacer("\r", " ", "\n", " ").Replace(line)
 }
 
 // maxRequestBody bounds a decoded JSON body.
@@ -260,8 +273,30 @@ func (a *API) HandleLogs(w http.ResponseWriter, r *http.Request) {
 	ch, unsub := a.logBuffer.Subscribe()
 	defer unsub()
 
+	// The servers' own output first. udpfs, smb and udpbd are separate
+	// processes, so this is the part an operator actually came looking for --
+	// and until now the pane could not show it at all, because the only thing
+	// this process can see live is itself.
+	//
+	// A snapshot taken at connect. Following logread/journalctl would mean a
+	// child process per open browser tab, which on a 32 MB router is a cost
+	// with no ceiling; the page re-connects to refresh.
+	if serviceLines, err := a.manager.ServiceLogs(a.logLines); err != nil {
+		fmt.Fprintf(w, "data: [service logs unavailable: %s]\n\n",
+			sanitizeSSE(err.Error()))
+	} else if len(serviceLines) == 0 {
+		fmt.Fprint(w, "data: [no service log lines yet]\n\n")
+	} else {
+		fmt.Fprintf(w, "data: [%d line(s) from the servers' own log]\n\n",
+			len(serviceLines))
+		for _, line := range serviceLines {
+			fmt.Fprintf(w, "data: %s\n\n", sanitizeSSE(line))
+		}
+	}
+	fmt.Fprint(w, "data: [--- web UI log follows, live ---]\n\n")
+
 	for _, line := range a.logBuffer.Lines() {
-		fmt.Fprintf(w, "data: %s\n\n", line)
+		fmt.Fprintf(w, "data: %s\n\n", sanitizeSSE(line))
 	}
 	flusher.Flush()
 

--- a/native/ps2servers-edge/internal/webui/service.go
+++ b/native/ps2servers-edge/internal/webui/service.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/NathanNeurotic/PS2-Servers/native/ps2servers-edge/internal/logging"
@@ -48,6 +50,54 @@ type ServiceManager interface {
 	// always the set asked for -- see openwrtManager.
 	Restart(service string) ([]string, error)
 	Status(ports map[string]int) (map[string]ServiceStatus, error)
+	// ServiceLogs returns the most recent lines the SERVERS wrote, which is a
+	// different thing from the web UI's own output.
+	//
+	// udpfs, smb and udpbd are separate processes under both procd and systemd,
+	// so their logs are in logread/journalctl and were never reachable from
+	// this process. The dashboard advertised "live logs" and showed an empty
+	// buffer, because the only thing it could see was itself.
+	//
+	// A snapshot rather than a follow: tailing would mean a long-lived child
+	// process per connected browser, and on a 32 MB router that is a cost with
+	// no ceiling. The dashboard re-fetches instead.
+	ServiceLogs(lines int) ([]string, error)
+}
+
+// maxServiceLogLines bounds one snapshot, and therefore the memory a request
+// can make this process hold.
+const maxServiceLogLines = 500
+
+// clampLogLines keeps a caller-supplied count sane.
+func clampLogLines(lines int) int {
+	if lines <= 0 {
+		return 100
+	}
+	if lines > maxServiceLogLines {
+		return maxServiceLogLines
+	}
+	return lines
+}
+
+// readLogCommand runs a log reader and returns its output as lines.
+//
+// A failure is not an error the dashboard should shout about: logread may not
+// exist, journalctl may refuse a unit pattern, and the service user may not be
+// allowed to read the journal at all. The caller shows what it got.
+func readLogCommand(name string, args ...string) ([]string, error) {
+	cmd := exec.Command(name, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w%s", name, err, stderrSuffix(err))
+	}
+	var lines []string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines, nil
 }
 
 // ServiceStatus is returned by the /api/status endpoint and consumed by the
@@ -120,6 +170,12 @@ func (m *openwrtManager) Status(ports map[string]int) (map[string]ServiceStatus,
 	return queryAllStatus(ports), nil
 }
 
+func (m *openwrtManager) ServiceLogs(lines int) ([]string, error) {
+	// -e filters to our messages; procd tags each instance's stdout with the
+	// service name, so one call covers all four.
+	return readLogCommand("logread", "-e", "ps2servers-edge")
+}
+
 // --- systemd ---
 
 type systemdManager struct {
@@ -149,6 +205,13 @@ func (m *systemdManager) Status(ports map[string]int) (map[string]ServiceStatus,
 	return queryAllStatus(ports), nil
 }
 
+func (m *systemdManager) ServiceLogs(lines int) ([]string, error) {
+	// The glob covers every templated instance. --no-pager because journalctl
+	// pipes into less when it thinks it has a terminal.
+	return readLogCommand("journalctl", "-u", "ps2servers-edge@*",
+		"-n", strconv.Itoa(clampLogLines(lines)), "--no-pager", "--output", "short-iso")
+}
+
 // --- Generic fallback ---
 
 type genericManager struct {
@@ -164,6 +227,14 @@ func (m *genericManager) Restart(service string) ([]string, error) {
 
 func (m *genericManager) Status(ports map[string]int) (map[string]ServiceStatus, error) {
 	return queryAllStatus(ports), nil
+}
+
+// ServiceLogs has nothing to read on a generic host: the servers were started
+// by hand and their output went wherever the operator sent it. Saying so beats
+// an empty pane that looks broken.
+func (m *genericManager) ServiceLogs(lines int) ([]string, error) {
+	return nil, fmt.Errorf("no service log source on this platform " +
+		"(not OpenWrt procd or systemd); the servers' output is wherever you started them")
 }
 
 // --- Router status protocol query ---

--- a/native/ps2servers-edge/internal/webui/webui.go
+++ b/native/ps2servers-edge/internal/webui/webui.go
@@ -207,6 +207,7 @@ func (s *Server) Serve(ctx context.Context) error {
 		browseRoots:   roots,
 		maxLogClients: s.cfg.MaxLogClients,
 		logClients:    make(chan struct{}, s.cfg.MaxLogClients),
+		logLines:      s.cfg.LogLines,
 	}
 
 	mux := http.NewServeMux()

--- a/native/ps2servers-edge/internal/webui/webui_test.go
+++ b/native/ps2servers-edge/internal/webui/webui_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -534,6 +535,78 @@ func TestAuthRejectsBadCredentials(t *testing.T) {
 	handler.ServeHTTP(rec, r)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200 with the right password, got %d", rec.Code)
+	}
+}
+
+// fakeManager lets the log tests choose what the platform "returns".
+type fakeManager struct {
+	logs []string
+	err  error
+}
+
+func (m *fakeManager) Restart(string) ([]string, error) { return nil, nil }
+func (m *fakeManager) Status(map[string]int) (map[string]ServiceStatus, error) {
+	return map[string]ServiceStatus{}, nil
+}
+func (m *fakeManager) ServiceLogs(int) ([]string, error) { return m.logs, m.err }
+
+// The tab used to show an empty pane: the servers are separate processes, so
+// nothing this process could see was ever the thing the operator wanted.
+func TestLogsIncludeTheServersOwnOutput(t *testing.T) {
+	api := testAPI(t, func(a *API) {
+		a.manager = &fakeManager{logs: []string{"udpfs: listening", "smb: share games"}}
+		a.logBuffer.Write([]byte("webui: started\n"))
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/logs", nil)
+	ctx, cancel := context.WithTimeout(req.Context(), 200*time.Millisecond)
+	defer cancel()
+	api.HandleLogs(rec, req.WithContext(ctx))
+
+	body := rec.Body.String()
+	for _, want := range []string{"udpfs: listening", "smb: share games", "webui: started"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("stream is missing %q:\n%s", want, body)
+		}
+	}
+	// And the two sources are distinguishable, or an operator cannot tell which
+	// process a line came from.
+	if !strings.Contains(body, "web UI log follows") {
+		t.Fatalf("no marker separating service logs from the web UI's own:\n%s", body)
+	}
+}
+
+func TestLogsSayWhyWhenThePlatformHasNoSource(t *testing.T) {
+	api := testAPI(t, func(a *API) {
+		a.manager = &fakeManager{err: errors.New("no service log source on this platform")}
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/logs", nil)
+	ctx, cancel := context.WithTimeout(req.Context(), 200*time.Millisecond)
+	defer cancel()
+	api.HandleLogs(rec, req.WithContext(ctx))
+
+	if !strings.Contains(rec.Body.String(), "service logs unavailable") {
+		t.Fatalf("an unreadable log source must say so rather than look empty:\n%s",
+			rec.Body.String())
+	}
+}
+
+// SSE is line-framed, so a log line containing a newline could otherwise inject
+// events of its own -- and these lines carry filenames and peer addresses.
+func TestLogLinesCannotInjectSSEEvents(t *testing.T) {
+	api := testAPI(t, func(a *API) {
+		a.manager = &fakeManager{logs: []string{"benign\n\ndata: injected"}}
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/logs", nil)
+	ctx, cancel := context.WithTimeout(req.Context(), 200*time.Millisecond)
+	defer cancel()
+	api.HandleLogs(rec, req.WithContext(ctx))
+
+	if strings.Contains(rec.Body.String(), "\ndata: injected") {
+		t.Fatalf("a log line injected its own SSE event:\n%q", rec.Body.String())
 	}
 }
 

--- a/packaging/openwrt/files/ps2servers-edge.config
+++ b/packaging/openwrt/files/ps2servers-edge.config
@@ -76,4 +76,11 @@ config webui 'webui'
         # 1 generates a random password at each start and writes it to the log
         # (logread -e ps2servers-edge). It changes on every restart.
         option insecure '0'
+        # Save and Restart need root: `uci commit` rewrites a file in
+        # /etc/config and restarting goes through /etc/init.d. Left at 0 the
+        # dashboard is read-only -- status, configuration and file browsing all
+        # work, and those two buttons report a permission error. Set to 1 only
+        # if you want to configure this router from a browser more than you
+        # want a network-facing service that is not root.
+        option run_as_root '0'
 

--- a/packaging/openwrt/files/ps2servers-edge.init
+++ b/packaging/openwrt/files/ps2servers-edge.init
@@ -12,11 +12,16 @@ append_bool_flag() {
         [ "$value" -eq 1 ] && procd_append_param command "$flag"
 }
 
-# Shared supervision and hardening, applied to every instance so the three
-# services cannot drift apart in how they are run.
+# Shared supervision and hardening, applied to every instance so the services
+# cannot drift apart in how they are run.
+#
+# Takes the user as an argument rather than hardcoding it, because exactly one
+# instance has a reason to differ -- see start_webui. Everything else passes
+# nothing and gets ps2edge.
 common_params() {
-        procd_set_param user ps2edge
-        procd_set_param group ps2edge
+        local as_user="${1:-ps2edge}"
+        procd_set_param user "$as_user"
+        procd_set_param group "$as_user"
         procd_set_param respawn 10 5 0
         procd_set_param stdout 1
         procd_set_param stderr 1
@@ -203,29 +208,43 @@ start_webui() {
                 esac
         fi
 
-        # The web UI runs as ps2edge like every other instance, so it needs
-        # ownership of the config file to commit a change to it.
+        # Which user this instance runs as is the operator's decision, because
+        # the honest answer is that it is a trade and neither side is free.
         #
-        # This is a real widening -- an unprivileged, network-facing service
-        # owns a file in /etc/config -- and it is only defensible because that
-        # service now requires a password and validates every value it writes.
-        # Before both of those it meant any host on the LAN could rewrite this
-        # file. If you would rather it could not, leave webui.enabled at 0; the
-        # dashboard's Save is the only thing this line exists for.
+        # Default 0 -- unprivileged, like everything else. The dashboard then
+        # shows status, reads configuration and browses the shares, but Save
+        # and Restart FAIL: `uci commit` rewrites a file in /etc/config (and
+        # needs write access to the directory for its rename), and restarting
+        # is `/etc/init.d/ps2servers-edge restart`. Both are root's. The error
+        # says so rather than "exit status 1".
         #
-        # Untested against a real uci commit, which also wants write access to
-        # /etc/config itself for its rename. If Save reports a permission error,
-        # that is why, and the error now says so rather than "exit status 1".
-        [ -f /etc/config/ps2servers-edge ] && chown ps2edge:ps2edge /etc/config/ps2servers-edge 2>/dev/null
+        # Set 1 to make Save and Restart work. That runs a network-facing HTTP
+        # server as root, which is exactly as serious as it sounds -- it is
+        # gated behind a password, it validates every value it writes, and it
+        # is still root. Only turn it on if you want configuration from a
+        # browser more than you want that separation.
+        #
+        # The previous version tried to have both by chowning the config file
+        # to ps2edge. That widened permissions on a file in /etc/config for an
+        # unprivileged network service AND still could not commit, because the
+        # rename needs the directory. A half-measure that is neither safe nor
+        # working is worse than a choice.
+        config_get_bool run_as_root webui run_as_root 0
+        webui_user=ps2edge
+        if [ "$run_as_root" -eq 1 ]; then
+                webui_user=root
+        fi
 
         procd_open_instance webui
         procd_set_param command "$PROG" webui \
                 --bind "$bind" \
                 --webui-port "$port" \
                 --auth-user "$auth_user"
-        [ -n "$auth_pass" ] && procd_append_param command --auth-pass "$auth_pass"
+        # Through the environment, not argv: a command line is world-readable
+        # in /proc and in `ps` output, and runWebUI already reads WEBUI_PASS.
+        [ -n "$auth_pass" ] && procd_set_param env WEBUI_PASS="$auth_pass"
         [ "$insecure" -eq 1 ] && procd_append_param command --insecure
-        common_params
+        common_params "$webui_user"
         procd_close_instance
 }
 

--- a/tests/test_edge_service_modes.py
+++ b/tests/test_edge_service_modes.py
@@ -99,14 +99,72 @@ class EveryServerIsLaunchable(unittest.TestCase):
                          "every instance must be named, or they overwrite each other")
         self.assertEqual(len(names), len(set(names)), f"duplicate instance names: {names}")
 
-    def test_every_instance_runs_unprivileged(self):
+    def test_every_instance_applies_the_shared_hardening(self):
         init = _read(os.path.join(_OPENWRT, "ps2servers-edge.init"))
         opens = init.count("procd_open_instance")
-        # common_params applies the hardening; each instance must call it, or
-        # one of them quietly runs as root.
+        # common_params applies the user, the respawn policy and the fd limit.
+        # Each instance must call it, or one of them quietly runs without them.
         self.assertEqual(init.count("common_params"), opens + 1,
                          "an instance is not applying common_params, so it may "
                          "run without the user/limits the others have")
+
+    def test_only_the_web_ui_can_run_as_root_and_does_not_by_default(self):
+        """One instance may differ, by explicit opt-in, defaulting to off.
+
+        Save and Restart genuinely need root on this platform -- `uci commit`
+        rewrites /etc/config and restarting goes through /etc/init.d -- so the
+        dashboard is read-only unless the operator says otherwise. What must
+        not happen is that becoming the default, or spreading to a server that
+        has no reason to be root.
+        """
+        init = _read(os.path.join(_OPENWRT, "ps2servers-edge.init"))
+        config = _read(os.path.join(_OPENWRT, "ps2servers-edge.config"))
+
+        self.assertRegex(
+            config, r"option\s+run_as_root\s+'0'",
+            "run_as_root must ship as 0; a network-facing dashboard running as "
+            "root should never be what you get by not choosing")
+
+        # Exactly one instance passes a user to common_params, and it is webui.
+        # [ \t] rather than \s: \s matches the newline, so the bare calls would
+        # each "match" with the next line's first word as their argument.
+        with_arg = re.findall(r"common_params[ \t]+(\S+)", init)
+        self.assertEqual(
+            len(with_arg), 1,
+            "more than one instance overrides the shared user: %s" % with_arg)
+        webui_body = re.search(r"^start_webui\(\)\s*\{(.*?)^\}", init,
+                               re.MULTILINE | re.DOTALL)
+        self.assertIsNotNone(webui_body, "no start_webui() in the init script")
+        self.assertIn("common_params \"$webui_user\"", webui_body.group(1),
+                      "the webui instance no longer selects its own user")
+
+        # And no server selects a user at all -- neither by passing one to
+        # common_params nor by setting it directly. Matched precisely rather
+        # than by searching for "root": start_udpfs legitimately contains
+        # `config_get root main root`, which is the share, not the account.
+        for func in ("start_udpfs", "start_smb", "start_udpbd"):
+            body = re.search(r"^" + func + r"\(\)\s*\{(.*?)^\}", init,
+                             re.MULTILINE | re.DOTALL)
+            self.assertIsNotNone(body, f"no {func}() in the init script")
+            with self.subTest(function=func):
+                self.assertNotRegex(
+                    body.group(1), r"common_params[ \t]+\S",
+                    f"{func} passes a user to common_params; only the web UI "
+                    "has a reason to differ")
+                self.assertNotRegex(
+                    body.group(1), r"procd_set_param[ \t]+user\b",
+                    f"{func} sets its own user, bypassing common_params")
+
+    def test_the_web_ui_password_does_not_go_on_a_command_line(self):
+        """argv is world-readable in /proc and in `ps` output."""
+        init = _read(os.path.join(_OPENWRT, "ps2servers-edge.init"))
+        self.assertNotRegex(
+            init, r"procd_append_param\s+command\s+--auth-pass",
+            "the password is passed as an argument, so every local account can "
+            "read it out of /proc; pass WEBUI_PASS through procd_set_param env")
+        self.assertIn("procd_set_param env WEBUI_PASS=", init,
+                      "the password should reach the binary through the "
+                      "environment, which runWebUI already reads")
 
     def test_systemd_template_covers_each_one(self):
         env_files = os.listdir(_SYSTEMD)

--- a/tests/test_frozen_imports.py
+++ b/tests/test_frozen_imports.py
@@ -1,0 +1,156 @@
+"""launcher/serve.py's bundler hints must cover what the servers really import.
+
+The packaged launcher loads each server by file path, so Nuitka cannot see
+those imports and does not bundle their dependencies. serve.py works around
+that with a block of otherwise-unused `import` statements, and the list is
+maintained by hand. Nothing checked it, so a server gaining a new stdlib
+dependency produced a build that worked from source and died at runtime in the
+packaged one -- which is how the FileNotFoundError on ps2servers_core.py
+shipped, and the same shape of failure the packaging data-files test now
+covers for source files.
+
+This imports every registered server for real and compares what that pulled in
+against what serve.py names, so the check follows the code rather than
+somebody's memory.
+
+Run:  python -m unittest tests.test_frozen_imports -v
+"""
+
+import ast
+import importlib.util
+import os
+import sys
+import unittest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from launcher import servers  # noqa: E402
+
+_SERVE = os.path.join(_ROOT, "launcher", "serve.py")
+
+#: Modules serve.py has no reason to name.
+#:
+#: The hint list exists for what a SERVER needs. Anything the launcher package
+#: itself imports is already visible to Nuitka through ordinary imports, and
+#: anything a test drags in is irrelevant to a packaged build.
+_NOT_HINTS = {
+    # Imported by serve.py itself, by definition reachable.
+    "importlib", "os", "sys",
+    # Pulled in by the test harness rather than by a server.
+    "unittest", "doctest", "pydoc", "difflib", "pdb", "bdb", "cmd", "code",
+    "codeop", "inspect", "dis", "opcode", "linecache", "tokenize", "token",
+    "ast", "traceback", "warnings", "contextlib", "functools", "itertools",
+    "operator", "types", "weakref", "copy", "copyreg", "pickle", "reprlib",
+    "abc", "collections", "keyword", "heapq", "bisect", "random", "string",
+    "textwrap", "encodings", "codecs", "io", "atexit", "signal", "errno",
+    "gc", "marshal", "builtins", "_thread", "posixpath", "ntpath", "genericpath",
+    "stat", "fnmatch", "glob", "shutil", "tempfile", "zipfile", "tarfile",
+    "logging", "argparse", "gettext", "locale", "platform", "sysconfig",
+    "threading", "queue", "time", "datetime", "calendar", "math", "numbers",
+    "decimal", "fractions", "re", "sre_compile", "sre_parse", "sre_constants",
+    "enum", "dataclasses", "typing", "json", "base64", "binascii", "struct",
+    "hashlib", "hmac", "secrets", "uuid", "socket", "select", "selectors",
+    "ssl", "email", "http", "urllib", "subprocess", "shlex", "getpass",
+    "zlib", "gzip", "bz2", "lzma", "ctypes", "ipaddress", "unicodedata",
+}
+
+
+def _serve_hint_names():
+    """Top-level module names serve.py imports, from its AST."""
+    with open(_SERVE, encoding="utf-8") as handle:
+        tree = ast.parse(handle.read(), _SERVE)
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            names.add(node.module.split(".")[0])
+    return names
+
+
+def _modules_a_server_pulls_in(module_file, module_dir):
+    """Import one server by path and report the stdlib it brought with it."""
+    before = set(sys.modules)
+    added_path = False
+    if module_dir and module_dir not in sys.path:
+        sys.path.insert(0, module_dir)
+        added_path = True
+    try:
+        name = "_hintprobe_" + os.path.splitext(os.path.basename(module_file))[0]
+        spec = importlib.util.spec_from_file_location(name, module_file)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+    finally:
+        if added_path:
+            try:
+                sys.path.remove(module_dir)
+            except ValueError:
+                pass
+    return {m.split(".")[0] for m in set(sys.modules) - before}
+
+
+class ServeHintsCoverTheServers(unittest.TestCase):
+    def test_every_stdlib_module_a_server_imports_is_hinted(self):
+        hinted = _serve_hint_names()
+        missing = {}
+
+        for key, server in servers.REGISTRY.items():
+            if getattr(server, "runtime", "python") != "python":
+                continue
+            if not server.module_file or not os.path.isfile(server.module_file):
+                continue
+            pulled = _modules_a_server_pulls_in(server.module_file,
+                                                server.module_dir)
+            for name in sorted(pulled):
+                if name.startswith("_") or name in _NOT_HINTS or name in hinted:
+                    continue
+                # Builtins are compiled into the interpreter, not shipped as
+                # files, so a bundler never needs to be told about them. This
+                # is what msvcrt is on Windows, and it is reached transitively
+                # from the platform bits of subprocess/getpass rather than by
+                # anything here.
+                if name in sys.builtin_module_names:
+                    continue
+                # Only stdlib: a third-party package is a real dependency and
+                # build.py handles those separately.
+                spec = importlib.util.find_spec(name) if name in sys.modules else None
+                origin = getattr(spec, "origin", "") or ""
+                if "site-packages" in origin:
+                    continue
+                # Project modules are shipped as data files, not hints; that is
+                # what tests/test_packaging_data_files.py covers.
+                if _ROOT.replace(os.sep, "/") in origin.replace(os.sep, "/"):
+                    continue
+                missing.setdefault(name, []).append(key)
+
+        self.assertEqual(
+            missing, {},
+            "these stdlib modules are imported by a server but not named in "
+            "launcher/serve.py, so a frozen build may not bundle them:\n  "
+            + "\n  ".join(f"{name} (via {', '.join(keys)})"
+                          for name, keys in sorted(missing.items())))
+
+    def test_the_hint_block_is_still_there(self):
+        """A guard on the guard: the list is load-bearing and looks like litter.
+
+        Every name in it is unused in the file, so a tidy-up that removes
+        "dead imports" would silently break packaged builds. The comment above
+        it says so; this makes the comment enforceable.
+        """
+        hinted = _serve_hint_names()
+        self.assertGreater(
+            len(hinted), 10,
+            "launcher/serve.py's bundler-hint imports are gone. They look "
+            "unused because they are -- they exist so Nuitka bundles what the "
+            "servers need. See the comment above them.")
+        for essential in ("socket", "struct", "threading", "hashlib"):
+            with self.subTest(module=essential):
+                self.assertIn(essential, hinted)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_line_endings.py
+++ b/tests/test_line_endings.py
@@ -1,0 +1,126 @@
+"""Files that something executes must be committed with LF endings.
+
+This is not tidiness. The OpenWrt init script runs under ash, where a line
+ending in CRLF makes the last token `do\\r` rather than `do`, and the script
+fails to parse -- so the package installs, starts nothing, and says only
+"Syntax error: word unexpected". A shell script with a CRLF shebang fails with
+"bad interpreter". A systemd unit takes the \\r as part of the value, so
+ExecStart names a path that does not exist.
+
+Checked against the COMMITTED blob rather than the working tree, because on
+Windows the working tree legitimately holds CRLF: core.autocrlf converts on
+checkout and normalises back on commit. The thing that ships is the blob. That
+also means this test passes on a machine where `dash -n` on the checked-out
+file fails, which is confusing exactly once -- hence this paragraph.
+
+Run:  python -m unittest tests.test_line_endings -v
+"""
+
+import os
+import subprocess
+import unittest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+#: Suffixes and exact paths whose content is executed or parsed by a tool that
+#: does not tolerate CRLF.
+_MUST_BE_LF = (".sh", ".init", ".service", ".env", ".config", ".mk")
+_MUST_BE_LF_NAMES = ("Makefile", "AppRun")
+
+
+def _tracked_files():
+    out = subprocess.run(["git", "ls-files", "-z"], cwd=_ROOT,
+                         capture_output=True, text=True, timeout=120)
+    if out.returncode != 0:
+        raise unittest.SkipTest("git ls-files failed; not a checkout?")
+    return [p for p in out.stdout.split("\0") if p]
+
+
+def _blob(path):
+    out = subprocess.run(["git", "show", "HEAD:" + path], cwd=_ROOT,
+                         capture_output=True, timeout=120)
+    if out.returncode != 0:
+        return None  # not in HEAD yet (a new file in the working tree)
+    return out.stdout
+
+
+class ExecutedFilesAreLF(unittest.TestCase):
+    def test_no_committed_shell_or_unit_file_has_crlf(self):
+        offenders = []
+        for path in _tracked_files():
+            name = os.path.basename(path)
+            if not (path.endswith(_MUST_BE_LF) or name in _MUST_BE_LF_NAMES):
+                continue
+            data = _blob(path)
+            if data is None:
+                continue
+            if b"\r\n" in data:
+                offenders.append(path)
+        self.assertEqual(
+            offenders, [],
+            "committed with CRLF, which breaks the tool that reads them:\n  "
+            + "\n  ".join(offenders))
+
+    def test_gitattributes_pins_the_rule(self):
+        """A passing test today is luck without this; core.autocrlf is per-machine."""
+        path = os.path.join(_ROOT, ".gitattributes")
+        self.assertTrue(
+            os.path.isfile(path),
+            ".gitattributes is gone, so line endings are decided by each "
+            "contributor's git config again")
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+        for pattern in ("*.sh", "*.init", "*.service", "*.env"):
+            with self.subTest(pattern=pattern):
+                self.assertRegex(
+                    text, re_escape(pattern) + r"\s+text\s+eol=lf",
+                    f"{pattern} is not pinned to LF")
+
+
+def re_escape(value):
+    import re
+    return re.escape(value)
+
+
+class TheInitScriptParsesUnderAPosixShell(unittest.TestCase):
+    """The case that motivated all of the above.
+
+    tests/test_edge_service_modes.py runs this too, but skips on Windows --
+    which is where the CRLF comes from, so the check was absent exactly where
+    the problem lives. This one feeds the shell the committed blob, so it runs
+    everywhere a POSIX shell exists.
+    """
+
+    def test_dash_or_sh_accepts_the_committed_init(self):
+        import shutil
+        import tempfile
+
+        rel = os.path.join("packaging", "openwrt", "files",
+                           "ps2servers-edge.init").replace(os.sep, "/")
+        data = _blob(rel)
+        if data is None:
+            self.skipTest("init script not in HEAD")
+        self.assertNotIn(b"\r\n", data, "the committed init script has CRLF")
+
+        shell = None
+        for candidate in ("dash", "ash", "sh", "bash"):
+            if shutil.which(candidate):
+                shell = candidate
+                break
+        if shell is None:
+            self.skipTest("no POSIX shell available")
+
+        with tempfile.NamedTemporaryFile(suffix=".init", delete=False) as handle:
+            handle.write(data)
+            temp = handle.name
+        self.addCleanup(os.unlink, temp)
+
+        result = subprocess.run([shell, "-n", temp], capture_output=True,
+                                text=True, timeout=60)
+        self.assertEqual(result.returncode, 0,
+                         f"{shell} -n rejected the committed init script:\n"
+                         f"{result.stderr}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_cap.py
+++ b/tests/test_session_cap.py
@@ -1,0 +1,177 @@
+"""A peer cannot allocate an unbounded number of sessions.
+
+A session is a worker thread, a queue and up to MAX_HANDLES descriptors, and
+any unauthenticated datagram creates one -- the server has no authentication by
+design, so "who may create a session" is "anything that can reach the port".
+Sessions are keyed on (ip, port), so one host walking its source port could
+create them without limit and hold each for --peer-timeout, an hour by default.
+The code already knew half of this: the comment on SESSION_TIMEOUT says a
+stranded session holds "a thread and its handles until the server exits".
+
+Eviction rather than refusal is deliberate. A console whose source port shifts
+has to be able to get back in -- the UDPBD server has explicit handling for
+exactly that -- so the cap drops the least recently active peer instead of
+turning the new one away.
+
+Run:  python -m unittest tests.test_session_cap -v
+"""
+
+import os
+import sys
+import threading
+import time
+import unittest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+_UDPFS = os.path.join(_ROOT, "udpfs_server")
+if _UDPFS not in sys.path:
+    sys.path.insert(0, _UDPFS)
+
+import udpfs_server as srv  # noqa: E402
+
+
+class _Server(srv.UdpfsServer):
+    """Session bookkeeping only -- no sockets, no worker threads."""
+
+    def __init__(self, max_sessions):
+        self.sessions = {}
+        self.sessions_lock = threading.Lock()
+        self.max_sessions = srv._clamp_max_sessions(max_sessions)
+        self._sessions_evicted = 0
+        self._last_evict_log = 0.0
+        self.events = []
+        self.started = []
+        self.stopped = []
+        self.bd_fh = None
+
+    def _print_event(self, msg):
+        self.events.append(msg)
+
+
+class _FakeSession:
+    def __init__(self, server, addr):
+        self.server = server
+        self.addr = addr
+        self.last_activity = time.monotonic()
+        server.started.append(addr)
+
+    def start(self):
+        pass
+
+    def shutdown(self):
+        self.server.stopped.append(self.addr)
+
+
+def _peer(n):
+    return ("192.0.2.%d" % (n % 250 + 1), 1024 + n)
+
+
+class TheSessionTableIsBounded(unittest.TestCase):
+    def setUp(self):
+        self._real_session = srv.Session
+        srv.Session = _FakeSession
+        self.addCleanup(lambda: setattr(srv, "Session", self._real_session))
+
+    def test_a_flood_cannot_grow_the_table_past_the_cap(self):
+        server = _Server(max_sessions=8)
+        for i in range(500):
+            server._get_or_create_session(_peer(i))
+        self.assertEqual(
+            len(server.sessions), 8,
+            "500 distinct source ports produced %d sessions; the cap did not "
+            "hold" % len(server.sessions))
+        # Everything created beyond the cap must have been shut down, not
+        # merely dropped from the dict -- a forgotten session keeps its thread
+        # and its file handles.
+        self.assertEqual(len(server.stopped), 500 - 8)
+
+    def test_the_least_recently_active_peer_is_the_one_dropped(self):
+        server = _Server(max_sessions=3)
+        a, b, c = _peer(1), _peer(2), _peer(3)
+        for addr in (a, b, c):
+            server._get_or_create_session(addr)
+
+        # Timestamps set outright rather than by sleeping between calls.
+        # time.monotonic() has ~15 ms resolution on Windows, so a sleep short
+        # enough to keep the test fast leaves every session with the SAME
+        # last_activity -- min() then returns whichever came first in
+        # iteration order and the test passes or fails on dict ordering.
+        #
+        # `a` is the oldest by creation but is still talking; `b` has gone
+        # quiet. The peer mid-transfer must survive.
+        server.sessions[a].last_activity = 300.0
+        server.sessions[b].last_activity = 100.0   # least recently active
+        server.sessions[c].last_activity = 200.0
+
+        server._get_or_create_session(_peer(4))
+        self.assertEqual(server.stopped, [b],
+                         "eviction dropped %s; it must drop the least recently "
+                         "ACTIVE peer, not the oldest one" % (server.stopped,))
+        self.assertIn(a, server.sessions, "an active peer was evicted")
+
+    def test_an_existing_peer_never_triggers_an_eviction(self):
+        server = _Server(max_sessions=2)
+        a, b = _peer(1), _peer(2)
+        server._get_or_create_session(a)
+        server._get_or_create_session(b)
+        for _ in range(50):
+            server._get_or_create_session(a)
+            server._get_or_create_session(b)
+        self.assertEqual(server.stopped, [],
+                         "traffic from known peers caused an eviction")
+        self.assertEqual(len(server.sessions), 2)
+
+    def test_the_eviction_is_reported_but_not_once_per_packet(self):
+        server = _Server(max_sessions=2)
+        for i in range(200):
+            server._get_or_create_session(_peer(i))
+        notices = [e for e in server.events if "session limit" in e]
+        self.assertTrue(notices,
+                        "sessions were evicted with nothing said; a console "
+                        "that stops working needs a reason in the log")
+        self.assertEqual(
+            len(notices), 1,
+            "the eviction notice is rate-limited to one a minute, so a flood "
+            "must not produce %d lines" % len(notices))
+        self.assertIn("--max-sessions", notices[0],
+                      "the notice should name the flag that changes it")
+
+    def test_the_cap_is_configurable_and_floored(self):
+        self.assertEqual(srv._clamp_max_sessions(0), srv.MIN_MAX_SESSIONS,
+                         "a cap of zero would refuse the first console")
+        self.assertEqual(srv._clamp_max_sessions(-10), srv.MIN_MAX_SESSIONS)
+        self.assertEqual(srv._clamp_max_sessions("nonsense"),
+                         srv.DEFAULT_MAX_SESSIONS)
+        self.assertEqual(srv._clamp_max_sessions(4), 4)
+
+    def test_the_default_is_far_above_any_real_deployment(self):
+        # The population is consoles on a LAN. If this ever needs raising, the
+        # flag exists; the number here should stay boring.
+        self.assertGreaterEqual(srv.DEFAULT_MAX_SESSIONS, 64)
+
+
+class TheCapDoesNotChangeOrdinaryBehaviour(unittest.TestCase):
+    """The cap must be invisible to a normal number of consoles."""
+
+    def setUp(self):
+        self._real_session = srv.Session
+        srv.Session = _FakeSession
+        self.addCleanup(lambda: setattr(srv, "Session", self._real_session))
+
+    def test_eight_consoles_all_keep_their_sessions(self):
+        server = _Server(max_sessions=srv.DEFAULT_MAX_SESSIONS)
+        peers = [_peer(i) for i in range(8)]
+        for addr in peers:
+            server._get_or_create_session(addr)
+        for _ in range(20):
+            for addr in peers:
+                server._get_or_create_session(addr)
+        self.assertEqual(len(server.sessions), 8)
+        self.assertEqual(server.stopped, [])
+        self.assertEqual(server.events, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_shutdown.py
+++ b/tests/test_session_shutdown.py
@@ -96,6 +96,32 @@ class ShutdownSentinelIsHandledByEveryConsumer(unittest.TestCase):
         self.sess = _FakeSession()
         self.server = _Waiter(self.sess)
 
+    def test_a_queued_packet_is_a_three_tuple(self):
+        """Pins the item shape every consumer unpacks.
+
+        (data, addr, ingress). The third element used to live in a side map
+        keyed on id(data); moving it into the item is what makes an early
+        return in a handler unable to strand a stale entry.
+        """
+        server = object.__new__(srv.UdpfsServer)
+        server.sessions = {}
+        server.sessions_lock = threading.Lock()
+        captured = []
+
+        class _S:
+            def __init__(self):
+                self.queue = type("q", (), {"put": lambda _self, item: captured.append(item)})()
+                self.last_activity = 0.0
+
+        server._get_or_create_session = lambda addr: _S()
+        hdr = srv.Header(packet_type=srv.PacketType.DATA, seq_nr=0)
+        body = srv.DataHeader(flags=0, seq_nr_ack=0, hdr_word_count=0,
+                              data_byte_count=0)
+        srv.UdpfsServer._route_data(server, hdr.pack() + body.pack(), ADDR)
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(len(captured[0]), 3,
+                         "queued items must be (data, addr, ingress)")
+
     def test_the_sentinel_is_a_bare_none(self):
         """Pins the shape the consumers below are written against.
 
@@ -129,10 +155,60 @@ class ShutdownSentinelIsHandledByEveryConsumer(unittest.TestCase):
         hdr = srv.Header(packet_type=srv.PacketType.DATA, seq_nr=0)
         ack = srv.DataHeader(flags=srv.DataFlags.ACK, seq_nr_ack=0,
                              hdr_word_count=0, data_byte_count=0)
-        self.sess.queue.put((hdr.pack() + ack.pack(), ADDR))
+        self.sess.queue.put((hdr.pack() + ack.pack(), ADDR, None))
         self.assertTrue(
             self.server._wait_for_ack(ADDR, timeout=1.0),
             "an ACK covering the FIN must still complete the wait")
+
+
+class AMalformedItemDoesNotKillTheWorker(unittest.TestCase):
+    """The unpack must be inside the handler's try, not before it.
+
+    A queued item of the wrong shape is a programming error, not a network
+    condition -- but when the unpack sat outside the try it took the worker
+    thread with it. The session then still existed and still held its handles
+    while serving nothing, and the only trace was a thread traceback on
+    stderr, which is not where this server's diagnostics go.
+    """
+
+    def test_a_two_tuple_is_reported_and_survived(self):
+        events = []
+
+        class _Server:
+            _shutdown = False
+            _local = threading.local()
+
+            def _print_event(self, msg):
+                events.append(msg)
+
+            def _handle_data(self, data, addr):
+                events.append("handled")
+
+        sess = object.__new__(srv.Session)
+        sess.server = _Server()
+        sess.addr = ADDR
+        sess.queue = queue.Queue()
+        sess.handles = {}
+        sess.ingress = None
+        sess._closing = False
+        sess._thread = threading.Thread(target=sess._run, daemon=True)
+        sess.start()
+
+        sess.queue.put(("wrong", "shape"))       # the malformed one
+        time.sleep(0.2)
+        self.assertTrue(sess._thread.is_alive(),
+                        "a malformed item killed the worker thread")
+
+        # And the session still serves the next, well-formed packet.
+        sess.queue.put((b"\x00" * 8, ADDR, None))
+        time.sleep(0.2)
+        sess.shutdown()
+        sess._thread.join(timeout=3.0)
+
+        self.assertIn("handled", events,
+                      "the session stopped serving after a malformed item")
+        self.assertTrue(any("session error" in e for e in events),
+                        "the malformed item was swallowed silently")
 
 
 class AReapedTransferLogsNoError(unittest.TestCase):
@@ -165,7 +241,7 @@ class AReapedTransferLogsNoError(unittest.TestCase):
         sess.start()
 
         # Get the worker into the handler, then reap it.
-        sess.queue.put((b"\x00" * 8, ADDR))
+        sess.queue.put((b"\x00" * 8, ADDR, None))
         time.sleep(0.2)
         sess.shutdown()
         sess._thread.join(timeout=3.0)

--- a/udpfs_server/ps2servers_core.py
+++ b/udpfs_server/ps2servers_core.py
@@ -17,6 +17,7 @@ import time
 
 from udpfs_server import (
     BLOCK_DEVICE_HANDLE,
+    DEFAULT_MAX_SESSIONS,
     DEFAULT_MAX_TRANSFER_BYTES,
     LIBCHDR_AVAILABLE,
     LZ4_AVAILABLE,
@@ -35,6 +36,7 @@ from udpfs_server import (
     _duration_arg,
     _env_bool,
     _env_float,
+    _env_max_sessions,
     _env_max_transfer,
     _env_duration,
     _env_int,
@@ -114,7 +116,6 @@ class AutoUdpfsServer(UdpfsServer):
             sess.fallback_sent = False
             sess.first_data_seen = False
             sess.compat_lock = threading.RLock()
-            sess.ingress_by_packet = {}
         return sess
 
     def _reset_session_state(self, sess, profile):
@@ -149,7 +150,6 @@ class AutoUdpfsServer(UdpfsServer):
         sess.response_socket = SOCKET_DATA
         sess.fallback_sent = False
         sess.first_data_seen = False
-        sess.ingress_by_packet.clear()
 
     def _get_or_create_session(self, addr):
         return self._init_compat(super()._get_or_create_session(addr))
@@ -296,12 +296,13 @@ class AutoUdpfsServer(UdpfsServer):
         if payload_size > len(data) - 6:
             return
         sess = self._get_or_create_session(addr)
-        # ACK/NACK packets are consumed directly by the base transfer waiters and
-        # never reach _handle_data, so only payload packets need ingress metadata.
-        if payload_size:
-            with sess.compat_lock:
-                sess.ingress_by_packet[id(data)] = ingress
-        sess.queue.put((data, addr))
+        # Carried in the queued item, not in a side map keyed on id(data).
+        # That map was correct only while the packet object stayed alive, and
+        # any path that skipped its pop -- an early return in _handle_data --
+        # left an entry that a later object could match by reusing the id, so a
+        # reply would go out of the wrong socket. ACK/NACK packets never reach
+        # _handle_data at all, so the value is simply unused for them.
+        sess.queue.put((data, addr, ingress))
 
     def _handle_data(self, data: bytes, addr):
         sess = self._local.session
@@ -310,7 +311,7 @@ class AutoUdpfsServer(UdpfsServer):
         except (struct.error, ValueError):
             return
         with sess.compat_lock:
-            ingress = sess.ingress_by_packet.pop(id(data), SOCKET_DATA)
+            ingress = sess.ingress or SOCKET_DATA
             if sess.protocol_profile == PROFILE_PENDING:
                 profile = classify_profile(sess.discovery_sequence, hdr.seq_nr)
                 sess.protocol_profile = profile
@@ -426,6 +427,10 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Ceiling on one READ, one BREAD and one assembled "
                              f"write (default {DEFAULT_MAX_TRANSFER_BYTES}, floor "
                              f"{MIN_MAX_TRANSFER_BYTES}; env: MAX_TRANSFER_BYTES)")
+    parser.add_argument("--max-sessions", type=int, default=_env_max_sessions(),
+                        help="Maximum concurrent peers; past this the least "
+                             "recently active is dropped (default "
+                             f"{DEFAULT_MAX_SESSIONS}; env: MAX_SESSIONS)")
     return parser
 
 
@@ -494,6 +499,7 @@ def main():
         data_port=data_port,
         tx_delay_ms=args.tx_delay_ms,
         max_transfer_bytes=args.max_transfer_bytes,
+        max_sessions=args.max_sessions,
         protocol_mode=args.protocol_mode,
         fallback_interval=args.compat_fallback,
     )

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -235,6 +235,21 @@ SESSION_TIMEOUT = 3600.0         # default seconds of peer inactivity before rea
 SESSION_TIMEOUT_MIN = 60.0
 SESSION_TIMEOUT_MAX = 86400.0
 SESSION_SWEEP_INTERVAL = 5.0     # how often the demux loop checks for idle sessions
+# Ceiling on concurrent peers. A session is a worker thread, a queue and up to
+# MAX_HANDLES descriptors, and any unauthenticated datagram creates one, so
+# without a cap a single host walking its source port can allocate without
+# bound and hold it for --peer-timeout (an hour by default).
+#
+# 256 is far above any real deployment -- the count here is consoles on a LAN,
+# and the largest plausible number is single digits -- while staying small
+# enough that the worst case is survivable on the low-memory boards this also
+# runs on. Configurable with --max-sessions for anyone who disagrees.
+DEFAULT_MAX_SESSIONS = 256
+# Floor of 1: a cap of zero would refuse the first console to say hello, which
+# is a server that is running and useless.
+MIN_MAX_SESSIONS = 1
+# Seconds between eviction log lines. At the cap this path runs per packet.
+SESSION_EVICT_LOG_INTERVAL = 60.0
 HAS_PREAD = hasattr(os, 'pread')     # POSIX: lock-free positional block-device reads
 HAS_PWRITE = hasattr(os, 'pwrite')
 
@@ -295,6 +310,19 @@ def _clamp_max_transfer(value):
     if value <= 0:
         return DEFAULT_MAX_TRANSFER_BYTES
     return max(MIN_MAX_TRANSFER_BYTES, value)
+
+
+def _clamp_max_sessions(value):
+    """Bound --max-sessions. Never raises, like the other clamps here."""
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_SESSIONS
+    return max(MIN_MAX_SESSIONS, value)
+
+
+def _env_max_sessions():
+    return _clamp_max_sessions(os.environ.get('MAX_SESSIONS'))
 
 
 def _env_max_transfer():
@@ -548,7 +576,8 @@ class UdpfsServer:
                  modulo_compat: bool = False,
                  data_port: int = 0,
                  tx_delay_ms: float = 0.0,
-                 max_transfer_bytes: int = DEFAULT_MAX_TRANSFER_BYTES):
+                 max_transfer_bytes: int = DEFAULT_MAX_TRANSFER_BYTES,
+                 max_sessions: int = DEFAULT_MAX_SESSIONS):
         # Modulo's client only ever talked to Modulo's own bundled server, which is
         # single-socket, so the two always travel together.
         if modulo_compat:
@@ -569,6 +598,9 @@ class UdpfsServer:
         # other out-of-range value.
         self.session_timeout = _clamp_peer_timeout(peer_timeout)
         self.max_transfer_bytes = _clamp_max_transfer(max_transfer_bytes)
+        self.max_sessions = _clamp_max_sessions(max_sessions)
+        self._sessions_evicted = 0
+        self._last_evict_log = 0.0
         self.metrics = metrics
         self.metrics_period = metrics_period
         self.single_port = single_port
@@ -753,10 +785,53 @@ class UdpfsServer:
             return n
 
     # -- session lifecycle -------------------------------------------------
+    def _evict_oldest_session_locked(self):
+        """Drop the least recently active peer. Caller holds sessions_lock.
+
+        Least-recently-active rather than oldest-created: a console that has
+        been streaming for an hour must outlive one that said hello and went
+        quiet, and creation order says nothing about which is which.
+        """
+        victim = min(self.sessions.items(), key=lambda kv: kv[1].last_activity)
+        addr, sess = victim
+        self.sessions.pop(addr, None)
+        sess.shutdown()
+        return addr
+
     def _get_or_create_session(self, addr):
         with self.sessions_lock:
             sess = self.sessions.get(addr)
             if sess is None:
+                # Bounded. A session is a thread, a queue and up to MAX_HANDLES
+                # descriptors, and it is created by an unauthenticated datagram
+                # -- one DISCOVERY per source port, held for --peer-timeout,
+                # an hour by default. Nothing stopped a single host walking its
+                # source port from making thousands, which on the low-memory
+                # boards this also runs on is the whole machine.
+                #
+                # Evicting rather than refusing: a real console whose port
+                # shifted (which happens, and which the UDPBD server has
+                # explicit handling for) must still be able to get in. The
+                # least recently active peer is the one least likely to be mid
+                # game.
+                if len(self.sessions) >= self.max_sessions:
+                    dropped = self._evict_oldest_session_locked()
+                    # Not verbose-gated, and rate-limited to one line a minute.
+                    # At the cap this fires per packet from a new peer, which
+                    # would bury every other line in the log -- but silence
+                    # here means a console that mysteriously stops working with
+                    # nothing to explain it.
+                    now = time.monotonic()
+                    self._sessions_evicted += 1
+                    if now - self._last_evict_log >= SESSION_EVICT_LOG_INTERVAL:
+                        self._last_evict_log = now
+                        self._print_event(
+                            f"[{addr[0]}:{addr[1]}] session limit "
+                            f"{self.max_sessions} reached -- dropped "
+                            f"{dropped[0]}:{dropped[1]}, its open files closed "
+                            f"({self._sessions_evicted} evicted so far; raise "
+                            "--max-sessions, or lower --peer-timeout so idle "
+                            "peers are reaped sooner)")
                 sess = Session(self, addr)
                 self.sessions[addr] = sess
                 sess.start()
@@ -770,7 +845,13 @@ class UdpfsServer:
         hdr = Header.unpack(data)
         if hdr.packet_type != PacketType.DATA:
             return
-        self._get_or_create_session(addr).queue.put((data, addr))
+        # Three elements, always. The third is which local socket the datagram
+        # arrived on, which only ps2servers_core reads -- but the shape is fixed
+        # here so every consumer can unpack the same way. It used to be threaded
+        # through a side map keyed on id(data), which is only safe for as long as
+        # the object stays alive and silently returns another packet's value once
+        # an id is reused.
+        self._get_or_create_session(addr).queue.put((data, addr, None))
 
     def _sweep_idle_sessions(self):
         now = time.monotonic()
@@ -2253,7 +2334,7 @@ class UdpfsServer:
             # messages exist to save.
             if item is None:
                 return  # session shutting down
-            pkt, _recv_addr = item
+            pkt, _recv_addr, _ingress = item
             if len(pkt) < 6:
                 continue
             hdr = Header.unpack(pkt)
@@ -2293,7 +2374,7 @@ class UdpfsServer:
             # Before unpacking, as in _wait_for_window_ack above.
             if item is None:
                 return False  # session shutting down
-            pkt, _recv_addr = item
+            pkt, _recv_addr, _ingress = item
             if len(pkt) < 6:
                 continue
             hdr = Header.unpack(pkt)
@@ -2574,6 +2655,11 @@ class Session:
         # it: its client keeps a background DISCOVERY going while it streams, and
         # a live stream must not be resynced out from under itself.
         self.rx_streaming = False
+        # Which local socket the datagram currently being handled arrived on.
+        # Set by _run immediately before dispatch and read by
+        # ps2servers_core._handle_data. Safe as plain state because exactly one
+        # worker thread ever runs a handler for this session.
+        self.ingress = None
         # concurrency plumbing
         self.queue: "queue.Queue" = queue.Queue()
         self.last_activity = time.monotonic()
@@ -2599,14 +2685,29 @@ class Session:
                 continue
             if item is None:
                 break
-            data, addr = item
+            # Inside the try, not before it. An unpack out here is not covered
+            # by the handler's except, so a queued item of the wrong shape kills
+            # this worker thread outright: the session then still exists, still
+            # holds its handles, and never serves another packet, while the only
+            # trace is a thread traceback on stderr. That is a programming
+            # error rather than a network condition, so it is loud -- but it is
+            # loud through the same channel as everything else, and the session
+            # survives it.
             try:
+                data, addr, ingress = item
+                self.ingress = ingress
                 self.server._handle_data(data, addr)
             except Exception as e:  # keep the session alive on a handler error
                 # Always surface handler errors -- silent swallowing makes
                 # multi-client issues very hard to debug.
+                #
+                # self.addr, not the unpacked addr: if the unpack itself is what
+                # failed, that name is unbound and formatting the message would
+                # raise a NameError out of the except, killing the thread the
+                # handler was written to keep alive.
                 self.server._print_event(
-                    f"[{addr[0]}:{addr[1]}] session error: {type(e).__name__}: {e}")
+                    f"[{self.addr[0]}:{self.addr[1]}] session error: "
+                    f"{type(e).__name__}: {e}")
         # Close this session's own file handles (never the shared block device).
         for hid, fh in list(self.handles.items()):
             if hid == BLOCK_DEVICE_HANDLE:
@@ -2876,6 +2977,12 @@ def main():
              f'{MIN_MAX_TRANSFER_BYTES}; env: MAX_TRANSFER_BYTES)'
     )
 
+    parser.add_argument(
+        '--max-sessions', type=int, default=_env_max_sessions(),
+        help='Maximum concurrent peers. Past this the least recently active is '
+             f'dropped (default: {DEFAULT_MAX_SESSIONS}; env: MAX_SESSIONS)'
+    )
+
     args = parser.parse_args()
 
     # Compression: default on; CLI beats env; an explicit disable beats an enable.
@@ -2942,7 +3049,8 @@ def main():
         single_port=args.single_port,
         modulo_compat=args.modulo_mode,
         data_port=args.data_port,
-        max_transfer_bytes=args.max_transfer_bytes
+        max_transfer_bytes=args.max_transfer_bytes,
+        max_sessions=args.max_sessions
     )
     server.run()
 


### PR DESCRIPTION
Closes the last five items in `AUDIT-2026-08-09.md`. Everything in that document
is now addressed; what remains open is not code, it is that **none of it has run
on a real PlayStation 2**.

## The five

**C6 — no session cap.** A session is a thread, a queue and up to `MAX_HANDLES`
descriptors, created by any unauthenticated datagram and keyed on `(ip, port)`.
One host walking its source port could allocate without bound and hold each for
`--peer-timeout` — an hour by default. `--max-sessions` bounds it (256, floor 1).

Past the cap the **least recently active** peer is evicted rather than the new
one refused: a console whose source port shifts has to be able to get back in,
which is a case the UDPBD server already handles explicitly. The notice names
the flag and is rate-limited to one a minute, because at the cap that path runs
once per packet.

**C3 — the OpenWrt privilege model.** This was a half-measure: the web UI ran as
`ps2edge` and the init chowned the config file to it, which widened permissions
on a file in `/etc/config` for a network-facing service *and* still could not
commit, because `uci`'s rename needs the directory. `webui.run_as_root` now
makes it an explicit choice, default `0` — dashboard read-only, Save/Restart
report a permission error. Set `1` and they work, at the cost of a
network-facing server running as root. The password also moves out of argv into
`WEBUI_PASS`, since a command line is world-readable in `/proc`.

**C1 — the Logs tab.** It could only ever show the web UI's own output, because
the servers are separate processes. `ServiceManager.ServiceLogs` now reads
`logread` on OpenWrt and `journalctl` on systemd, and says so plainly on a host
that is neither. A snapshot rather than a follow: tailing means a child process
per open browser tab, which on a 32 MB router has no ceiling. Lines are
sanitised before entering the stream — SSE is line-framed and these carry
filenames.

**D14 — `id()`-keyed side map.** Queued items are now `(data, addr, ingress)`.
The map was correct only while the packet object stayed alive; any handler path
that skipped its `pop` left an entry a later object could match by reusing the
id, sending a reply out of the wrong socket.

**D15 — unverified bundler hints.** `tests/test_frozen_imports.py` imports every
registered server for real and diffs `sys.modules` against `serve.py`'s hint
list, so the list follows the code rather than somebody's memory. It also guards
the block against a "remove unused imports" tidy-up, which would break packaged
builds.

## Two things this uncovered

**`Session._run` unpacked its queue item outside the handler's `try`.** A
malformed item killed the worker thread; the session then still existed and
still held its handles while serving nothing, with only a thread traceback on
stderr — not where this server's diagnostics go.

**The OpenWrt init script only parses because git normalises line endings.**
`dash -n` rejects a CRLF copy — ash reads `do\r`, not `do` — and there was no
`.gitattributes`, so the answer depended on each contributor's `core.autocrlf`.
Added, covering the files something executes, with `tests/test_line_endings.py`
checking the **committed blob** and feeding it to a real shell. The existing
shell check skips on Windows, which is exactly where the CRLF comes from.

## Verification

- **515 Python tests** (was 499), Go race- and vet-clean, gofmt clean,
  compliance green, 3.14 compiles clean.
- Every fix mutation-tested where testable: removing the session cap turns three
  tests red; removing the symlink resolution, the env parsing, the `realpath`,
  or a `serve.py` hint each turns its own test red.
- One test I wrote was itself wrong and the full-suite run caught it —
  `time.monotonic()` has ~15 ms resolution on Windows, so a 10 ms sleep left
  every session with the same timestamp and the eviction assertion passed or
  failed on dict ordering. It sets timestamps outright now.

## Not done, deliberately

Per-instance restart on OpenWrt still restarts everything, and the API reports
that rather than implying otherwise. Doing it properly means `ubus` calls that
have never run on a real router, and a restart button that silently does nothing
is worse than one that does too much.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Web UI logs now include bounded service-log snapshots alongside live dashboard logs.
  - Added configurable maximum concurrent sessions with least-recently-active eviction.
  - Added optional Web UI root execution for configuration saves and service restarts; read-only behavior remains the default.
  - Web UI now supports password authentication and defaults to loopback access.

- **Bug Fixes**
  - Improved log safety, session-worker resilience, and handling of malformed session data.
  - Standardized text and binary file handling across platforms.

- **Documentation**
  - Expanded OpenWrt and Web UI guidance for logs, permissions, authentication, and security settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->