### PR TITLE
feat(launcher): reset settings, updates link, dark theme, UX polish

### DIFF
--- a/.github/release-notes-common.md
+++ b/.github/release-notes-common.md
@@ -89,7 +89,7 @@ runs the dashboard as root; that is a real trade, which is why it is a choice.
 PS2 Servers is an open-source PS2 homebrew utility for user-controlled local
 server setup. It runs local LAN servers for Open PS2 Loader:
 
-- **SMBv1/RiptOPL** — built-in SMB/CIFS subset, normally TCP port `1111`
+- **SMBv1** — built-in SMB/CIFS subset, normally TCP port `1111`
   (below 1033 discouraged).
 - **SMB2/SMB3** — a separate, newer server for clients that speak them,
   off by default and with NTLMv2 authentication when credentials are set.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -17,11 +17,11 @@ from Rick Gaiser's Neutrino project, which is licensed under AFL-3.0.
 The following parts are original to this repository unless otherwise noted:
 
 - the Tkinter GUI launcher and tray/Windows setup glue;
-- the RiptOPL SMBv1/CIFS server implementation in `smbv1_server/`;
+- the SMBv1/CIFS server implementation in `smbv1_server/`;
 - the pure-Python UDPBD server in `udpbd_server/udpbd_server.py`;
 - release/build workflow glue and project documentation.
 
-The RiptOPL SMBv1 server was authored from public protocol documentation and
+The SMBv1 server was authored from public protocol documentation and
 Open PS2 Loader protocol/header behavior. No third-party SMB server source code
 was copied into that implementation.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # PS2-Servers
 
-Standard PS2 network servers — **SMBv1 (RiptOPL)**, **UDPFS**, and **UDPBD** — for
+Standard PS2 network servers — **SMBv1**, **UDPFS**, and **UDPBD** — for
 loading PlayStation 2 games, apps, and media over a LAN. These are the protocols
 PS2 homebrew uses to load over a network, so they are not OPL-only. Loaders
 confirmed working include [Open PS2 Loader](https://github.com/ps2homebrew/Open-PS2-Loader)
@@ -49,7 +49,7 @@ PS2 Servers is an unsigned open-source network tool. Because it runs local serve
 processes and may ask Windows Firewall to allow inbound LAN traffic, some
 antivirus products may flag the packaged Windows EXE heuristically.
 
-The SMBv1/RiptOPL server does **not** enable Windows' built-in SMB1 optional
+The SMBv1 server does **not** enable Windows' built-in SMB1 optional
 feature tree. It speaks the OPL-compatible SMB1/CIFS subset itself and normally
 listens on custom TCP port `1111`; OPL connects to this program directly. (Avoid
 ports below 1033 — Windows can reserve or block low ports.)
@@ -87,7 +87,7 @@ All three servers are pure-Python (standard library) and run on Windows, Linux a
 
 | Folder | Server | What it does |
 |--------|--------|--------------|
-| [`smbv1_server/`](smbv1_server/) | **SMBv1 (RiptOPL)** | Shares a games folder over SMB — works even on Windows 11 where the OS removed SMB1. |
+| [`smbv1_server/`](smbv1_server/) | **SMBv1** | Shares a games folder over SMB — works even on Windows 11 where the OS removed SMB1. |
 | [`udpfs_server/`](udpfs_server/) | **UDPFS** | Serves a folder and/or disk image over UDP; can transparently decompress CHD/CSO/ZSO. |
 | [`udpbd_server/`](udpbd_server/) | **UDPBD** | Serves a disk image as a block device over UDP; the PS2 auto-discovers it. |
 
@@ -384,7 +384,7 @@ work in something click‑and‑go. With genuine gratitude:
 
 ### What's original here
 
-The **GUI launcher**, the **RiptOPL** SMBv1 server, and the **pure‑Python UDPBD port**
+The **GUI launcher**, the **SMBv1** server, and the **pure‑Python UDPBD port**
 were written for this repo. Everything at the protocol level is the community's —
 we reimplemented from public protocols/source (rather than copying code) where we
 could, and tried to attribute accurately.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,7 +38,7 @@ risk and makes antivirus heuristics more suspicious.
 
 ## Windows SMB behavior
 
-The SMBv1/RiptOPL server does **not** enable or depend on Windows' built-in SMB1
+The SMBv1 server does **not** enable or depend on Windows' built-in SMB1
 optional feature tree.
 
 Normal SMB mode uses PS2 Servers' own small SMB/CIFS implementation and listens

--- a/docs/antivirus-transparency.md
+++ b/docs/antivirus-transparency.md
@@ -85,7 +85,11 @@ The Windows SMB server uses PS2 Servers' own SMB/CIFS implementation. It does no
   created by the app use the prefix `PS2 Servers - ...` and can be removed from
   the GUI or with the command below. The firewall logic runs as inline
   PowerShell (`-Command`, not a `.ps1` script file) and does **not** pass
-  `-ExecutionPolicy Bypass`.
+  `-ExecutionPolicy Bypass`. The one exception is the standalone
+  `smbv1_server/Start-SMB-Server.bat`: it creates its single
+  `PS2 Servers - SMB Server` rule through an elevated inline PowerShell that
+  **does** pass `-ExecutionPolicy Bypass` (the batch file cannot otherwise run
+  PowerShell on machines with a restrictive policy).
 - **Windows file-sharing service:** the optional, off-by-default "Take port 445"
   SMB mode temporarily **stops** the Windows `LanmanServer` service while that
   server runs and **restarts it on exit**. It only stops the service (never

--- a/docs/antivirus-transparency.md
+++ b/docs/antivirus-transparency.md
@@ -67,7 +67,7 @@ published per platform for convenience. macOS already ships as a standalone
 PS2 Servers only exposes local server behavior that the user chooses from the
 GUI:
 
-- SMBv1/RiptOPL: built-in SMB/CIFS subset, normally TCP port 1111. (Ports below 1033 are discouraged — Windows can reserve or block low ports.)
+- SMBv1: built-in SMB/CIFS subset, normally TCP port 1111. (Ports below 1033 are discouraged — Windows can reserve or block low ports.)
 - UDPFS: UDP file/block serving, normally UDP port 0xF5F6 for discovery. Each console is then served on a second UDP port, which the OS assigns on startup unless the user pins it ("Data port"); single-port and Modulo modes serve everything on the discovery port instead. All of it is inbound LAN serving — the server never initiates a connection.
 - UDPBD: UDP block-device serving, normally UDP port 0xBDBD.
 

--- a/docs/falsepositives.html
+++ b/docs/falsepositives.html
@@ -454,7 +454,7 @@
       <div class="hero-card">
         <div class="card pad">
           <p>
-            <strong>PS2 Servers</strong> is an open-source PlayStation 2 homebrew utility. Its purpose is to let Open PS2 Loader and compatible forks load files from a PC using local-network server modes such as SMBv1/RiptOPL, UDPFS, and UDPBD.
+            <strong>PS2 Servers</strong> is an open-source PlayStation 2 homebrew utility. Its purpose is to let Open PS2 Loader and compatible forks load files from a PC using local-network server modes such as SMBv1, UDPFS, and UDPBD.
           </p>
           <div class="button-row">
             <a class="button primary" href="https://github.com/NathanNeurotic/PS2-Servers">View source repository</a>
@@ -514,7 +514,7 @@
       </p>
 
       <ul class="checks">
-        <li><strong>SMBv1/RiptOPL:</strong> local SMB/CIFS-compatible server, normally TCP 1111 (ports below 1033 discouraged).</li>
+        <li><strong>SMBv1:</strong> local SMB/CIFS-compatible server, normally TCP 1111 (ports below 1033 discouraged).</li>
         <li><strong>UDPFS:</strong> local UDP file/block serving, normally UDP 0xF5F6.</li>
         <li><strong>UDPBD:</strong> local UDP block-device serving, normally UDP 0xBDBD.</li>
         <li><strong>Firewall helper:</strong> optional Windows Firewall allow rules after user action.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
         <p class="section-intro">PS2 Servers packages the useful host-side network servers into a single launcher that shows your LAN IP, collects the right folder or image path, and prints the exact values you need to enter in Open PS2 Loader.</p>
         <div class="cards">
           <article class="card">
-            <h3>SMBv1 / RiptOPL</h3>
+            <h3>SMBv1</h3>
             <p>Shares a games folder over SMB. It speaks SMB itself, so it works on Windows 11 even though Windows removed its own SMB1 support — and it leaves your Windows file sharing untouched.</p>
             <p><code>OPL: port 1111 · share games</code></p>
           </article>
@@ -92,7 +92,7 @@
           <h3>What you enter on the PS2</h3>
           <div class="terminal">
             <div class="terminal-bar"><span></span><span></span><span></span></div>
-            <pre><b>SMBv1 / RiptOPL</b>   —   OPL &rarr; Settings &rarr; Network
+            <pre><b>SMBv1</b>   —   OPL &rarr; Settings &rarr; Network
 Address type      IP address      (turn NetBIOS off)
 PC IP Address     the LAN IP the launcher shows after you press Start
 Port              1111

--- a/launcher/config.py
+++ b/launcher/config.py
@@ -53,3 +53,12 @@ def save(data):
         except OSError:
             pass
         raise
+
+
+def reset():
+    """Delete the persisted settings file. A missing file is already 'reset',
+    so it is not an error."""
+    try:
+        os.remove(config_path())
+    except FileNotFoundError:
+        pass

--- a/launcher/full_skin_controls.py
+++ b/launcher/full_skin_controls.py
@@ -139,9 +139,9 @@ def install(app, gui):
         card = app_obj.cards.get(key)
         if not card:
             return
-        app_obj._save()
+        saved = app_obj._save()
         flash = getattr(card, "_saved_flash", None)
-        if flash is not None:
+        if saved and flash is not None:
             app_obj._flash_label(flash, "Saved ✓")
         card.refresh_status(app_obj.is_running(key))
         label = gui.TAB_TITLES.get(key, key.upper())
@@ -180,11 +180,11 @@ def install(app, gui):
         app_obj.start_server(key)
 
     def revert_server_defaults(app_obj, key):
-        app_obj._save()
+        saved = app_obj._save()
         card = app_obj.cards.get(key)
         if card:
             flash = getattr(card, "_saved_flash", None)
-            if flash is not None:
+            if saved and flash is not None:
                 app_obj._flash_label(flash, "Defaults restored ✓")
             card.refresh_status(app_obj.is_running(key))
         label = gui.TAB_TITLES.get(key, key.upper())

--- a/launcher/full_skin_controls.py
+++ b/launcher/full_skin_controls.py
@@ -59,18 +59,24 @@ def install(app, gui):
             font=("", 9, "bold"),
         ).grid(row=0, column=0, sticky="w", pady=(6, 0))
 
+        # Transient "Saved ✓" / "Defaults restored ✓" next to the buttons that
+        # caused it: an Apply that only logs a line reads as "nothing happened".
+        flash = gui.ttk.Label(actions, text="", style="PageActions.TLabel")
+        flash.grid(row=0, column=1, sticky="e", padx=(8, 0), pady=(6, 0))
+        card._saved_flash = flash
+
         gui.ttk.Button(
             actions,
             text="Revert to Default",
             command=lambda c=card: c.revert_to_defaults(),
-        ).grid(row=0, column=1, sticky="e", padx=(8, 0), pady=(6, 0))
+        ).grid(row=0, column=2, sticky="e", padx=(8, 0), pady=(6, 0))
 
         gui.ttk.Button(
             actions,
             text="Apply",
             style="Accent.TButton",
             command=lambda c=card: c.apply_page_settings(),
-        ).grid(row=0, column=2, sticky="e", padx=(8, 0), pady=(6, 0))
+        ).grid(row=0, column=3, sticky="e", padx=(8, 0), pady=(6, 0))
 
     def build_with_page_actions(card):
         original_build(card)
@@ -134,6 +140,9 @@ def install(app, gui):
         if not card:
             return
         app_obj._save()
+        flash = getattr(card, "_saved_flash", None)
+        if flash is not None:
+            app_obj._flash_label(flash, "Saved ✓")
         card.refresh_status(app_obj.is_running(key))
         label = gui.TAB_TITLES.get(key, key.upper())
         app_obj._append_log("setup", "[settings] applied {} page settings\n".format(label))
@@ -174,6 +183,9 @@ def install(app, gui):
         app_obj._save()
         card = app_obj.cards.get(key)
         if card:
+            flash = getattr(card, "_saved_flash", None)
+            if flash is not None:
+                app_obj._flash_label(flash, "Defaults restored ✓")
             card.refresh_status(app_obj.is_running(key))
         label = gui.TAB_TITLES.get(key, key.upper())
         app_obj._append_log("setup", "[settings] reverted {} page to defaults\n".format(label))

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -127,7 +127,7 @@ PS2 Servers is a no-terminal launcher for PlayStation 2 network-loading servers.
 
 What it runs
 
-- SMBv1 / RiptOPL mode: runs PS2 Servers' own small OPL-compatible SMB/CIFS server. This is not Windows File Sharing and does not require Windows' built-in SMB1 optional feature tree.
+- SMBv1 mode: runs PS2 Servers' own small OPL-compatible SMB/CIFS server. This is not Windows File Sharing and does not require Windows' built-in SMB1 optional feature tree.
 - UDPFS mode: runs a UDPFS server for OPL's UDPFS device support.
 - UDPBD mode: runs a UDPBD block-device server for compatible clients.
 
@@ -462,6 +462,12 @@ class ServerCard(ttk.LabelFrame):
         else:
             self.adv_frame.grid_remove()
             self.adv_btn.config(text="Advanced ▸")
+        # The card just changed height; refresh the page scrollregion now rather
+        # than waiting out the 400 ms watcher, so the bottom is reachable
+        # immediately. Guarded: a bare card built in a test has no app.
+        refresh = getattr(getattr(self, "app", None), "_refresh_scroll_body", None)
+        if refresh is not None:
+            self.after_idle(refresh)
 
     def _browse(self, var, kind):
         path = (filedialog.askdirectory(parent=self) if kind == "folder"
@@ -570,6 +576,13 @@ class LauncherApp:
         self.out_queue = queue.Queue()
         self.logs = {}
         self.saved = config.load()
+        # Set by reset_settings once the config file is deleted: _save becomes a
+        # no-op so the shutdown path cannot resurrect the old settings.
+        self._config_reset = False
+        # Armed _flash_label timers, keyed by widget path, so _shutdown_app can
+        # disarm them: a flash that outlives the window fires into a dead
+        # interpreter and Tcl complains about it on the way out.
+        self._flash_jobs = {}
         self._firewall_ok = set()   # _restore fills it; never read before it exists
         self._direct_proc = None            # the DHCP helper child, when running
         self._direct_expected = False       # we started it and expect it alive
@@ -770,6 +783,29 @@ class LauncherApp:
 
         body.bind("<Configure>", refresh_scroll_region)
         canvas.bind("<Configure>", refresh_scroll_region)
+
+        # The body's height is pinned to max(content, view), so a content
+        # reqheight change -- Advanced opening, the OPL hint appearing on start,
+        # a label rewrapping -- fires no <Configure> on either widget above, and
+        # the scrollregion goes stale: the bottom of the page becomes impossible
+        # to scroll to (yview never reaches 1.0). Nothing else notices those
+        # changes, so poll cheaply and refresh when the number moves.
+        seen_reqheight = [None]
+
+        def watch_reqheight():
+            if getattr(self, "_shutting_down", False):
+                return
+            try:
+                req = body.winfo_reqheight()
+                if req != seen_reqheight[0]:
+                    seen_reqheight[0] = req
+                    refresh_scroll_region()
+                canvas.after(400, watch_reqheight)
+            except tk.TclError:
+                # The window is being destroyed; stop rescheduling.
+                return
+
+        canvas.after(400, watch_reqheight)
         self._scroll_shell = shell
         self._scroll_canvas = canvas
         self._scrollbar = scrollbar
@@ -868,6 +904,10 @@ class LauncherApp:
             row=0, column=2, sticky="w")
         ttk.Button(header, text="What's my IP?", command=self._show_whats_my_ip).grid(
             row=0, column=3, sticky="w", padx=(4, 0))
+        # Transient "Saved ✓" after a typed address commits -- the stretch
+        # column absorbs it, so showing it never moves the other controls.
+        self._ip_feedback = ttk.Label(header, text="", style="TopStripHint.TLabel")
+        self._ip_feedback.grid(row=0, column=4, sticky="w", padx=(8, 0))
         # Its own full-width row rather than a fifth column on the controls row:
         # four controls plus a paragraph cannot share one row at every window
         # width, and a row of its own reflows to any width without squeezing them.
@@ -1029,7 +1069,7 @@ class LauncherApp:
                    command=lambda: self._open_url(PROJECT_URL)).pack(side="left", padx=(6, 0), pady=6)
         ttk.Button(links, text="GitHub repo",
                    command=lambda: self._open_url(REPO_URL)).pack(side="left", padx=(6, 0), pady=6)
-        ttk.Button(links, text="Releases",
+        ttk.Button(links, text="Check for updates",
                    command=lambda: self._open_url(RELEASES_URL)).pack(side="left", padx=(6, 0), pady=6)
         ttk.Button(links, text="Security notes",
                    command=lambda: self._open_url(SECURITY_URL)).pack(side="left", padx=(6, 0), pady=6)
@@ -1043,24 +1083,26 @@ class LauncherApp:
         behavior.grid(row=row, column=0, sticky="ew", padx=8, pady=(8, 0))
         behavior.columnconfigure(3, weight=1)
         row += 1
+        # Kept for _save_with_feedback, which flashes "Saved" on the frame title.
+        self._options_frame = behavior
         b_col = 0
         b_row = 0
         if tray.AVAILABLE:
             close_to_tray = ttk.Checkbutton(
                 behavior, text="Close to tray", variable=self.close_to_tray_var,
-                command=self._save, style="Card.TCheckbutton")
+                command=self._save_with_feedback, style="Card.TCheckbutton")
             close_to_tray.grid(row=b_row, column=b_col, sticky="w", padx=(6, 12), pady=6)
             b_col += 1
             minimize_to_tray = ttk.Checkbutton(
                 behavior, text="Minimize to tray", variable=self.minimize_to_tray_var,
-                command=self._save, style="Card.TCheckbutton")
+                command=self._save_with_feedback, style="Card.TCheckbutton")
             minimize_to_tray.grid(row=b_row, column=b_col, sticky="w", padx=(0, 12), pady=6)
             b_col += 1
             self._tray_option_widgets.extend([close_to_tray, minimize_to_tray])
 
         autostart_chk = ttk.Checkbutton(
             behavior, text="Auto-start servers on launch", variable=self.autostart_var,
-            command=self._save, style="Card.TCheckbutton")
+            command=self._save_with_feedback, style="Card.TCheckbutton")
         autostart_chk.grid(row=b_row, column=b_col, sticky="w", padx=(6 if b_col == 0 else 0, 12), pady=6)
         b_col += 1
 
@@ -1070,8 +1112,20 @@ class LauncherApp:
                 b_col = 0
             ignore_fw_chk = ttk.Checkbutton(
                 behavior, text="Ignore Windows Firewall prompts", variable=self.ignore_firewall_var,
-                command=self._save, style="Card.TCheckbutton")
+                command=self._save_with_feedback, style="Card.TCheckbutton")
             ignore_fw_chk.grid(row=b_row, column=b_col, sticky="w", padx=(6 if b_col == 0 else 0, 12), pady=6)
+            b_col += 1
+
+        # Reset goes on the Options grid's last row: no new frame, so the About
+        # tab asks for no more width or height than it already did (the layout
+        # tests in tests/test_gui_layout.py measure exactly that).
+        if b_col >= 3:
+            b_row += 1
+            b_col = 0
+        reset_btn = ttk.Button(behavior, text="Reset all settings…",
+                               command=self.reset_settings)
+        reset_btn.grid(row=b_row, column=b_col, sticky="w",
+                       padx=(6 if b_col == 0 else 0, 12), pady=6)
 
         text_frame = ttk.Frame(about)
         about.rowconfigure(row, weight=1)
@@ -1160,7 +1214,8 @@ class LauncherApp:
         for key, card in self.cards.items():
             if self.is_running(key):
                 card.refresh_status(running=True)
-        self._save()
+        if self._save():
+            self._flash_label(self._ip_feedback, "Saved ✓")
 
     def _on_ip_combobox_select(self, event=None):
         if self.ip_var.get() == "Custom IP...":
@@ -2557,6 +2612,47 @@ class LauncherApp:
         self._set_direct_status(self._direct_ready_status(cfg))
 
     # -- config ----------------------------------------------------------- #
+    def _flash_label(self, widget, text, ms=2500, restore=""):
+        """Transient confirmation where the click happened, not only in a log
+        nobody is watching. A second flash before the first clears restarts
+        the timer rather than stacking clears that would blank it early."""
+        key = str(widget)
+        job = self._flash_jobs.get(key)
+        if job is not None:
+            try:
+                widget.after_cancel(job)
+            except tk.TclError:
+                pass
+        widget.config(text=text)
+
+        def clear(key=key, widget=widget):
+            self._flash_jobs.pop(key, None)
+            try:
+                widget.config(text=restore)
+            except tk.TclError:
+                pass
+
+        job = widget.after(ms, clear)
+        self._flash_jobs[key] = job
+        widget._flash_job = job
+
+    def _cancel_flashes(self):
+        for key, job in self._flash_jobs.items():
+            try:
+                self.root.nametowidget(key).after_cancel(job)
+            except tk.TclError:
+                pass
+        self._flash_jobs.clear()
+
+    def _save_with_feedback(self):
+        """The About page checkboxes save on click; say so on the frame title
+        (a separate label would have to live somewhere and shift the layout)."""
+        if self._save():
+            frame = getattr(self, "_options_frame", None)
+            if frame is not None:
+                self._flash_label(frame, " Options — Saved ✓ ",
+                                  restore=" Options ")
+
     def _saved_bool(self, key, default=False):
         value = self.saved.get(key, default)
         return bool(value) if isinstance(value, bool) else bool(default)
@@ -2606,6 +2702,10 @@ class LauncherApp:
     def _save(self, pending_start=None, pending_cleanup=False,
               pending_firewall_allow=False, pending_direct_link=False,
               pending_direct_link_off=False) -> bool:
+        if getattr(self, "_config_reset", False):
+            # reset_settings deleted the config and owns the restart: nothing
+            # (stop_server, _shutdown_app) may write the old state back.
+            return True
         active = [k for k in self.cards if self.is_running(k)]
         data = {"servers": {key: card.values() for key, card in self.cards.items()},
                 "ip": self.ip_var.get(),
@@ -2661,6 +2761,50 @@ class LauncherApp:
             return [frozen_self_exe()]
         return [sys.executable, "-m", "launcher"]
 
+    def reset_settings(self):
+        """Factory reset: delete the saved settings and restart into defaults.
+
+        Restarting (rather than resetting widgets in place) is the only way to
+        be sure no in-memory residue of the old configuration survives.
+        """
+        direct_cfg = self.saved.get("direct_link") or {}
+        direct_on = (direct_cfg.get("enabled")
+                     or self.saved.get("pending_direct_link_restore")
+                     or (self.direct_link_var is not None
+                         and self.direct_link_var.get()))
+        if direct_on:
+            # The NIC is statically configured and the saved config is what
+            # restores it -- wiping it now would strand the adapter.
+            messagebox.showwarning(
+                "Reset settings",
+                "Turn Direct Link off before resetting settings, so your "
+                "network port is restored to its normal settings.")
+            return
+        if not messagebox.askyesno(
+                "Reset all settings?",
+                "Every server page, saved folder and port, the IP choice and "
+                "all options return to their defaults, and the launcher "
+                "restarts.\n\nWindows Firewall rules are not removed (use "
+                "\"Remove PS2 Servers firewall rules\" for that).\n\n"
+                "Reset everything?"):
+            return
+        if not self._confirm_app_shutdown("Reset settings?"):
+            return
+        config.reset()
+        self.saved = {}
+        self._config_reset = True
+        try:
+            subprocess.Popen(self._restart_command(),
+                             cwd=None if is_frozen() else REPO_ROOT)
+        except OSError as e:
+            # The restart never happened, so give the settings back: _save
+            # re-persists the in-memory state the reset just disowned.
+            self._config_reset = False
+            self._save()
+            messagebox.showerror("Restart failed", str(e))
+            return
+        self._shutdown_app()
+
     def _confirm_app_shutdown(self, title):
         running = [TAB_TITLES.get(key, key.upper())
                    for key in self.procs if self.is_running(key)]
@@ -2701,6 +2845,7 @@ class LauncherApp:
         # not just at destroy time, so nothing reschedules during stop_all.
         self._shutting_down = True
         self._save()
+        self._cancel_flashes()
         # hide first so the (up to a few seconds of) child termination doesn't
         # look like a frozen window
         self.root.withdraw()

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -2780,6 +2780,19 @@ class LauncherApp:
                 "Turn Direct Link off before resetting settings, so your "
                 "network port is restored to its normal settings.")
             return
+        if direct_cfg.get("server_ip"):
+            # Off, but the user chose to keep the fixed address: the port is
+            # still static and this config is the only record of it (the
+            # firewall-cleanup path makes the same call on server_ip, not
+            # enabled). Wiping it strands the adapter exactly the same way.
+            messagebox.showwarning(
+                "Reset settings",
+                "The direct-link port '{}' still uses the fixed address {}. "
+                "Tick Direct Link on, then untick it and choose \"Yes\" to "
+                "return the port to automatic (DHCP) before resetting "
+                "settings.".format(direct_cfg.get("adapter", "?"),
+                                   direct_cfg.get("server_ip")))
+            return
         if not messagebox.askyesno(
                 "Reset all settings?",
                 "Every server page, saved folder and port, the IP choice and "
@@ -2790,7 +2803,12 @@ class LauncherApp:
             return
         if not self._confirm_app_shutdown("Reset settings?"):
             return
-        config.reset()
+        try:
+            config.reset()
+        except OSError as e:
+            # Nothing was deleted and nothing disowned -- stay put and say so.
+            messagebox.showerror("Reset failed", str(e))
+            return
         self.saved = {}
         self._config_reset = True
         try:

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -222,25 +222,27 @@ _SMB2_FIELDS = [
 
 # How the protocol mode is offered, and what each choice puts on the wire.
 #
-# "Proper" rather than "Standard" because the choice a user is making is between
-# the protocol as specified and a client that counts sequences differently --
-# "standard" reads like a recommendation, and the recommended setting is Auto.
-# The wire value stays "standard": it is what both the Python server and Edge
-# accept, and renaming it would break every saved configuration and command line.
+# The labels match the wire values, so the dropdown, the docs, and the logged
+# command line all say the same word. (The middle label was "Proper" once --
+# the thinking was that "standard" reads like a recommendation when the
+# recommended setting is Auto -- but one name everywhere beats that nuance.)
 PROTOCOL_MODE_CHOICES = (
     ("Auto", "auto"),
-    ("Proper", "standard"),
+    ("Standard", "standard"),
     ("Modulo", "modulo"),
 )
 
 # Accepts the label, the wire value, or any casing of either. A saved settings
-# file predating the dropdown holds "standard"; a new one holds "Proper"; and a
+# file predating the dropdown holds "standard"; a new one holds "Standard"; and a
 # user editing the file by hand may write either. All three should work rather
 # than silently falling back to auto.
 _PROTOCOL_MODE_BY_NAME = {}
 for _label, _value in PROTOCOL_MODE_CHOICES:
     _PROTOCOL_MODE_BY_NAME[_label.lower()] = _value
     _PROTOCOL_MODE_BY_NAME[_value.lower()] = _value
+# Settings files written before the "Proper" label was renamed hold the old
+# word. Keep accepting it forever rather than silently moving someone to auto.
+_PROTOCOL_MODE_BY_NAME["proper"] = "standard"
 
 
 def migrate_saved(server_key, saved):
@@ -315,7 +317,7 @@ def _udpfs_argv(v):
         args.append("--no-compression")
     # The old global "Modulo mode" checkbox was removed because it applied one
     # client's quirk to every client at once. Auto classifies each session on its
-    # own, so a Proper client and several Modulo clients transfer side by side.
+    # own, so a Standard client and several Modulo clients transfer side by side.
     #
     # The selector is back as a visible three-way choice, not because Auto is
     # unreliable, but because when it does misjudge a client there has to be a
@@ -348,7 +350,7 @@ def _udpbd_argv(v):
 
 SMBV1 = ServerDef(
     key="smbv1",
-    label="SMBv1 server (RiptOPL)",
+    label="SMBv1 server",
     blurb="Share a games folder over SMB. Works even on Windows 11 where the OS removed SMB1.",
     runtime="python",
     default_port=1025,
@@ -434,7 +436,7 @@ UDPFS = ServerDef(
         # use to the person who needs it.
         Field("protocol_mode", "Protocol mode", "choice", default="Auto",
               choices=PROTOCOL_MODE_CHOICES,
-              help="Auto handles Proper and Modulo clients at the same time and "
+              help="Auto detects Standard and Modulo clients at the same time and "
                    "suits almost everyone. Pick one explicitly only if a console "
                    "will not connect on Auto."),
         Field("read_only", "Read-only", "bool", default=False, advanced=True),

--- a/launcher/theme.py
+++ b/launcher/theme.py
@@ -11,30 +11,30 @@ Keeping this module pure data -- no imports from the rest of ``launcher`` -- mak
 it safe to import from anywhere in the package (``main``, ``asset_skin``,
 ``gui``) without risking an import cycle.
 
-The palette is a calm, modern dark theme. It keeps the PS2 blue identity but
-trades the old near-black + neon look for lifted slate surfaces, a clear
-elevation scale (bg -> panel -> panel2 -> panel3), subtle slate hairlines
-instead of glowing borders, and one confident accent used sparingly.
+The palette is a true-black PS2 theme: the window sits on near-black, surfaces
+rise through midnight-blue elevations (bg -> panel -> panel2 -> panel3), the
+hairlines are blue rather than grey, and the accent is the deep PlayStation
+blue with an icy lighter blue for text that has to glow on black.
 """
 
 PALETTE = {
-    "bg":       "#0d1420",   # window background (deep slate-navy)
-    "panel":    "#161f2e",   # card / strip surface
-    "panel2":   "#1f2a3d",   # hover / slightly elevated surface
-    "panel3":   "#293850",   # selected tab / pressed surface
-    "edge":     "#31415d",   # subtle hairline border (was a neon blue)
+    "bg":       "#05080f",   # window background (true black, blue undertone)
+    "panel":    "#0a0f1c",   # card / strip surface (near-black midnight)
+    "panel2":   "#10182b",   # hover / slightly elevated surface
+    "panel3":   "#182446",   # selected tab / pressed surface (clear midnight blue)
+    "edge":     "#223258",   # subtle midnight-blue hairline border
     "text":     "#e9eef7",   # primary text
-    "muted":    "#93a3bd",   # secondary / helper text
-    "accent":   "#2563eb",   # primary blue -- button fill; dark enough that
-                             # white text clears WCAG AA (~4.5:1) on it
-    "accent_hover": "#1b57d1",  # darker primary for button hover/press (keeps
+    "muted":    "#8d9db8",   # secondary / helper text
+    "accent":   "#1d4ed8",   # deep PlayStation blue -- button fill; dark enough
+                             # that white text clears WCAG AA (~6:1) on it
+    "accent_hover": "#1e40af",  # darker blue for button hover/press (keeps
                                 # white text well above AA on the active state)
-    "accent2":  "#74b6ff",   # lighter blue -- used as TEXT on dark surfaces
+    "accent2":  "#7cc4ff",   # icy lighter blue -- used as TEXT on dark surfaces
                              # (hints, selected-tab label), never as a fill under
-                             # white text, so it stays bright
+                             # white text, so it stays bright on black
     "ok":       "#43d597",   # running / recommended (green)
     "warn":     "#e7b750",   # warning (amber)
     "error":    "#f16d7f",   # error / stopped-in-error (red)
-    "entry":    "#0f1826",   # input fields + terminal background
-    "disabled": "#5c6c88",   # disabled text
+    "entry":    "#060a12",   # input fields + terminal background (near-black)
+    "disabled": "#55637d",   # disabled text
 }

--- a/smbv1_server/README.md
+++ b/smbv1_server/README.md
@@ -59,6 +59,21 @@ Then in OPL → **Settings → Network**:
 
 Save, and your network games should populate from the share.
 
+## Windows Firewall
+
+On first run the `.bat` offers to add a single inbound allow-rule named
+`PS2 Servers - SMB Server` (for the printed port). It uses the same `PS2 Servers - `
+prefix as the main launcher, so the launcher's **Remove PS2 Servers firewall rules**
+button and `tools/remove-windows-firewall-rules.ps1` both remove it.
+
+Releases from before the rebrand named that rule `RiptOPL SMB Server`. Such a leftover
+rule is harmless (a duplicate allow), but the cleanup tools do **not** match it — remove
+it once from an elevated PowerShell:
+
+```powershell
+Get-NetFirewallRule -DisplayName 'RiptOPL SMB Server' | Remove-NetFirewallRule
+```
+
 ## Options
 
 ```

--- a/smbv1_server/README.md
+++ b/smbv1_server/README.md
@@ -1,4 +1,4 @@
-# RiptOPL SMBv1 server
+# PS2 Servers SMBv1 server
 
 A tiny, dependency-free **SMBv1/CIFS server** that Open-PS2-Loader (and forks) can browse and
 load games from — so SMB keeps working even on hosts where the OS has killed SMBv1.
@@ -40,7 +40,7 @@ python smbserver_opl.py --share games=D:/PS2Games
 It prints something like:
 
 ```
- RiptOPL SMBv1 server -- listening on 0.0.0.0:1111
+ PS2 Servers SMBv1 server -- listening on 0.0.0.0:1111
  In OPL  ->  SMB Server IP: 192.168.1.50   Port: 1111   User: guest   Password: blank
             Share: games   ->   D:\PS2Games   (writable)
  (writable -- OPL can save settings + VMC-on-SMB here; pass --read-only to lock it)

--- a/smbv1_server/Start-SMB-Server.bat
+++ b/smbv1_server/Start-SMB-Server.bat
@@ -1,10 +1,10 @@
 @echo off
 setlocal EnableExtensions
-title RiptOPL SMB Server
+title PS2 SMB Server
 cd /d "%~dp0"
 
 REM ============================================================================
-REM  RiptOPL SMBv1 server -- double-click launcher for Windows.
+REM  PS2 Servers SMBv1 server -- double-click launcher for Windows.
 REM
 REM  EASIEST: drag your PS2 games folder onto this .bat file.
 REM  OR: set GAMES below to your games folder, then just double-click.
@@ -25,7 +25,7 @@ if not "%~1"=="" set "GAMES=%~1"
 
 echo.
 echo   ============================================================
-echo     RiptOPL SMB Server
+echo     PS2 SMB Server
 echo   ============================================================
 echo.
 
@@ -56,8 +56,10 @@ goto askfolder
 
 :run
 REM --- one-time: allow the port through Windows Firewall (you'll see a single admin prompt) ---
+REM NOTE: the rule was once named 'RiptOPL SMB Server'; a machine that ran the old script
+REM keeps that (harmless duplicate) allow-rule -- this script only adds the new one.
 echo   Checking Windows Firewall (a one-time "Yes" admin prompt may appear)...
-powershell -NoProfile -ExecutionPolicy Bypass -Command "if (-not (Get-NetFirewallRule -DisplayName 'RiptOPL SMB Server' -EA SilentlyContinue)) { try { Start-Process powershell -Verb RunAs -ArgumentList '-NoProfile','-Command','New-NetFirewallRule -DisplayName ''RiptOPL SMB Server'' -Direction Inbound -Protocol TCP -LocalPort %PORT% -Action Allow -Profile Private,Domain' -Wait } catch { Write-Host '  (skipped -- if OPL cannot connect, allow TCP %PORT% inbound manually)' } }"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "if (-not (Get-NetFirewallRule -DisplayName 'PS2 Servers SMB Server' -EA SilentlyContinue)) { try { Start-Process powershell -Verb RunAs -ArgumentList '-NoProfile','-Command','New-NetFirewallRule -DisplayName ''PS2 Servers SMB Server'' -Direction Inbound -Protocol TCP -LocalPort %PORT% -Action Allow -Profile Private,Domain' -Wait } catch { Write-Host '  (skipped -- if OPL cannot connect, allow TCP %PORT% inbound manually)' } }"
 echo.
 echo   Games folder : %GAMES%
 echo   Port         : %PORT%

--- a/smbv1_server/Start-SMB-Server.bat
+++ b/smbv1_server/Start-SMB-Server.bat
@@ -57,9 +57,11 @@ goto askfolder
 :run
 REM --- one-time: allow the port through Windows Firewall (you'll see a single admin prompt) ---
 REM NOTE: the rule was once named 'RiptOPL SMB Server'; a machine that ran the old script
-REM keeps that (harmless duplicate) allow-rule -- this script only adds the new one.
+REM keeps that (harmless duplicate) allow-rule, which the cleanup tools do not match.
+REM Remove it once from an elevated prompt:
+REM   powershell -Command "Get-NetFirewallRule -DisplayName 'RiptOPL SMB Server' | Remove-NetFirewallRule"
 echo   Checking Windows Firewall (a one-time "Yes" admin prompt may appear)...
-powershell -NoProfile -ExecutionPolicy Bypass -Command "if (-not (Get-NetFirewallRule -DisplayName 'PS2 Servers SMB Server' -EA SilentlyContinue)) { try { Start-Process powershell -Verb RunAs -ArgumentList '-NoProfile','-Command','New-NetFirewallRule -DisplayName ''PS2 Servers SMB Server'' -Direction Inbound -Protocol TCP -LocalPort %PORT% -Action Allow -Profile Private,Domain' -Wait } catch { Write-Host '  (skipped -- if OPL cannot connect, allow TCP %PORT% inbound manually)' } }"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "if (-not (Get-NetFirewallRule -DisplayName 'PS2 Servers - SMB Server' -EA SilentlyContinue)) { try { Start-Process powershell -Verb RunAs -ArgumentList '-NoProfile','-Command','New-NetFirewallRule -DisplayName ''PS2 Servers - SMB Server'' -Direction Inbound -Protocol TCP -LocalPort %PORT% -Action Allow -Profile Private,Domain' -Wait } catch { Write-Host '  (skipped -- if OPL cannot connect, allow TCP %PORT% inbound manually)' } }"
 echo.
 echo   Games folder : %GAMES%
 echo   Port         : %PORT%

--- a/smbv1_server/build_exe.ps1
+++ b/smbv1_server/build_exe.ps1
@@ -1,4 +1,4 @@
-# Optional: build a single-file Windows .exe of the RiptOPL SMBv1 server.
+# Optional: build a single-file Windows .exe of the PS2 Servers SMBv1 server.
 #
 # Power users should just run `python smbserver_opl.py` -- it's pure stdlib, zero deps, and a bare
 # .py has no antivirus false-positives. This script is only for shipping a double-clickable binary.
@@ -19,13 +19,13 @@ python -m nuitka `
     --onefile `
     --standalone `
     --assume-yes-for-downloads `
-    --output-filename=riptopl-smbserver.exe `
-    --company-name=RiptOPL `
-    --product-name="RiptOPL SMBv1 Server" `
+    --output-filename=ps2-smbserver.exe `
+    --company-name=NathanNeurotic `
+    --product-name="PS2 Servers SMBv1 Server" `
     --file-description="Minimal SMBv1 server for Open-PS2-Loader" `
     smbserver_opl.py
 
 Write-Host ""
-Write-Host "Built riptopl-smbserver.exe" -ForegroundColor Green
+Write-Host "Built ps2-smbserver.exe" -ForegroundColor Green
 Write-Host "STRONGLY recommended: sign it to avoid antivirus false-positives, e.g." -ForegroundColor Yellow
-Write-Host '  signtool sign /fd SHA256 /a /tr http://timestamp.digicert.com /td SHA256 riptopl-smbserver.exe'
+Write-Host '  signtool sign /fd SHA256 /a /tr http://timestamp.digicert.com /td SHA256 ps2-smbserver.exe'

--- a/smbv1_server/smbserver_opl.py
+++ b/smbv1_server/smbserver_opl.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# RiptOPL SMBv1 server -- a tiny, dependency-free SMB1/CIFS server that Open-PS2-Loader
+# PS2 Servers SMBv1 server -- a tiny, dependency-free SMB1/CIFS server that Open-PS2-Loader
 # (and forks) can browse + read games from, so SMB keeps working on hosts where the OS has
 # disabled SMBv1 / removed NTLMv1 (Windows 11 24H2/25H2). It speaks "NT LM 0.12" itself and
 # accepts GUEST logons, so it bypasses the host's SMB stack entirely: OPL connects to THIS
@@ -13,7 +13,7 @@
 #   then in OPL: SMB IP = this PC's LAN IP, SMB Port = 1111 (the printed port), Share = games,
 #   User = guest, Password = blank. Writable by default (OPL saves + VMC-on-SMB); pass --read-only to lock.
 #
-# License: same as the surrounding RiptOPL project.
+# License: same as the surrounding PS2 Servers project.
 
 import argparse
 import hmac
@@ -1284,7 +1284,7 @@ def main(argv=None):
 
     ips = _lan_ips()
     print("=" * 64)
-    print(" RiptOPL SMBv1 server -- listening on %s:%d" % (args.bind, bound))
+    print(" PS2 Servers SMBv1 server -- listening on %s:%d" % (args.bind, bound))
     if users:
         first = sorted(users)[0]
         creds = "User: %s   Password: %s" % (

--- a/tests/test_gui_layout.py
+++ b/tests/test_gui_layout.py
@@ -225,6 +225,49 @@ class LauncherLayout(unittest.TestCase):
             states.append(bool(self.app._scrollbar.winfo_ismapped()))
         self.assertEqual(len(set(states)), 1, "scrollbar flip-flopped: %s" % states)
 
+    def test_the_bottom_of_a_grown_page_can_always_be_scrolled_to(self):
+        """Opening Advanced grew the page but not the scrollregion: the body's
+        height is pinned, so no <Configure> fired, the region stayed short, and
+        the last advanced fields could never be scrolled into view.
+        """
+        self.resize(self.min_width, 640)
+        self.app.nb.select(self.app.server_tabs["smbv1"])
+        card = self.app.cards["smbv1"]
+        opened = not card._advanced_shown
+        try:
+            if opened:
+                card._toggle_advanced()
+            self._settle()
+            canvas = self.app._scroll_canvas
+            # The 400 ms reqheight watcher needs real time to notice the growth;
+            # give it a bounded window before declaring the bug still present.
+            import time
+            deadline = time.time() + 2.5
+            while time.time() < deadline:
+                self._settle(2)
+                region = str(canvas.cget("scrollregion") or "0 0 0 0").split()
+                if float(region[3]) >= self.app.content.winfo_reqheight():
+                    break
+                time.sleep(0.1)
+            self.assertGreaterEqual(float(region[3]),
+                                    self.app.content.winfo_reqheight(),
+                                    "scrollregion is shorter than the page: "
+                                    "its bottom can never scroll into view")
+            # And with the region right, the bottom really is reachable.
+            canvas.yview_moveto(1.0)
+            self._settle(1)
+            self.assertGreaterEqual(canvas.yview()[1], 0.999)
+        finally:
+            if opened and card._advanced_shown:
+                card._toggle_advanced()
+            # Settle clean for the tests that follow: at a height the page fits
+            # even with the bar out, the scrollbar releases and the wrap labels
+            # widen back (a bar left mapped would keep them narrow -- and tall).
+            self.resize(1024, 1000)
+            import time
+            time.sleep(0.5)   # let the reqheight watcher run once for real
+            self._settle()
+
     # -- fields ------------------------------------------------------------ #
     def test_take_445_greys_out_the_port_field_it_overrides(self):
         """A saved take-445 silently wins over the port field -- the field must

--- a/tests/test_protocol_mode_selector.py
+++ b/tests/test_protocol_mode_selector.py
@@ -5,11 +5,12 @@ quirk to every client at once. It was replaced by per-session negotiation, and
 the checkbox was removed -- correctly, but that left no way to override a
 misjudgement except by hand-editing a settings file.
 
-It is a visible three-way choice again: Auto, Proper, Modulo. What makes that
-worth testing is that the label and the wire value deliberately differ. The user
-picks "Proper"; the servers only accept "standard". A mapping that silently
-returned "Proper" would be rejected by the server at startup, and under procd or
-the launcher's respawn that is a mode that simply never comes up.
+It is a visible three-way choice again: Auto, Standard, Modulo. The middle
+label was "Proper" until it was renamed to match the wire value; settings files
+written before the rename still hold "Proper", so it stays an accepted alias.
+What makes the mapping worth testing is that a label or typo reaching the server
+unchanged would be rejected at startup, and under procd or the launcher's
+respawn that is a mode that simply never comes up.
 
 Run:  python -m unittest tests.test_protocol_mode_selector -v
 """
@@ -49,7 +50,7 @@ class ChoicesAreServable(unittest.TestCase):
 
     def test_the_labels_are_the_ones_asked_for(self):
         self.assertEqual([label for label, _ in PROTOCOL_MODE_CHOICES],
-                         ["Auto", "Proper", "Modulo"])
+                         ["Auto", "Standard", "Modulo"])
 
     def test_auto_is_first_so_it_is_what_an_empty_selection_lands_on(self):
         self.assertEqual(PROTOCOL_MODE_CHOICES[0], ("Auto", "auto"))
@@ -66,8 +67,12 @@ class ChoicesAreServable(unittest.TestCase):
 class ValueMapping(unittest.TestCase):
     def test_labels_map_to_wire_values(self):
         self.assertEqual(protocol_mode_value("Auto"), "auto")
-        self.assertEqual(protocol_mode_value("Proper"), "standard")
+        self.assertEqual(protocol_mode_value("Standard"), "standard")
         self.assertEqual(protocol_mode_value("Modulo"), "modulo")
+
+    def test_the_retired_proper_label_still_maps(self):
+        """Settings files from before the rename hold "Proper"; never lose them."""
+        self.assertEqual(protocol_mode_value("Proper"), "standard")
 
     def test_wire_values_map_to_themselves(self):
         """A settings file written before the dropdown holds the wire value."""
@@ -76,7 +81,7 @@ class ValueMapping(unittest.TestCase):
                 self.assertEqual(protocol_mode_value(value), value)
 
     def test_casing_and_padding_are_tolerated(self):
-        for raw in ("proper", "PROPER", "  Proper  ", "sTaNdArD"):
+        for raw in ("proper", "PROPER", "  Proper  ", "sTaNdArD", "  Standard  "):
             with self.subTest(raw=raw):
                 self.assertEqual(protocol_mode_value(raw), "standard")
 
@@ -93,7 +98,10 @@ class ValueMapping(unittest.TestCase):
 
 
 class ArgvContract(unittest.TestCase):
-    def test_proper_is_sent_as_standard(self):
+    def test_standard_is_sent_as_standard(self):
+        self.assertEqual(_mode_in(_argv(protocol_mode="Standard")), "standard")
+
+    def test_the_proper_alias_is_sent_as_standard(self):
         self.assertEqual(_mode_in(_argv(protocol_mode="Proper")), "standard")
 
     def test_modulo_is_sent(self):
@@ -120,8 +128,8 @@ class ArgvContract(unittest.TestCase):
                          "modulo")
 
     def test_every_emitted_value_is_one_the_servers_accept(self):
-        for raw in ("Auto", "Proper", "Modulo", "standard", "modulo", "auto",
-                    "nonsense", None):
+        for raw in ("Auto", "Standard", "Proper", "Modulo", "standard", "modulo",
+                    "auto", "nonsense", None):
             with self.subTest(raw=raw):
                 mode = _mode_in(_argv(protocol_mode=raw))
                 if mode is not None:

--- a/tests/test_reset_settings.py
+++ b/tests/test_reset_settings.py
@@ -141,6 +141,48 @@ class ResetSettingsGUITest(unittest.TestCase):
         self.assertTrue(os.path.exists(config.config_path()))
         self.assertFalse(app._config_reset)
 
+    def test_reset_refused_with_retained_static_address(self):
+        # "Turn off Direct Link but keep the fixed address" saves enabled=False
+        # with the adapter metadata still attached: the port is still static,
+        # and this config is the only thing that knows how to undo that.
+        gui, app = self._make_app()
+        from launcher import config
+        stale = {"enabled": False, "adapter": "Ethernet", "server_ip": "10.0.0.1"}
+        config.save({"direct_link": dict(stale)})
+        app.saved["direct_link"] = dict(stale)
+
+        with (mock.patch.object(gui.messagebox, "askyesno") as ask_mock,
+              mock.patch.object(gui.messagebox, "showwarning") as warn_mock,
+              mock.patch.object(gui.subprocess, "Popen") as popen_mock):
+            app.reset_settings()
+
+        warn_mock.assert_called_once()
+        ask_mock.assert_not_called()  # refused before the confirm prompt
+        popen_mock.assert_not_called()
+        self.assertTrue(os.path.exists(config.config_path()))
+        self.assertFalse(app._config_reset)
+
+    def test_reset_delete_failure_keeps_everything(self):
+        # A config that cannot be deleted (permissions, another process holding
+        # it) must surface as an error, not escape the Tk callback -- and the
+        # restart must not happen, or the app would come back on defaults while
+        # the old config still sits on disk.
+        gui, app = self._make_app()
+        from launcher import config
+        config.save({"servers": {"udpfs": {"root": "/keep"}}})
+
+        with (mock.patch.object(gui.messagebox, "askyesno", return_value=True),
+              mock.patch.object(gui.messagebox, "showerror") as err_mock,
+              mock.patch.object(gui.config, "reset",
+                                side_effect=PermissionError("locked")),
+              mock.patch.object(gui.subprocess, "Popen") as popen_mock):
+            app.reset_settings()
+
+        err_mock.assert_called_once()
+        popen_mock.assert_not_called()
+        self.assertTrue(os.path.exists(config.config_path()))
+        self.assertFalse(app._config_reset)
+
     def test_reset_restart_failure_restores_settings(self):
         gui, app = self._make_app()
         from launcher import config

--- a/tests/test_reset_settings.py
+++ b/tests/test_reset_settings.py
@@ -1,0 +1,180 @@
+"""Tests for the About tab "Reset all settings" action and updates button.
+
+Run:
+    python -m unittest tests.test_reset_settings -v
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+class ConfigResetTest(unittest.TestCase):
+    def setUp(self):
+        self.scratch = tempfile.mkdtemp(prefix="ps2-reset-test-")
+        self.saved_env = {v: os.environ.get(v) for v in ("APPDATA", "XDG_CONFIG_HOME")}
+        for var in ("APPDATA", "XDG_CONFIG_HOME"):
+            os.environ[var] = self.scratch
+
+    def tearDown(self):
+        for var, was in self.saved_env.items():
+            if was is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = was
+        import shutil
+        shutil.rmtree(self.scratch, ignore_errors=True)
+
+    def test_reset_removes_config_file(self):
+        from launcher import config
+        config.save({"servers": {"udpfs": {"root": "/games"}}})
+        self.assertTrue(os.path.exists(config.config_path()))
+        config.reset()
+        self.assertFalse(os.path.exists(config.config_path()))
+        # A fresh load after reset is the defaults: an empty dict.
+        self.assertEqual(config.load(), {})
+
+    def test_reset_tolerates_missing_file(self):
+        from launcher import config
+        self.assertFalse(os.path.exists(config.config_path()))
+        config.reset()  # must not raise
+        self.assertFalse(os.path.exists(config.config_path()))
+
+
+class ResetSettingsGUITest(unittest.TestCase):
+    def setUp(self):
+        self.scratch = tempfile.mkdtemp(prefix="ps2-reset-gui-test-")
+        self.saved_env = {v: os.environ.get(v) for v in ("APPDATA", "XDG_CONFIG_HOME")}
+        for var in ("APPDATA", "XDG_CONFIG_HOME"):
+            os.environ[var] = self.scratch
+
+        from launcher import tray
+        self.saved_tray_available = tray.AVAILABLE
+        tray.AVAILABLE = False
+
+    def tearDown(self):
+        for var, was in self.saved_env.items():
+            if was is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = was
+        import shutil
+        shutil.rmtree(self.scratch, ignore_errors=True)
+        from launcher import tray
+        tray.AVAILABLE = self.saved_tray_available
+
+    def _make_app(self):
+        try:
+            import tkinter as tk
+        except ImportError:
+            raise unittest.SkipTest("no tkinter")
+        from launcher import gui
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            raise unittest.SkipTest("no display")
+        app = gui.LauncherApp(root)
+
+        def cleanup(app=app, root=root):
+            app._shutting_down = True
+            root.destroy()
+
+        self.addCleanup(cleanup)
+        return gui, app
+
+    def test_reset_deletes_config_blocks_save_and_restarts(self):
+        gui, app = self._make_app()
+        from launcher import config
+        config.save({"servers": {"udpfs": {"root": "/poisoned"}}})
+        self.assertTrue(os.path.exists(config.config_path()))
+
+        popen_calls = []
+        with (mock.patch.object(gui.messagebox, "askyesno", return_value=True),
+              mock.patch.object(gui.messagebox, "showwarning"),
+              mock.patch.object(gui.subprocess, "Popen",
+                                side_effect=lambda *a, **k: popen_calls.append((a, k))
+                                or mock.Mock()),
+              mock.patch.object(app, "_shutdown_app")):
+            app.reset_settings()
+
+        self.assertFalse(os.path.exists(config.config_path()))
+        self.assertTrue(app._config_reset)
+        self.assertEqual(app.saved, {})
+        self.assertEqual(len(popen_calls), 1)
+        # After reset, _save is a no-op: nothing may resurrect the old config.
+        self.assertTrue(app._save())
+        self.assertFalse(os.path.exists(config.config_path()))
+
+    def test_reset_cancelled_keeps_config(self):
+        gui, app = self._make_app()
+        from launcher import config
+        config.save({"servers": {"udpfs": {"root": "/keep"}}})
+
+        with (mock.patch.object(gui.messagebox, "askyesno", return_value=False),
+              mock.patch.object(gui.subprocess, "Popen") as popen_mock):
+            app.reset_settings()
+
+        self.assertTrue(os.path.exists(config.config_path()))
+        self.assertFalse(app._config_reset)
+        popen_mock.assert_not_called()
+
+    def test_reset_refused_while_direct_link_enabled(self):
+        gui, app = self._make_app()
+        from launcher import config
+        config.save({"direct_link": {"enabled": True}})
+        app.saved["direct_link"] = {"enabled": True}
+
+        with (mock.patch.object(gui.messagebox, "askyesno") as ask_mock,
+              mock.patch.object(gui.messagebox, "showwarning") as warn_mock,
+              mock.patch.object(gui.subprocess, "Popen") as popen_mock):
+            app.reset_settings()
+
+        warn_mock.assert_called_once()
+        ask_mock.assert_not_called()  # refused before the confirm prompt
+        popen_mock.assert_not_called()
+        self.assertTrue(os.path.exists(config.config_path()))
+        self.assertFalse(app._config_reset)
+
+    def test_reset_restart_failure_restores_settings(self):
+        gui, app = self._make_app()
+        from launcher import config
+        config.save({"servers": {"udpfs": {"root": "/keep"}}})
+
+        with (mock.patch.object(gui.messagebox, "askyesno", return_value=True),
+              mock.patch.object(gui.messagebox, "showerror"),
+              mock.patch.object(gui.subprocess, "Popen",
+                                side_effect=OSError("boom"))):
+            app.reset_settings()
+
+        # Rollback: the reset flag is cleared and the current state is saved again.
+        self.assertFalse(app._config_reset)
+        self.assertTrue(os.path.exists(config.config_path()))
+
+    def test_about_tab_has_check_for_updates_button(self):
+        gui, app = self._make_app()
+        texts = []
+
+        def collect(widget):
+            if isinstance(widget, gui.ttk.Button):
+                texts.append(widget.cget("text"))
+            for child in widget.winfo_children():
+                collect(child)
+
+        # Scan every notebook page rather than naming the About tab: the
+        # runtime shim (main._apply_gui_review_fixes) pads tab text, and whether
+        # it ran yet depends on which tests ran before this one.
+        for tab_id in app.nb.tabs():
+            collect(app.nb.nametowidget(tab_id))
+        self.assertIn("Check for updates", texts)
+        self.assertNotIn("Releases", texts)
+        self.assertIn("Reset all settings…", texts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_settings_feedback.py
+++ b/tests/test_settings_feedback.py
@@ -1,0 +1,123 @@
+"""Settings edits must say they took: transient feedback at the control used.
+
+Covers the per-card Apply/Revert flash, the LAN IP "Saved ✓" flash, and the
+About Options frame-title flash (including its restore).
+
+Run:
+    python -m unittest tests.test_settings_feedback -v
+"""
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+class SettingsFeedbackTest(unittest.TestCase):
+    def setUp(self):
+        self.scratch = tempfile.mkdtemp(prefix="ps2-flash-test-")
+        self.saved_env = {v: os.environ.get(v) for v in ("APPDATA", "XDG_CONFIG_HOME")}
+        for var in ("APPDATA", "XDG_CONFIG_HOME"):
+            os.environ[var] = self.scratch
+
+        from launcher import tray
+        self.saved_tray_available = tray.AVAILABLE
+        tray.AVAILABLE = False
+
+    def tearDown(self):
+        for var, was in self.saved_env.items():
+            if was is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = was
+        import shutil
+        shutil.rmtree(self.scratch, ignore_errors=True)
+        from launcher import tray
+        tray.AVAILABLE = self.saved_tray_available
+
+    def _make_app(self):
+        try:
+            import tkinter as tk
+        except ImportError:
+            raise unittest.SkipTest("no tkinter")
+        from launcher import gui
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            raise unittest.SkipTest("no display")
+        app = gui.LauncherApp(root)
+
+        def cleanup(app=app, root=root):
+            app._shutting_down = True
+            app._cancel_flashes()
+            try:
+                # Let every periodic (status poller, scroll watcher, log drain)
+                # fire once on the live interpreter and stand down: none of
+                # them re-arms once _shutting_down is set, so nothing is left
+                # armed to fire mid-destroy, where its command is already gone.
+                deadline = time.time() + 0.8
+                while time.time() < deadline:
+                    root.update()
+                    time.sleep(0.1)
+            except tk.TclError:
+                pass
+            root.destroy()
+
+        self.addCleanup(cleanup)
+        return gui, app
+
+    def test_apply_flashes_saved_on_the_card(self):
+        gui, app = self._make_app()
+        card = app.cards["udpfs"]
+        self.assertEqual(card._saved_flash.cget("text"), "")
+        card.apply_page_settings()
+        self.assertEqual(card._saved_flash.cget("text"), "Saved ✓")
+
+    def test_revert_flashes_defaults_restored_on_the_card(self):
+        gui, app = self._make_app()
+        card = app.cards["udpfs"]
+        card.revert_to_defaults()
+        self.assertEqual(card._saved_flash.cget("text"), "Defaults restored ✓")
+
+    def test_ip_commit_flashes_saved(self):
+        gui, app = self._make_app()
+        app._commit_ip_edit()
+        self.assertEqual(app._ip_feedback.cget("text"), "Saved ✓")
+
+    def test_options_save_flashes_the_frame_title(self):
+        gui, app = self._make_app()
+        self.assertEqual(app._options_frame.cget("text"), " Options ")
+        app._save_with_feedback()
+        self.assertEqual(app._options_frame.cget("text"), " Options — Saved ✓ ")
+
+    def test_flash_restores_the_original_text(self):
+        gui, app = self._make_app()
+        frame = app._options_frame
+        app._flash_label(frame, " Options — Saved ✓ ", ms=50,
+                         restore=" Options ")
+        deadline = time.time() + 2.5
+        while time.time() < deadline:
+            app.root.update_idletasks()
+            app.root.update()
+            if frame.cget("text") == " Options ":
+                break
+            time.sleep(0.05)
+        self.assertEqual(frame.cget("text"), " Options ")
+
+    def test_a_second_flash_restarts_the_timer(self):
+        gui, app = self._make_app()
+        label = app._ip_feedback
+        app._flash_label(label, "Saved ✓", ms=2500)
+        first_job = label._flash_job
+        app._flash_label(label, "Saved ✓", ms=2500)
+        self.assertNotEqual(label._flash_job, first_job)
+        self.assertEqual(label.cget("text"), "Saved ✓")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_settings_feedback.py
+++ b/tests/test_settings_feedback.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import time
 import unittest
+from unittest import mock
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if ROOT not in sys.path:
@@ -83,6 +84,22 @@ class SettingsFeedbackTest(unittest.TestCase):
         card = app.cards["udpfs"]
         card.revert_to_defaults()
         self.assertEqual(card._saved_flash.cget("text"), "Defaults restored ✓")
+
+    def test_apply_does_not_flash_when_the_save_fails(self):
+        # _save() returns False when the config cannot be written; claiming
+        # "Saved" then would be a lie the user acts on at the next launch.
+        gui, app = self._make_app()
+        card = app.cards["udpfs"]
+        with mock.patch.object(app, "_save", return_value=False):
+            card.apply_page_settings()
+        self.assertEqual(card._saved_flash.cget("text"), "")
+
+    def test_revert_does_not_flash_when_the_save_fails(self):
+        gui, app = self._make_app()
+        card = app.cards["udpfs"]
+        with mock.patch.object(app, "_save", return_value=False):
+            card.revert_to_defaults()
+        self.assertEqual(card._saved_flash.cget("text"), "")
 
     def test_ip_commit_flashes_saved(self):
         gui, app = self._make_app()

--- a/tools/check_release_compliance.py
+++ b/tools/check_release_compliance.py
@@ -170,7 +170,7 @@ def main():
         "Windows executable: PS2Servers.exe",
         "Windows release package: PS2Servers-windows-x64.zip",
         "32-bit Windows release package: PS2Servers-windows-x86.zip",
-        "SMBv1/RiptOPL",
+        "SMBv1: built-in SMB/CIFS subset",
         "TCP port 1111",
         "UDP port 0xF5F6",
         "UDP port 0xBDBD",


### PR DESCRIPTION
## Summary

Batch of launcher UX improvements from review feedback:

- **About page**: new **Check for updates** button linking to the releases page, and **Reset all settings...** — wipes saved config back to defaults (old settings poisoning an update, or starting fresh). Refuses while Direct Link is active, asks for confirmation, restarts the app, and rolls back if deleting the config fails.
- **Protocol mode rename**: the UDPFS mode labelled **Proper** is now **Standard**. The wire value is unchanged (`standard`) and old saves with `proper` still load via an alias, so nothing breaks on upgrade.
- **Scroll fix**: Advanced sections (e.g. SMBv1 Advanced) could expand out of frame and become unreachable. The scroll region now refreshes via a 400 ms height watcher plus an after-idle refresh on toggle. Regression test included (fails without the fix).
- **Action feedback**: Save/Apply/Revert buttons flash "Saved ✓" / "Defaults restored ✓", the About option checkboxes confirm on click, and the LAN IP field flashes when an edit commits — there's now a visible indication that settings take hold.
- **Rebrand**: RiptOPL identity removed in favour of "PS2 Homebrew Applications" phrasing (banner, About text, firewall rule name, exe name, docs). Factual compatibility lists kept as-is.
- **Darker PS2-style theme**: near-black background with midnight-blue panels and blue accents instead of navy. Single-file change in `launcher/theme.py`; white-on-accent contrast stays WCAG AA (≥ 4.5:1), enforced by the theme tests.

## Testing

- `python -m unittest discover -s tests` → **545 passed, 4 skipped** (same skip count as main)
- New tests: `test_reset_settings.py` (7), `test_settings_feedback.py` (6), scroll regression in `test_gui_layout.py`
- `python tools/check_release_compliance.py` passes (updated for the rebrand)
- Manual smoke: GUI launches, mode dropdown shows Auto/Standard/Modulo, SMBv1 card and banner use the new naming; dark theme screenshot checked visually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a factory-reset option for launcher settings, with safeguards and restart handling.
  - Added clearer save, restore, and reset status feedback throughout the launcher.
  - Added an “About” link for checking updates.
  - Improved scrolling when expanding advanced settings.

- **Improvements**
  - Renamed the UDPFS “Proper” mode to “Standard” while preserving compatibility with the legacy name.
  - Updated SMBv1 terminology and branding across the app and documentation.
  - Introduced a darker, PlayStation 2-inspired visual theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->