### PR TITLE
feat(edge): --dump-schema prints the config contract as JSON

### DIFF
--- a/docs/EDGE.md
+++ b/docs/EDGE.md
@@ -45,6 +45,15 @@ Observability & Web Management:
 - `--metrics` — log periodic transfer counters
 - `--metrics-period 1m` — how often, from `1s` to `24h`
 
+Tooling & automation:
+
+- `--version` — print the version and exit
+- `--dump-schema` — print the whole configuration contract as JSON: every
+  section and option of `/etc/config/ps2servers-edge` with its type, default,
+  range, and which layer rejects a bad value. Firmware and provisioning tools
+  that generate the config should validate against this output from the exact
+  binary they ship; section and option names are additive-only across updates.
+
 Web UI:
 
 - `ps2servers-edge webui` — run embedded web dashboard on port `8082` (or OS assigned)

--- a/docs/EDGE.md
+++ b/docs/EDGE.md
@@ -43,7 +43,7 @@ Compressed images:
 Observability & Web Management:
 
 - `--metrics` — log periodic transfer counters
-- `--metrics-period 1m` — how often, from `1s` to `24h`
+- `--metrics-period 1m` — how often, from `1s` to `24h`; parsed (and validated) only when `--metrics` is on
 
 Tooling & automation:
 

--- a/native/ps2servers-edge/cmd/ps2servers-edge/main.go
+++ b/native/ps2servers-edge/cmd/ps2servers-edge/main.go
@@ -54,6 +54,22 @@ func duration(v string) (time.Duration, error) {
 	return time.Duration(seconds * float64(time.Second)), nil
 }
 
+// parseMetricsPeriod reads --metrics-period, but only when metrics are on:
+// with them off the value is never parsed, so anything (even garbage) is
+// accepted. --dump-schema states the same condition via applies_when, so a
+// provisioning tool does not reject a disabled-metrics config the binary
+// would happily run.
+func parseMetricsPeriod(enabled bool, period string) (time.Duration, error) {
+	if !enabled {
+		return 0, nil
+	}
+	every, err := duration(period)
+	if err != nil || every < time.Second || every > 24*time.Hour {
+		return 0, fmt.Errorf("--metrics-period must be between 1s and 24h")
+	}
+	return every, nil
+}
+
 // applyMemoryLimit gives the collector a ceiling on machines small enough for
 // it to matter.
 //
@@ -206,13 +222,10 @@ func main() {
 	if *txDelayMs > 0 {
 		txDelay = time.Duration(*txDelayMs * float64(time.Millisecond))
 	}
-	var metricsEvery time.Duration
-	if *metrics {
-		metricsEvery, err = duration(*metricsPeriod)
-		if err != nil || metricsEvery < time.Second || metricsEvery > 24*time.Hour {
-			fmt.Fprintln(os.Stderr, "error: --metrics-period must be between 1s and 24h")
-			os.Exit(2)
-		}
+	metricsEvery, err := parseMetricsPeriod(*metrics, *metricsPeriod)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(2)
 	}
 	logger := edgelog.New(os.Stdout, *logFormat, *quiet, *verbose)
 	server, err := udpfs.New(udpfs.Config{Root: *root, Bind: *bind, Port: *port, DataPort: *dataPort, SinglePort: *singlePort, ProtocolMode: profile, PeerTimeout: timeout, TxDelay: txDelay, ReadOnly: *readOnly, MetricsPeriod: metricsEvery, BlockDevice: *blockDevice, SectorSize: *sectorSize, NoCompression: *noCompression, CompressionCache: *compressionCache, Log: logger, ServerName: "PS2 Servers Edge"})

--- a/native/ps2servers-edge/cmd/ps2servers-edge/main.go
+++ b/native/ps2servers-edge/cmd/ps2servers-edge/main.go
@@ -33,7 +33,8 @@ func usage() {
 		"  ps2servers-edge udpbd --image /path/ps2.img [options]\n"+
 		"  ps2servers-edge smb --share games=/games [options]\n"+
 		"  ps2servers-edge webui [options]\n"+
-		"  ps2servers-edge --version\n\n"+
+		"  ps2servers-edge --version\n"+
+		"  ps2servers-edge --dump-schema\n\n"+
 		"  udpfs serves a folder as a network file share.\n"+
 		"  udpbd serves one disk image as a network hard drive.\n"+
 		"  smb   serves folders over SMBv1, for OPL's game list and POPSTARTER.\n"+
@@ -72,6 +73,15 @@ func applyMemoryLimit() {
 func main() {
 	if len(os.Args) == 2 && (os.Args[1] == "--version" || os.Args[1] == "version") {
 		fmt.Printf("ps2servers-edge %s\n", version)
+		return
+	}
+	// The UCI/JSON config contract as JSON, for firmware and tooling that
+	// generates the config and needs to validate against this exact binary.
+	if len(os.Args) == 2 && (os.Args[1] == "--dump-schema" || os.Args[1] == "dump-schema") {
+		if err := webui.WriteSchema(os.Stdout, version); err != nil {
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
 		return
 	}
 	// Before either server starts, so both are covered.

--- a/native/ps2servers-edge/cmd/ps2servers-edge/main_test.go
+++ b/native/ps2servers-edge/cmd/ps2servers-edge/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// --dump-schema marks metrics_period applies_when=metrics; this pins the
+// binary behaviour that metadata describes, so the two cannot drift apart.
+func TestParseMetricsPeriodOnlyAppliesWhenMetricsAreOn(t *testing.T) {
+	// Off: the period is never parsed, so even garbage is accepted.
+	for _, period := range []string{"banana", "", "999h"} {
+		if d, err := parseMetricsPeriod(false, period); err != nil || d != 0 {
+			t.Errorf("metrics off, period %q: got (%v, %v), want (0, nil)", period, d, err)
+		}
+	}
+	// On: parsed and bounded to 1s..24h.
+	for _, period := range []string{"banana", "500ms", "25h"} {
+		if _, err := parseMetricsPeriod(true, period); err == nil {
+			t.Errorf("metrics on, period %q: accepted, want rejection", period)
+		}
+	}
+	if d, err := parseMetricsPeriod(true, "30s"); err != nil || d != 30*time.Second {
+		t.Errorf("metrics on, period 30s: got (%v, %v), want (30s, nil)", d, err)
+	}
+}

--- a/native/ps2servers-edge/internal/webui/schema.go
+++ b/native/ps2servers-edge/internal/webui/schema.go
@@ -1,0 +1,175 @@
+package webui
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// The machine-readable form of /etc/config/ps2servers-edge, printed by
+// `ps2servers-edge --dump-schema`.
+//
+// It exists for firmware/tooling that GENERATES the UCI config (router images,
+// provisioning adapters): they validate against the exact binary they ship
+// instead of a hardcoded copy of this list. The stability rule is that section
+// and option names are additive-only -- a new field may appear, an existing one
+// is never renamed or removed -- so schema_version only bumps on additions.
+//
+// Defaults and coverage are not hand-maintained here in spirit: schema_test.go
+// walks DefaultConfig() and fails if a field is missing, mis-typed, or has a
+// different default, and probes ValidateConfig against every constraint marked
+// enforced by the API. Editing the config model without updating this table
+// breaks the build, which is the point.
+
+// Field types emitted in "type".
+const (
+	TypeBool     = "bool"
+	TypeInt      = "int"
+	TypeFloat    = "float"
+	TypeString   = "string"
+	TypePath     = "path"
+	TypeDuration = "duration" // Go duration ("1h") or plain seconds
+	TypeEnum     = "enum"
+)
+
+// Who rejects a bad value first. "webui-api" means ValidateConfig refuses it
+// (so the dashboard's Save also reports it); "server" means only the server
+// refuses at start. Fields without constraints omit the key.
+const (
+	EnforcedByAPI    = "webui-api"
+	EnforcedByServer = "server"
+)
+
+type FieldSpec struct {
+	Name       string   `json:"name"`
+	Type       string   `json:"type"`
+	Default    any      `json:"default"`
+	Doc        string   `json:"doc,omitempty"`
+	Values     []string `json:"values,omitempty"`      // enum: the accepted values
+	Min        *float64 `json:"min,omitempty"`         // numeric lower bound
+	Max        *float64 `json:"max,omitempty"`         // numeric upper bound
+	MultipleOf *int     `json:"multiple_of,omitempty"` // int: value must be a multiple of this
+	MinValue   string   `json:"min_value,omitempty"`   // duration lower bound
+	MaxValue   string   `json:"max_value,omitempty"`   // duration upper bound
+	EnforcedBy string   `json:"enforced_by,omitempty"`
+}
+
+type SectionSpec struct {
+	Name string `json:"name"` // EdgeConfig section name
+	// The UCI section as `uci set ps2servers-edge.<uci_section>.<option>`.
+	// udpfs is the historical 'main'; the rest match their name.
+	UCISection  string      `json:"uci_section"`
+	Description string      `json:"description,omitempty"`
+	Fields      []FieldSpec `json:"fields"`
+}
+
+type Schema struct {
+	SchemaVersion int           `json:"schema_version"`
+	Binary        string        `json:"binary"`
+	Version       string        `json:"version"`
+	ConfigFile    string        `json:"config_file"`
+	Sections      []SectionSpec `json:"sections"`
+}
+
+func fnum(v float64) *float64 { return &v }
+func inum(v int) *int         { return &v }
+
+// schema assembles the contract. Defaults for fields modelled in EdgeConfig
+// must equal DefaultConfig() -- the test walks both.
+func schema(version string) *Schema {
+	return &Schema{
+		SchemaVersion: 1,
+		Binary:        "ps2servers-edge",
+		Version:       version,
+		ConfigFile:    "/etc/config/ps2servers-edge",
+		Sections: []SectionSpec{
+			{
+				Name:       "udpfs",
+				UCISection: "main",
+				Description: "Network file share over UDP, with optional disk-image " +
+					"block access. The recommended mode for most setups.",
+				Fields: []FieldSpec{
+					{Name: "enabled", Type: TypeBool, Default: true, Doc: "start this service at boot"},
+					{Name: "root", Type: TypePath, Default: "/mnt/sda1/PS2", Doc: "directory served to consoles; required to start"},
+					{Name: "bind", Type: TypeString, Default: "0.0.0.0", Doc: "IPv4 address to listen on"},
+					{Name: "port", Type: TypeInt, Default: 62966, Min: fnum(0), Max: fnum(65535), EnforcedBy: EnforcedByAPI, Doc: "UDP discovery port (0xF5F6)"},
+					{Name: "data_port", Type: TypeInt, Default: 0, Min: fnum(0), Max: fnum(65535), EnforcedBy: EnforcedByAPI, Doc: "fixed UDP data port; 0 chooses automatically"},
+					{Name: "protocol", Type: TypeEnum, Default: "auto", Values: []string{"auto", "standard", "modulo"}, EnforcedBy: EnforcedByAPI, Doc: "auto classifies each client on its own; force one only when auto misjudges a console"},
+					{Name: "single_port", Type: TypeBool, Default: false, Doc: "use the discovery port for all traffic"},
+					{Name: "read_only", Type: TypeBool, Default: true, Doc: "refuse writes. The package ships 1 (a router share is often a whole disk); the binary itself defaults to writable"},
+					{Name: "peer_timeout", Type: TypeDuration, Default: "1h", MinValue: "1m", MaxValue: "24h", EnforcedBy: EnforcedByServer, Doc: "idle session expiry; Go duration or plain seconds"},
+					{Name: "tx_delay_ms", Type: TypeFloat, Default: float64(0), Min: fnum(0), EnforcedBy: EnforcedByAPI, Doc: "inter-packet pacing in milliseconds; raise it if a slow link drops packets"},
+					{Name: "log_format", Type: TypeEnum, Default: "text", Values: []string{"text", "json"}, EnforcedBy: EnforcedByAPI},
+					{Name: "verbose", Type: TypeBool, Default: false, Doc: "verbose protocol logging"},
+					{Name: "block_device", Type: TypePath, Default: "", Doc: "also serve this disk image over UDPFS block access; empty disables. Inherits read_only"},
+					{Name: "sector_size", Type: TypeInt, Default: 512, Min: fnum(512), Max: fnum(65536), MultipleOf: inum(512), EnforcedBy: EnforcedByServer, Doc: "sector size for block_device; only sent alongside it"},
+					{Name: "no_compression", Type: TypeBool, Default: false, Doc: "serve CSO/ZSO as raw bytes. Diagnostic only -- games do not load this way"},
+					{Name: "compression_cache_size", Type: TypeInt, Default: 32, Min: fnum(0), Max: fnum(4096), EnforcedBy: EnforcedByServer, Doc: "decompressed blocks cached per open image; 0 disables"},
+					{Name: "metrics", Type: TypeBool, Default: false, Doc: "log periodic transfer counters to syslog"},
+					{Name: "metrics_period", Type: TypeDuration, Default: "1m", MinValue: "1s", MaxValue: "24h", EnforcedBy: EnforcedByServer, Doc: "how often metrics are logged; only used when metrics is 1"},
+				},
+			},
+			{
+				Name:       "smb",
+				UCISection: "smb",
+				Description: "SMBv1 shares for OPL's network game list and POPSTARTER. " +
+					"Off by default: enabling binds a port with no password.",
+				Fields: []FieldSpec{
+					{Name: "enabled", Type: TypeBool, Default: false, Doc: "start this service at boot"},
+					{Name: "share", Type: TypeString, Default: "games=/mnt/sda1/PS2", Doc: "space-separated NAME=PATH pairs. Required to start; a path containing a space cannot be expressed"},
+					{Name: "bind", Type: TypeString, Default: "0.0.0.0", Doc: "IPv4 address to listen on"},
+					{Name: "port", Type: TypeInt, Default: 1111, Min: fnum(0), Max: fnum(65535), EnforcedBy: EnforcedByAPI, Doc: "TCP port; set OPL's SMB Port to match. Below 1024 needs root"},
+					{Name: "read_only", Type: TypeBool, Default: true, Doc: "refuse writes; this server has no password"},
+					{Name: "status_port", Type: TypeInt, Default: 0, Min: fnum(-1), Max: fnum(65535), EnforcedBy: EnforcedByAPI, Doc: "router status query port: 0 is off, -1 is the standard discovery port (which udpfs already owns -- set -1 only when smb is the only service)"},
+					{Name: "log_format", Type: TypeEnum, Default: "text", Values: []string{"text", "json"}, EnforcedBy: EnforcedByAPI},
+					{Name: "verbose", Type: TypeBool, Default: false, Doc: "verbose protocol logging"},
+				},
+			},
+			{
+				Name:       "udpbd",
+				UCISection: "udpbd",
+				Description: "One disk image as a network hard drive. A separate " +
+					"protocol from udpfs on its own port; largely superseded by udpfs.",
+				Fields: []FieldSpec{
+					{Name: "enabled", Type: TypeBool, Default: false, Doc: "start this service at boot"},
+					{Name: "image", Type: TypePath, Default: "", Doc: "disk image to serve; required to start"},
+					{Name: "bind", Type: TypeString, Default: "0.0.0.0", Doc: "IPv4 address to listen on"},
+					{Name: "port", Type: TypeInt, Default: 48573, Min: fnum(0), Max: fnum(65535), EnforcedBy: EnforcedByAPI, Doc: "0xBDBD -- the port the PS2's udpbd client broadcasts to, not a free choice"},
+					{Name: "read_only", Type: TypeBool, Default: true, Doc: "refuse writes"},
+					{Name: "status_port", Type: TypeInt, Default: 0, Min: fnum(-1), Max: fnum(65535), EnforcedBy: EnforcedByAPI, Doc: "router status query port: 0 is off, -1 is the standard discovery port (set -1 only when udpbd is the only service)"},
+					{Name: "log_format", Type: TypeEnum, Default: "text", Values: []string{"text", "json"}, EnforcedBy: EnforcedByAPI},
+					{Name: "verbose", Type: TypeBool, Default: false, Doc: "verbose protocol logging"},
+				},
+			},
+			{
+				Name:       "webui",
+				UCISection: "webui",
+				Description: "Web dashboard. Reaching it is equivalent to shell " +
+					"access: it rewrites this config and restarts services.",
+				Fields: []FieldSpec{
+					{Name: "enabled", Type: TypeBool, Default: false, Doc: "start this service at boot"},
+					{Name: "port", Type: TypeInt, Default: 8082, Min: fnum(0), Max: fnum(65535), EnforcedBy: EnforcedByAPI, Doc: "HTTP port; 0 uses 8082 with fallback to an OS-assigned port"},
+					{Name: "bind", Type: TypeString, Default: "0.0.0.0", Doc: "a non-loopback bind needs auth_pass or insecure -- the init script refuses to start it otherwise"},
+					// auth_* and the two toggles below are consumed by the init
+					// script (mapped to CLI flags and WEBUI_PASS), not modelled in
+					// EdgeConfig: the dashboard gets its credentials at process
+					// start, not from reading this file back.
+					{Name: "auth_user", Type: TypeString, Default: "admin", Doc: "HTTP basic auth username"},
+					{Name: "auth_pass", Type: TypeString, Default: "", Doc: "HTTP basic auth password. Required for a non-loopback bind; passed to the process as WEBUI_PASS, never on the command line"},
+					{Name: "insecure", Type: TypeBool, Default: false, Doc: "accept a LAN bind with no password; a random one is generated and logged at every start"},
+					{Name: "run_as_root", Type: TypeBool, Default: false, Doc: "let the dashboard's Save and Restart work (uci commit + init.d restart are root's). At 0 the dashboard is read-only: status, config view and file browsing all work"},
+				},
+			},
+		},
+	}
+}
+
+// WriteSchema prints the schema as indented JSON for `ps2servers-edge
+// --dump-schema`.
+func WriteSchema(w io.Writer, version string) error {
+	out, err := json.MarshalIndent(schema(version), "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(append(out, '\n'))
+	return err
+}

--- a/native/ps2servers-edge/internal/webui/schema.go
+++ b/native/ps2servers-edge/internal/webui/schema.go
@@ -39,6 +39,17 @@ const (
 	EnforcedByServer = "server"
 )
 
+// schema_version history (the additive-only rule: consumers must keep working
+// when a new version appears):
+//
+//	1 -- initial
+//	2 -- FieldSpec gained "applies_when": the name of a sibling bool option
+//	     that must be enabled before the field's constraints (and value)
+//	     matter at all. metrics_period is the first user: the server parses
+//	     it only when metrics is on, so an unconditional range would have a
+//	     validator reject disabled-metrics configs the binary accepts.
+const schemaVersion = 2
+
 type FieldSpec struct {
 	Name       string   `json:"name"`
 	Type       string   `json:"type"`
@@ -51,6 +62,9 @@ type FieldSpec struct {
 	MinValue   string   `json:"min_value,omitempty"`   // duration lower bound
 	MaxValue   string   `json:"max_value,omitempty"`   // duration upper bound
 	EnforcedBy string   `json:"enforced_by,omitempty"`
+	// A sibling bool option that gates this field's constraints. Empty means
+	// unconditional.
+	AppliesWhen string `json:"applies_when,omitempty"`
 }
 
 type SectionSpec struct {
@@ -77,7 +91,7 @@ func inum(v int) *int         { return &v }
 // must equal DefaultConfig() -- the test walks both.
 func schema(version string) *Schema {
 	return &Schema{
-		SchemaVersion: 1,
+		SchemaVersion: schemaVersion,
 		Binary:        "ps2servers-edge",
 		Version:       version,
 		ConfigFile:    "/etc/config/ps2servers-edge",
@@ -105,7 +119,7 @@ func schema(version string) *Schema {
 					{Name: "no_compression", Type: TypeBool, Default: false, Doc: "serve CSO/ZSO as raw bytes. Diagnostic only -- games do not load this way"},
 					{Name: "compression_cache_size", Type: TypeInt, Default: 32, Min: fnum(0), Max: fnum(4096), EnforcedBy: EnforcedByServer, Doc: "decompressed blocks cached per open image; 0 disables"},
 					{Name: "metrics", Type: TypeBool, Default: false, Doc: "log periodic transfer counters to syslog"},
-					{Name: "metrics_period", Type: TypeDuration, Default: "1m", MinValue: "1s", MaxValue: "24h", EnforcedBy: EnforcedByServer, Doc: "how often metrics are logged; only used when metrics is 1"},
+					{Name: "metrics_period", Type: TypeDuration, Default: "1m", MinValue: "1s", MaxValue: "24h", EnforcedBy: EnforcedByServer, AppliesWhen: "metrics", Doc: "how often metrics are logged; only used when metrics is 1"},
 				},
 			},
 			{

--- a/native/ps2servers-edge/internal/webui/schema_test.go
+++ b/native/ps2servers-edge/internal/webui/schema_test.go
@@ -1,0 +1,217 @@
+package webui
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// The schema table is what tooling validates against, so it must not drift
+// from what the binary actually does. These tests pin it to the two things
+// that already enforce the config for real: DefaultConfig() (names, types,
+// defaults) and ValidateConfig (constraints marked enforced by the API).
+
+func jsonTagName(sf reflect.StructField) string {
+	return strings.Split(sf.Tag.Get("json"), ",")[0]
+}
+
+func sectionValue(cfg *EdgeConfig, section string) reflect.Value {
+	v := reflect.ValueOf(cfg).Elem()
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		if jsonTagName(t.Field(i)) == section {
+			return v.Field(i)
+		}
+	}
+	return reflect.Value{}
+}
+
+func setConfigValue(t *testing.T, cfg *EdgeConfig, key string, value any) {
+	t.Helper()
+	parts := strings.SplitN(key, ".", 2)
+	sv := sectionValue(cfg, parts[0])
+	if !sv.IsValid() {
+		t.Fatalf("no config section %q", parts[0])
+	}
+	st := sv.Type()
+	for i := 0; i < st.NumField(); i++ {
+		if jsonTagName(st.Field(i)) != parts[1] {
+			continue
+		}
+		fv := sv.Field(i)
+		rv := reflect.ValueOf(value)
+		if !rv.Type().ConvertibleTo(fv.Type()) {
+			t.Fatalf("%s: cannot assign %T to %s", key, value, fv.Type())
+		}
+		fv.Set(rv.Convert(fv.Type()))
+		return
+	}
+	t.Fatalf("no config field %q", key)
+}
+
+func configKeys(cfg *EdgeConfig) map[string]bool {
+	keys := map[string]bool{}
+	v := reflect.ValueOf(cfg).Elem()
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		sec := jsonTagName(t.Field(i))
+		ft := v.Field(i).Type()
+		for j := 0; j < ft.NumField(); j++ {
+			keys[sec+"."+jsonTagName(ft.Field(j))] = true
+		}
+	}
+	return keys
+}
+
+func TestSchemaMatchesDefaultConfig(t *testing.T) {
+	s := schema("test")
+	bySection := map[string]SectionSpec{}
+	for _, sec := range s.Sections {
+		bySection[sec.Name] = sec
+	}
+	cfg := DefaultConfig()
+	cv := reflect.ValueOf(cfg).Elem()
+	ct := cv.Type()
+	for i := 0; i < ct.NumField(); i++ {
+		secName := jsonTagName(ct.Field(i))
+		sec, ok := bySection[secName]
+		if !ok {
+			t.Errorf("schema has no section %q", secName)
+			continue
+		}
+		fields := map[string]FieldSpec{}
+		for _, f := range sec.Fields {
+			fields[f.Name] = f
+		}
+		fv, ft := cv.Field(i), cv.Field(i).Type()
+		for j := 0; j < ft.NumField(); j++ {
+			name := jsonTagName(ft.Field(j))
+			spec, ok := fields[name]
+			if !ok {
+				t.Errorf("%s.%s: missing from the schema", secName, name)
+				continue
+			}
+			if want := fv.Field(j).Interface(); !reflect.DeepEqual(spec.Default, want) {
+				t.Errorf("%s.%s: schema default %#v, DefaultConfig() has %#v",
+					secName, name, spec.Default, want)
+			}
+			switch fv.Field(j).Kind() {
+			case reflect.Bool:
+				if spec.Type != TypeBool {
+					t.Errorf("%s.%s: schema type %q, config is bool", secName, name, spec.Type)
+				}
+			case reflect.Int:
+				if spec.Type != TypeInt {
+					t.Errorf("%s.%s: schema type %q, config is int", secName, name, spec.Type)
+				}
+			case reflect.Float64:
+				if spec.Type != TypeFloat {
+					t.Errorf("%s.%s: schema type %q, config is float", secName, name, spec.Type)
+				}
+			case reflect.String:
+				switch spec.Type {
+				case TypeString, TypePath, TypeDuration, TypeEnum:
+				default:
+					t.Errorf("%s.%s: schema type %q, config is string", secName, name, spec.Type)
+				}
+			}
+		}
+	}
+
+	// Reverse direction: a schema field that EdgeConfig does not model must be
+	// one of the known init-script-consumed webui options, or it is a typo.
+	extras := map[string]bool{
+		"webui.auth_user": true, "webui.auth_pass": true,
+		"webui.insecure": true, "webui.run_as_root": true,
+	}
+	modelled := configKeys(cfg)
+	for _, sec := range s.Sections {
+		for _, f := range sec.Fields {
+			key := sec.Name + "." + f.Name
+			if !modelled[key] && !extras[key] {
+				t.Errorf("%s is in the schema but not in EdgeConfig, and is not a known extra", key)
+			}
+		}
+	}
+}
+
+func TestSchemaUCISectionNames(t *testing.T) {
+	// The uci set path is ps2servers-edge.<uci_section>.<option>; the OpenWrt
+	// init script loads sections by these names, so they are contract.
+	want := map[string]string{"udpfs": "main", "smb": "smb", "udpbd": "udpbd", "webui": "webui"}
+	got := map[string]string{}
+	for _, sec := range schema("test").Sections {
+		got[sec.Name] = sec.UCISection
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("uci section names: got %v, want %v", got, want)
+	}
+}
+
+func TestSchemaConstraintsAreEnforcedByTheAPI(t *testing.T) {
+	for _, sec := range schema("test").Sections {
+		for _, f := range sec.Fields {
+			if f.EnforcedBy != EnforcedByAPI {
+				continue
+			}
+			key := sec.Name + "." + f.Name
+			if len(f.Values) > 0 {
+				cfg := DefaultConfig()
+				setConfigValue(t, cfg, key, "not-a-valid-value")
+				if err := ValidateConfig(cfg); err == nil {
+					t.Errorf("%s: ValidateConfig accepted an invalid enum value", key)
+				}
+				for _, v := range f.Values {
+					cfg := DefaultConfig()
+					setConfigValue(t, cfg, key, v)
+					if err := ValidateConfig(cfg); err != nil {
+						t.Errorf("%s: ValidateConfig rejected valid value %q: %v", key, v, err)
+					}
+				}
+			}
+			if f.Min != nil {
+				cfg := DefaultConfig()
+				setConfigValue(t, cfg, key, *f.Min-1)
+				if err := ValidateConfig(cfg); err == nil {
+					t.Errorf("%s: ValidateConfig accepted %v, below min %v", key, *f.Min-1, *f.Min)
+				}
+			}
+			if f.Max != nil {
+				cfg := DefaultConfig()
+				setConfigValue(t, cfg, key, *f.Max+1)
+				if err := ValidateConfig(cfg); err == nil {
+					t.Errorf("%s: ValidateConfig accepted %v, above max %v", key, *f.Max+1, *f.Max)
+				}
+			}
+		}
+	}
+}
+
+func TestWriteSchemaProducesValidJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteSchema(&buf, "v9.9.9-test"); err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("--dump-schema produced invalid JSON: %v", err)
+	}
+	if doc["schema_version"] != float64(1) {
+		t.Errorf("schema_version: got %v", doc["schema_version"])
+	}
+	if doc["binary"] != "ps2servers-edge" {
+		t.Errorf("binary: got %v", doc["binary"])
+	}
+	if doc["version"] != "v9.9.9-test" {
+		t.Errorf("version did not pass through: got %v", doc["version"])
+	}
+	if doc["config_file"] != "/etc/config/ps2servers-edge" {
+		t.Errorf("config_file: got %v", doc["config_file"])
+	}
+	sections, ok := doc["sections"].([]any)
+	if !ok || len(sections) != 4 {
+		t.Fatalf("sections: got %v", doc["sections"])
+	}
+}

--- a/native/ps2servers-edge/internal/webui/schema_test.go
+++ b/native/ps2servers-edge/internal/webui/schema_test.go
@@ -189,6 +189,43 @@ func TestSchemaConstraintsAreEnforcedByTheAPI(t *testing.T) {
 	}
 }
 
+func TestMetricsPeriodIsConditionalOnMetrics(t *testing.T) {
+	// The binary parses metrics_period only when metrics is on; an
+	// unconditional range in the schema would have a validator reject
+	// disabled-metrics configs the binary accepts.
+	for _, sec := range schema("test").Sections {
+		if sec.Name != "udpfs" {
+			continue
+		}
+		for _, f := range sec.Fields {
+			if f.Name == "metrics_period" {
+				if f.AppliesWhen != "metrics" {
+					t.Errorf("metrics_period applies_when: got %q, want %q", f.AppliesWhen, "metrics")
+				}
+				return
+			}
+		}
+	}
+	t.Error("udpfs.metrics_period is missing from the schema")
+}
+
+func TestSchemaAppliesWhenReferencesARealBoolSibling(t *testing.T) {
+	for _, sec := range schema("test").Sections {
+		bools := map[string]bool{}
+		for _, f := range sec.Fields {
+			if f.Type == TypeBool {
+				bools[f.Name] = true
+			}
+		}
+		for _, f := range sec.Fields {
+			if f.AppliesWhen != "" && !bools[f.AppliesWhen] {
+				t.Errorf("%s.%s: applies_when %q is not a bool option in this section",
+					sec.Name, f.Name, f.AppliesWhen)
+			}
+		}
+	}
+}
+
 func TestWriteSchemaProducesValidJSON(t *testing.T) {
 	var buf bytes.Buffer
 	if err := WriteSchema(&buf, "v9.9.9-test"); err != nil {
@@ -198,7 +235,7 @@ func TestWriteSchemaProducesValidJSON(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
 		t.Fatalf("--dump-schema produced invalid JSON: %v", err)
 	}
-	if doc["schema_version"] != float64(1) {
+	if doc["schema_version"] != float64(schemaVersion) {
 		t.Errorf("schema_version: got %v", doc["schema_version"])
 	}
 	if doc["binary"] != "ps2servers-edge" {

--- a/packaging/openwrt/README.md
+++ b/packaging/openwrt/README.md
@@ -18,6 +18,13 @@ The `procd` service:
 - logs through the normal OpenWrt service logger;
 - serves read-only.
 
+The UCI file is the stable configuration contract: section and option names
+are additive-only, so tooling that generates it can rely on them across
+updates. `ps2servers-edge --dump-schema` prints the whole surface (sections,
+options, types, defaults, ranges, and which layer rejects a bad value) as
+JSON — validate generated configs against the binary being shipped rather
+than a hardcoded copy of the option list.
+
 For low-flash routers, install the package metadata/init files normally and place
 the executable or game data on attached USB storage. Update the service path with
 an init-script override if the executable itself lives on USB.


### PR DESCRIPTION
## Summary

For the EtherDrive-style use case: firmware that embeds ps2servers-edge and generates `/etc/config/ps2servers-edge` needs to validate against the exact binary it ships, not a hardcoded copy of the option list that can drift across updates.

`ps2servers-edge --dump-schema` prints the whole configuration surface as JSON:

- all 4 sections (`udpfs`/`smb`/`udpbd`/`webui`) with their UCI section names (`main`/`smb`/`udpbd`/`webui`) — 41 options total
- per option: `name`, `type` (bool/int/float/string/path/duration/enum), `default`, and constraints (`min`/`max`/`multiple_of`/`min_value`/`max_value`/`values`)
- `enforced_by`: which layer rejects a bad value first — `webui-api` (ValidateConfig refuses it, so the dashboard's Save reports it too) or `server` (only the binary refuses at start)
- `schema_version` (starts at 1) and the binary `version`

The stated contract: section and option names are **additive-only** — new options may appear, existing ones are never renamed or removed, so `schema_version` only bumps on additions and generated configs keep working across image updates.

## Anti-drift design

The table lives in `internal/webui/schema.go` next to the EdgeConfig model it describes. `schema_test.go` pins it to the two things that already enforce config for real:

- walks `DefaultConfig()` via reflection — every modelled field must be in the schema with a matching type and default; unmodelled schema fields must be the four known init-script-consumed webui options (`auth_user`, `auth_pass`, `insecure`, `run_as_root`)
- probes `ValidateConfig` with below-min / above-max / invalid-enum values for every constraint marked `webui-api`, and confirms every valid enum value passes

Editing the config model without updating the schema (or vice versa) fails the test suite instead of shipping a stale contract.

## Testing

- 4 new tests in `internal/webui/schema_test.go`; `go vet` clean; full `go test ./...` green
- Built the binary and ran `--dump-schema` for real: valid JSON, 4 sections, spot-checked field output
- Docs: `docs/EDGE.md` (Tooling & automation section) and `packaging/openwrt/README.md` (the contract + how to validate against it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dump-schema` to output the Web UI configuration schema as formatted JSON.
  * Schema includes configuration sections, options, types, defaults, allowed values, ranges, and validation details.

* **Documentation**
  * Documented schema export and additive-only configuration requirements.
  * Added usage guidance for generating and validating configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->