### PR TITLE
Release v0.5.1: the completed audit work

### DIFF
--- a/.github/release-notes-common.md
+++ b/.github/release-notes-common.md
@@ -72,6 +72,12 @@ instance, so a board can serve UDPFS and SMB at once. There are systemd units
 for the same thing on ordinary Linux, where `systemctl restart
 ps2servers-edge@smb` does restart just that one.
 
+On OpenWrt the dashboard's **Save and Restart need root** — `uci commit` rewrites
+a file in `/etc/config` and restarting goes through `/etc/init.d` — so they are
+off by default and report a permission error. Status, configuration and file
+browsing all work regardless. Set `option run_as_root '1'` to enable them, which
+runs the dashboard as root; that is a real trade, which is why it is a choice.
+
 > **Edge has not been verified on a physical PlayStation 2 or an emulator.** Its
 > wire behaviour is checked in CI against the hardware-validated Python servers,
 > including a byte-for-byte comparison for UDPBD, which is the strongest evidence

--- a/PICKUP-FROM-HERE.md
+++ b/PICKUP-FROM-HERE.md
@@ -24,21 +24,37 @@ source of truth**, not whatever a worktree has checked out.
 > the "Older state" subsection below it, and every section after it, are from the
 > 2026-07-29 session and are kept for their reasoning, not their numbers.
 
-- **Version is `0.5.0`** in `launcher/release_metadata.py`, bumped for the
-  release. That file is the single source; `tools/version_source.py` reads it and
-  `release.yml` refuses a tag that disagrees.
+- **Version is `0.5.1`** in `launcher/release_metadata.py` — the single source;
+  `tools/version_source.py` reads it and `release.yml` refuses a tag that
+  disagrees. Both v0.5.0 and v0.5.1 were cut on 2026-08-09.
 - **v0.5.0 is the release that introduces PS2 Servers Edge.** Everything from
   #119 onward landed after the v0.4.9 tag: 43 PRs, ~30k lines, Edge in Go across
-  11 targets serving UDPFS/UDPBD/SMB plus a web dashboard, the SMB2/SMB3 server,
+  12 targets serving UDPFS/UDPBD/SMB plus a web dashboard, the SMB2/SMB3 server,
   the router status protocol, and systemd + OpenWrt packaging.
-- Full suite green: **492 Python tests**, Go race- and vet-clean, gofmt gated.
-- Edge mipsle binary: **7.19 MiB** (was 3.31 MiB before the web GUI). CI now
-  fails the build above 9 MiB per target — see the comment in `edge-build.yml`
-  before raising it.
-- An audit ran 2026-08-09; findings and their status are in
-  `AUDIT-2026-08-09.md`. Still open from it: no session cap in the Python UDPFS
-  server, the OpenWrt web-UI privilege model, and reading real per-service logs
-  in the dashboard.
+- **v0.5.1 carries the completed audit work**: the UDPFS session cap
+  (`--max-sessions`), the OpenWrt web-UI privilege model (`webui.run_as_root`,
+  default off), real per-service logs in the dashboard, and `.gitattributes`.
+- Full suite green: **515 Python tests**, Go race- and vet-clean, gofmt gated,
+  and CI now runs the *whole* suite — it ran 1 of 26 modules until v0.5.0.
+- Edge mipsle binary: **6.19 MiB in CI** (was 3.31 MiB before the web GUI; a
+  local Go 1.26 build is ~1 MiB larger). CI fails above 9 MiB per target — read
+  the comment in `edge-build.yml` before raising it.
+- **`AUDIT-2026-08-09.md` is fully closed.** Every finding has a status; nothing
+  is outstanding in it. Read it before re-deriving anything about the web UI,
+  the packaging, or the transfer limits.
+
+### How a release is cut here
+
+1. Bump `PRODUCT_VERSION` in `launcher/release_metadata.py`, alone, in a commit
+   named `Release vX.Y.Z`. Make it the **last** commit on the branch.
+2. Open a PR and let CI go green.
+3. **Rebase-merge** (not squash) so that commit survives on `main` and the tag
+   shows only the bump, as every past release tag does.
+4. `git tag -a vX.Y.Z <bump-commit> -m "PS2 Servers vX.Y.Z"` and push the tag.
+   That is the entire publish step; `release.yml` and `edge.yml` do the rest.
+
+`.github/release-notes-common.md` is appended to every published release. If a
+capability changes, it changes in the same PR — it has gone stale twice.
 
 ### Older state (2026-07-29, stale)
 

--- a/launcher/release_metadata.py
+++ b/launcher/release_metadata.py
@@ -10,7 +10,7 @@ PRODUCT_NAME = APP_NAME
 # reject anything that is not a dotted number. A pre-release qualifier like
 # "-rc1" lives in VERSION_QUALIFIER instead and is shown to the user via
 # DISPLAY_VERSION, never handed to the build.
-PRODUCT_VERSION = "0.5.0"
+PRODUCT_VERSION = "0.5.1"
 FILE_VERSION = PRODUCT_VERSION
 # "" for a normal release; "-rc1" / "-beta1" while a version is under test.
 VERSION_QUALIFIER = ""

--- a/tests/test_session_cap.py
+++ b/tests/test_session_cap.py
@@ -40,7 +40,7 @@ class _Server(srv.UdpfsServer):
         self.sessions_lock = threading.Lock()
         self.max_sessions = srv._clamp_max_sessions(max_sessions)
         self._sessions_evicted = 0
-        self._last_evict_log = 0.0
+        self._last_evict_log = None
         self.events = []
         self.started = []
         self.stopped = []
@@ -122,6 +122,25 @@ class TheSessionTableIsBounded(unittest.TestCase):
         self.assertEqual(server.stopped, [],
                          "traffic from known peers caused an eviction")
         self.assertEqual(len(server.sessions), 2)
+
+    def test_the_first_eviction_is_reported_on_a_freshly_booted_machine(self):
+        """time.monotonic() is time since boot, so the sentinel cannot be 0.0.
+
+        With `_last_evict_log = 0.0`, `now - 0.0 >= 60` is false for the first
+        minute of uptime and the first notice is swallowed -- which is exactly
+        the router that boots and is immediately flooded. CI runners are
+        seconds old, which is how this surfaced.
+        """
+        server = _Server(max_sessions=2)
+        self.assertIsNone(server._last_evict_log,
+                          "the sentinel must mean 'never logged', not 'logged "
+                          "at monotonic time zero'")
+        for i in range(10):
+            server._get_or_create_session(_peer(i))
+        self.assertTrue(
+            [e for e in server.events if "session limit" in e],
+            "the first eviction said nothing; on a machine up for less than "
+            "the rate-limit interval the notice must still appear")
 
     def test_the_eviction_is_reported_but_not_once_per_packet(self):
         server = _Server(max_sessions=2)

--- a/udpfs_server/udpfs_server.py
+++ b/udpfs_server/udpfs_server.py
@@ -600,7 +600,12 @@ class UdpfsServer:
         self.max_transfer_bytes = _clamp_max_transfer(max_transfer_bytes)
         self.max_sessions = _clamp_max_sessions(max_sessions)
         self._sessions_evicted = 0
-        self._last_evict_log = 0.0
+        # None, not 0.0. time.monotonic() is time since boot on Linux, so on a
+        # machine that has been up less than SESSION_EVICT_LOG_INTERVAL the
+        # comparison against 0.0 suppresses the FIRST notice -- exactly the
+        # case of a router that boots and is immediately flooded, which is when
+        # the line matters most. Caught by CI, whose runners are seconds old.
+        self._last_evict_log = None
         self.metrics = metrics
         self.metrics_period = metrics_period
         self.single_port = single_port
@@ -823,7 +828,8 @@ class UdpfsServer:
                     # nothing to explain it.
                     now = time.monotonic()
                     self._sessions_evicted += 1
-                    if now - self._last_evict_log >= SESSION_EVICT_LOG_INTERVAL:
+                    if (self._last_evict_log is None
+                            or now - self._last_evict_log >= SESSION_EVICT_LOG_INTERVAL):
                         self._last_evict_log = now
                         self._print_event(
                             f"[{addr[0]}:{addr[1]}] session limit "


### PR DESCRIPTION
Cuts **v0.5.1**, carrying the audit work that landed after v0.5.0 shipped.

v0.5.1 rather than re-cutting v0.5.0: two of these are behaviour changes rather
than pure fixes, so a user who reads "v0.5.0" should get the same software
either way, and the checksums already published for v0.5.0 stay meaningful.

## What's new since v0.5.0

**A session cap for the Python UDPFS server** (`--max-sessions`, default 256).
A session is a thread, a queue and up to `MAX_HANDLES` descriptors, created by
any unauthenticated datagram and keyed on `(ip, port)` — so one host walking its
source port could allocate without bound and hold each for `--peer-timeout`, an
hour by default. Past the cap the *least recently active* peer is evicted rather
than the new one refused, because a console whose source port shifts has to be
able to get back in.

**The OpenWrt web dashboard's privilege model is now a choice.** Save and
Restart need root — `uci commit` rewrites a file in `/etc/config`, restarting
goes through `/etc/init.d` — so they are off by default and report a permission
error, while status, configuration and browsing keep working.
`webui.run_as_root '1'` enables them at the cost of running the dashboard as
root. The previous arrangement chowned the config file to the service user,
which widened permissions *and* still could not commit, because the rename needs
the directory.

**Real per-service logs in the dashboard.** It could only ever show its own
output, because the servers are separate processes. It now reads `logread` on
OpenWrt and `journalctl` on systemd, and says so plainly where neither exists.

**Two defects found while doing the above**, both pre-existing:

- `Session._run` unpacked its queue item *outside* the handler's `try`, so a
  malformed item killed the worker thread — leaving a session that still held
  its handles and served nothing, with only a thread traceback on stderr.
- The OpenWrt init script only parses because git normalises line endings.
  `dash -n` rejects a CRLF copy (ash reads `do\r`, not `do`), and there was no
  `.gitattributes`, so the answer depended on each contributor's
  `core.autocrlf`.

Plus `actions/attest` 4.2.0 → 4.2.2 (#168), verified against upstream: the new
SHA is exactly what `refs/tags/v4.2.2` points at, all 8 pinned occurrences were
replaced with none stranded, and the action's inputs are unchanged.

## Release mechanics

- `launcher/release_metadata.py` → `0.5.1` in its own `Release v0.5.1` commit,
  touching only that file and placed last, so `git show v0.5.1` shows the bump.
- **Rebase-merge, not squash**, so that commit survives on `main`.
- `.github/release-notes-common.md` updated for the OpenWrt dashboard change —
  it is appended to every published release and had to say that Save and Restart
  are off by default.

## Verification

- **515 Python tests**, Go race- and vet-clean, gofmt clean, 3.14 compiles clean.
- `tools/version_source.py --check-tag v0.5.1` passes; `v0.5.0` is now correctly
  refused.
- `tools/check_release_compliance.py` passes, and the disclosures still survive
  the comment-stripping `sed` (checked by rendering, not by reading it).
- Edge binary reports `ps2servers-edge 0.5.1`.

## Known limits

Still **not validated on real PS2 hardware**. The OpenWrt privilege model in
particular is a decision made without a router to test it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
