### PR TITLE
fix(smbv1): support fresh-share writes and folder creation

### DIFF
--- a/native/ps2servers-edge/internal/smb/handlers.go
+++ b/native/ps2servers-edge/internal/smb/handlers.go
@@ -8,6 +8,22 @@ import (
 	"strings"
 )
 
+const (
+	fileSupersede   uint32 = 0x00000000
+	fileOpen        uint32 = 0x00000001
+	fileCreate      uint32 = 0x00000002
+	fileOpenIf      uint32 = 0x00000003
+	fileOverwrite   uint32 = 0x00000004
+	fileOverwriteIf uint32 = 0x00000005
+
+	fileSuperseded  uint32 = 0x00000000
+	fileOpened      uint32 = 0x00000001
+	fileCreated     uint32 = 0x00000002
+	fileOverwritten uint32 = 0x00000003
+
+	fileDirectoryFile uint32 = 0x00000001
+)
+
 // asciiz reads a NUL-terminated ASCII string from the front of b.
 //
 // Every string in this protocol is single-byte OEM/ASCII: the reply Flags2
@@ -239,10 +255,21 @@ func (c *conn) ntCreateAndX(r *req) reply {
 	if sh == nil {
 		return fail(StatusObjectNameNotFound)
 	}
-	// NameLength sits after AndX(4) + Reserved(1).
+	if len(r.params) < 39 {
+		return fail(StatusAccessDenied)
+	}
+
 	nameLen := int(u16(r.params, 5))
+	disposition := u32(r.params, 35)
+	var createOptions uint32
+	if len(r.params) >= 43 {
+		createOptions = u32(r.params, 39)
+	}
+	if disposition > fileOverwriteIf {
+		return fail(StatusAccessDenied)
+	}
+
 	raw := r.data
-	// ASCII with unicode off: the name may be preceded by a single pad byte.
 	if len(raw) > 0 && raw[0] == 0x00 {
 		raw = raw[1:]
 	}
@@ -250,22 +277,88 @@ func (c *conn) ntCreateAndX(r *req) reply {
 		nameLen = len(raw)
 	}
 	name := asciiz(raw[:nameLen])
-
-	local, ok := sh.resolve(name, false)
+	local, ok := sh.resolve(name, true)
 	if !ok {
-		return fail(StatusObjectNameNotFound)
+		return fail(StatusAccessDenied)
 	}
+
+	info, statErr := os.Stat(local)
+	exists := statErr == nil
+	if statErr != nil && !os.IsNotExist(statErr) {
+		return fail(StatusAccessDenied)
+	}
+	requestedDir := createOptions&fileDirectoryFile != 0
+	action := fileOpened
+
+	if exists {
+		isDir := info.IsDir()
+		if disposition == fileCreate {
+			return fail(StatusObjectNameCollision)
+		}
+		if requestedDir && !isDir {
+			return fail(StatusAccessDenied)
+		}
+		switch disposition {
+		case fileSupersede, fileOverwrite, fileOverwriteIf:
+			if c.server.cfg.ReadOnly || isDir {
+				return fail(StatusAccessDenied)
+			}
+			fh, err := os.OpenFile(local, os.O_WRONLY|os.O_TRUNC, 0)
+			if err != nil {
+				return fail(StatusAccessDenied)
+			}
+			if err := fh.Close(); err != nil {
+				return fail(StatusAccessDenied)
+			}
+			if disposition == fileSupersede {
+				action = fileSuperseded
+			} else {
+				action = fileOverwritten
+			}
+		}
+	} else {
+		if disposition == fileOpen || disposition == fileOverwrite {
+			return fail(StatusObjectNameNotFound)
+		}
+		if c.server.cfg.ReadOnly {
+			return fail(StatusAccessDenied)
+		}
+		parentInfo, err := os.Stat(filepath.Dir(local))
+		if err != nil || !parentInfo.IsDir() {
+			return fail(StatusObjectNameNotFound)
+		}
+		if requestedDir {
+			if err := os.Mkdir(local, 0o777); err != nil {
+				if os.IsExist(err) {
+					return fail(StatusObjectNameCollision)
+				}
+				return fail(StatusAccessDenied)
+			}
+		} else {
+			fh, err := os.OpenFile(local, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o666)
+			if err != nil {
+				if os.IsExist(err) {
+					return fail(StatusObjectNameCollision)
+				}
+				return fail(StatusAccessDenied)
+			}
+			if err := fh.Close(); err != nil {
+				return fail(StatusAccessDenied)
+			}
+		}
+		action = fileCreated
+	}
+
 	info, err := os.Stat(local)
 	if err != nil {
-		c.server.cfg.Log.Debug("SMB ntcreate miss", map[string]any{"name": name})
-		return fail(StatusObjectNameNotFound)
+		return fail(StatusAccessDenied)
 	}
 	isDir := info.IsDir()
 	of := &openFile{path: local, isDir: isDir}
 	if !isDir {
 		fh, err := os.Open(local)
 		if err != nil {
-			return fail(StatusObjectNameNotFound)
+			return fail(StatusAccessDenied)
 		}
 		of.fh = fh
 		of.size = info.Size()
@@ -283,26 +376,23 @@ func (c *conn) ntCreateAndX(r *req) reply {
 
 	p := make([]byte, 0, 68)
 	p = append(p, ComNone, 0)
-	p = le16(p, 0)           // AndXOffset
-	p = append(p, 0)         // OplockLevel
-	p = le16(p, fid)         // FID
-	p = le32(p, 1)           // CreateAction = FILE_OPENED
-	for i := 0; i < 4; i++ { // Creation/Access/Write/Change
+	p = le16(p, 0)
+	p = append(p, 0)
+	p = le16(p, fid)
+	p = le32(p, action)
+	for i := 0; i < 4; i++ {
 		p = le64(p, uint64(ft))
 	}
-	p = le32(p, attrs)           // ExtFileAttributes
-	p = le64(p, uint64(of.size)) // AllocationSize
-	p = le64(p, uint64(of.size)) // EndOfFile
-	p = le16(p, 0)               // FileType
-	p = le16(p, 0)               // IPCState
+	p = le32(p, attrs)
+	p = le64(p, uint64(of.size))
+	p = le64(p, uint64(of.size))
+	p = le16(p, 0)
+	p = le16(p, 0)
 	if isDir {
 		p = append(p, 1)
 	} else {
 		p = append(p, 0)
 	}
-	// The parameter block must be a whole number of 16-bit words; the trailing
-	// IsDirectory byte makes it odd, so it is padded. buildBody divides by two
-	// to produce WordCount, and an odd length would understate it.
 	if len(p)%2 != 0 {
 		p = append(p, 0)
 	}
@@ -429,6 +519,42 @@ func (c *conn) closeFile(r *req) reply {
 			}
 		}
 	}
+	return reply{params: []byte{}, data: []byte{}}
+}
+
+func (c *conn) createDirectory(r *req) reply {
+	if c.server.cfg.ReadOnly {
+		return fail(StatusAccessDenied)
+	}
+	sh := c.shareForTID(r.tid)
+	if sh == nil {
+		return fail(StatusObjectNameNotFound)
+	}
+	raw := r.data
+	if len(raw) > 0 && raw[0] == 0x04 {
+		raw = raw[1:]
+	}
+	name := asciiz(raw)
+	local, ok := sh.resolve(name, true)
+	if !ok {
+		return fail(StatusAccessDenied)
+	}
+	if _, err := os.Stat(local); err == nil {
+		return fail(StatusObjectNameCollision)
+	} else if !os.IsNotExist(err) {
+		return fail(StatusAccessDenied)
+	}
+	parentInfo, err := os.Stat(filepath.Dir(local))
+	if err != nil || !parentInfo.IsDir() {
+		return fail(StatusObjectNameNotFound)
+	}
+	if err := os.Mkdir(local, 0o777); err != nil {
+		if os.IsExist(err) {
+			return fail(StatusObjectNameCollision)
+		}
+		return fail(StatusAccessDenied)
+	}
+	c.server.cfg.Log.Debug("SMB mkdir", map[string]any{"name": name})
 	return reply{params: []byte{}, data: []byte{}}
 }
 

--- a/native/ps2servers-edge/internal/smb/server.go
+++ b/native/ps2servers-edge/internal/smb/server.go
@@ -610,6 +610,8 @@ func (c *conn) dispatch(r *req) reply {
 	case ComLogoffAndX:
 		c.dropSearches()
 		return reply{params: []byte{ComNone, 0, 0, 0}, data: []byte{}}
+	case ComCreateDirectory:
+		return c.createDirectory(r)
 	case ComOpenAndX:
 		return c.openAndX(r)
 	case ComNTCreateAndX:

--- a/native/ps2servers-edge/internal/smb/wire.go
+++ b/native/ps2servers-edge/internal/smb/wire.go
@@ -22,6 +22,7 @@ var Magic = [4]byte{0xFF, 'S', 'M', 'B'}
 // Command codes, and only the ones this server answers. An unlisted command is
 // refused rather than guessed at.
 const (
+	ComCreateDirectory      = 0x00
 	ComClose                = 0x04
 	ComCheckDirectory       = 0x10
 	ComTransaction          = 0x25
@@ -45,10 +46,11 @@ const (
 
 // NT status codes used in replies.
 const (
-	StatusSuccess            uint32 = 0x00000000
-	StatusNotImplemented     uint32 = 0xC0000002
-	StatusAccessDenied       uint32 = 0xC0000022
-	StatusObjectNameNotFound uint32 = 0xC0000034
+	StatusSuccess             uint32 = 0x00000000
+	StatusNotImplemented      uint32 = 0xC0000002
+	StatusAccessDenied        uint32 = 0xC0000022
+	StatusObjectNameNotFound  uint32 = 0xC0000034
+	StatusObjectNameCollision uint32 = 0xC0000035
 )
 
 const (

--- a/native/ps2servers-edge/internal/smb/write_semantics_test.go
+++ b/native/ps2servers-edge/internal/smb/write_semantics_test.go
@@ -1,0 +1,123 @@
+package smb
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func ntCreateParams(name string, disposition uint32) ([]byte, []byte) {
+	p := make([]byte, 48)
+	binary.LittleEndian.PutUint16(p[5:], uint16(len(name)))
+	binary.LittleEndian.PutUint32(p[35:], disposition)
+	return p, append([]byte{0}, []byte(name)...)
+}
+
+func writeParams(fid uint16, payload []byte) []byte {
+	p := make([]byte, 28)
+	binary.LittleEndian.PutUint16(p[4:], fid)
+	binary.LittleEndian.PutUint16(p[20:], uint16(len(payload)))
+	binary.LittleEndian.PutUint16(p[22:], uint16(32+1+len(p)+2))
+	return p
+}
+
+func TestFreshShareCreatesDirectoryAndNewCFG(t *testing.T) {
+	root := t.TempDir()
+	srv := startServer(t, root, false)
+	cl := dial(t, srv)
+	cl.handshake("games")
+
+	h, _, _ := cl.call(ComCreateDirectory, nil, []byte("\x04CFG\x00"))
+	if h.Status != StatusSuccess {
+		t.Fatalf("CREATE_DIRECTORY status %#x", h.Status)
+	}
+	if info, err := os.Stat(filepath.Join(root, "CFG")); err != nil || !info.IsDir() {
+		t.Fatalf("CFG was not created: info=%v err=%v", info, err)
+	}
+
+	p, d := ntCreateParams(`CFG\SLUS_000.00.cfg`, fileOpenIf)
+	h, rp, _ := cl.call(ComNTCreateAndX, p, d)
+	if h.Status != StatusSuccess {
+		t.Fatalf("NT_CREATE OPEN_IF status %#x", h.Status)
+	}
+	fid := binary.LittleEndian.Uint16(rp[5:])
+	if action := binary.LittleEndian.Uint32(rp[7:]); action != fileCreated {
+		t.Fatalf("CreateAction=%d want FILE_CREATED", action)
+	}
+	payload := []byte("compat=3\r\n")
+	h, _, _ = cl.call(ComWriteAndX, writeParams(fid, payload), payload)
+	if h.Status != StatusSuccess {
+		t.Fatalf("WRITE_ANDX status %#x", h.Status)
+	}
+	closeParams := make([]byte, 2)
+	binary.LittleEndian.PutUint16(closeParams, fid)
+	cl.call(ComClose, closeParams, nil)
+
+	got, err := os.ReadFile(filepath.Join(root, "CFG", "SLUS_000.00.cfg"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("cfg=%q want %q", got, payload)
+	}
+}
+
+func TestOverwriteIfTruncatesOldTail(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "CFG"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "CFG", "SLUS_000.00.cfg")
+	if err := os.WriteFile(target, []byte("compat=7\r\nvmc=old-long-value\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := startServer(t, root, false)
+	cl := dial(t, srv)
+	cl.handshake("games")
+	p, d := ntCreateParams(`CFG\SLUS_000.00.cfg`, fileOverwriteIf)
+	h, rp, _ := cl.call(ComNTCreateAndX, p, d)
+	if h.Status != StatusSuccess {
+		t.Fatalf("NT_CREATE OVERWRITE_IF status %#x", h.Status)
+	}
+	if action := binary.LittleEndian.Uint32(rp[7:]); action != fileOverwritten {
+		t.Fatalf("CreateAction=%d want FILE_OVERWRITTEN", action)
+	}
+	if info, err := os.Stat(target); err != nil || info.Size() != 0 {
+		t.Fatalf("target not truncated at create: info=%v err=%v", info, err)
+	}
+	fid := binary.LittleEndian.Uint16(rp[5:])
+	payload := []byte("compat=1\r\n")
+	h, _, _ = cl.call(ComWriteAndX, writeParams(fid, payload), payload)
+	if h.Status != StatusSuccess {
+		t.Fatalf("WRITE_ANDX status %#x", h.Status)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("stale tail survived: got %q want %q", got, payload)
+	}
+}
+
+func TestReadOnlyRefusesCreates(t *testing.T) {
+	root := t.TempDir()
+	srv := startServer(t, root, true)
+	cl := dial(t, srv)
+	cl.handshake("games")
+
+	h, _, _ := cl.call(ComCreateDirectory, nil, []byte("\x04CFG\x00"))
+	if h.Status != StatusAccessDenied {
+		t.Fatalf("CREATE_DIRECTORY status %#x want ACCESS_DENIED", h.Status)
+	}
+	p, d := ntCreateParams("new.cfg", fileOpenIf)
+	h, _, _ = cl.call(ComNTCreateAndX, p, d)
+	if h.Status != StatusAccessDenied {
+		t.Fatalf("NT_CREATE status %#x want ACCESS_DENIED", h.Status)
+	}
+	if _, err := os.Stat(filepath.Join(root, "new.cfg")); !os.IsNotExist(err) {
+		t.Fatalf("read-only server created new.cfg: %v", err)
+	}
+}

--- a/smbv1_server/smbserver_opl.py
+++ b/smbv1_server/smbserver_opl.py
@@ -30,6 +30,7 @@ import time
 SMB_MAGIC = b"\xffSMB"
 
 # Commands
+SMB_COM_CREATE_DIRECTORY = 0x00
 SMB_COM_CLOSE = 0x04
 SMB_COM_CHECK_DIRECTORY = 0x10
 SMB_COM_QUERY_INFORMATION_DISK = 0x80
@@ -53,6 +54,7 @@ STATUS_SUCCESS = 0x00000000
 STATUS_NOT_IMPLEMENTED = 0xC0000002
 STATUS_ACCESS_DENIED = 0xC0000022
 STATUS_OBJECT_NAME_NOT_FOUND = 0xC0000034
+STATUS_OBJECT_NAME_COLLISION = 0xC0000035
 STATUS_LOGON_FAILURE = 0xC000006D
 
 # NEGOTIATE response capabilities. UNICODE deliberately OFF so every string stays ASCII/OEM --
@@ -71,6 +73,23 @@ FLAGS1_REPLY = 0x80  # SERVER_TO_REDIR
 # Ext file attributes
 ATTR_NORMAL = 0x80
 ATTR_DIRECTORY = 0x10
+
+# NT_CREATE_ANDX CreateDisposition values. These are not bit flags.
+FILE_SUPERSEDE = 0x00000000
+FILE_OPEN = 0x00000001
+FILE_CREATE = 0x00000002
+FILE_OPEN_IF = 0x00000003
+FILE_OVERWRITE = 0x00000004
+FILE_OVERWRITE_IF = 0x00000005
+
+# NT_CREATE_ANDX CreateAction response values.
+FILE_SUPERSEDED = 0x00000000
+FILE_OPENED = 0x00000001
+FILE_CREATED = 0x00000002
+FILE_OVERWRITTEN = 0x00000003
+
+# CreateOptions bits used here.
+FILE_DIRECTORY_FILE = 0x00000001
 
 # TRANS2 subcommands
 TRANS2_FIND_FIRST2 = 0x01
@@ -623,43 +642,97 @@ def h_open_andx(conn, r):
 
 
 def h_nt_create_andx(conn, r):
-    # smbman opens files (cover art / cfg) because we advertised CAP_NT_SMBS.
+    # OPL's ioman layer uses NT_CREATE_ANDX for ordinary opens AND for
+    # O_CREAT/O_TRUNC. The old server treated every request as OPEN:
+    # a missing file returned NAME_NOT_FOUND and overwrite requests did
+    # not truncate, so a fresh CFG/VMC could never be born and shorter
+    # rewrites left stale tail bytes behind.
     sh = _share_for_tid(conn, r)
     if sh is None:
         return None, None, STATUS_OBJECT_NAME_NOT_FOUND
-    name_len = struct.unpack_from("<H", r.params, 5)[0]  # NameLength after AndX(4)+Reserved(1)
-    d = r.data
-    # ASCII (unicode off): name is name_len bytes, possibly after a 1-byte pad.
-    raw = d
+    if len(r.params) < 39:
+        return None, None, STATUS_ACCESS_DENIED
+
+    name_len = struct.unpack_from("<H", r.params, 5)[0]
+    disposition = struct.unpack_from("<I", r.params, 35)[0]
+    create_options = struct.unpack_from("<I", r.params, 39)[0] if len(r.params) >= 43 else 0
+    if disposition > FILE_OVERWRITE_IF:
+        return None, None, STATUS_ACCESS_DENIED
+
+    raw = r.data
     if raw[:1] == b"\x00":
         raw = raw[1:]
     name = raw[:name_len].split(b"\x00", 1)[0].decode("ascii", "ignore")
     local = sh.resolve(name)
-    if local is None or not os.path.exists(local):
-        log("ntcreate MISS", repr(name))
-        return None, None, STATUS_OBJECT_NAME_NOT_FOUND
+    if local is None:
+        return None, None, STATUS_ACCESS_DENIED
+
+    exists = os.path.exists(local)
+    requested_dir = bool(create_options & FILE_DIRECTORY_FILE)
+    action = FILE_OPENED
+
+    if exists:
+        is_dir = os.path.isdir(local)
+        if disposition == FILE_CREATE:
+            return None, None, STATUS_OBJECT_NAME_COLLISION
+        if requested_dir and not is_dir:
+            return None, None, STATUS_ACCESS_DENIED
+        if disposition in (FILE_SUPERSEDE, FILE_OVERWRITE, FILE_OVERWRITE_IF):
+            if conn.server.read_only or is_dir:
+                return None, None, STATUS_ACCESS_DENIED
+            try:
+                # Truncate during CREATE, before WRITE_ANDX, matching
+                # O_TRUNC and preventing stale tail bytes on shorter CFGs.
+                with open(local, "wb"):
+                    pass
+            except OSError:
+                return None, None, STATUS_ACCESS_DENIED
+            action = FILE_SUPERSEDED if disposition == FILE_SUPERSEDE else FILE_OVERWRITTEN
+    else:
+        if disposition in (FILE_OPEN, FILE_OVERWRITE):
+            return None, None, STATUS_OBJECT_NAME_NOT_FOUND
+        if conn.server.read_only:
+            return None, None, STATUS_ACCESS_DENIED
+        parent = os.path.dirname(local)
+        if not os.path.isdir(parent):
+            return None, None, STATUS_OBJECT_NAME_NOT_FOUND
+        try:
+            if requested_dir:
+                os.mkdir(local)
+            else:
+                with open(local, "xb"):
+                    pass
+        except FileExistsError:
+            return None, None, STATUS_OBJECT_NAME_COLLISION
+        except OSError:
+            return None, None, STATUS_ACCESS_DENIED
+        action = FILE_CREATED
+
     is_dir = os.path.isdir(local)
-    of = OpenFile(local, is_dir=is_dir)
+    try:
+        of = OpenFile(local, is_dir=is_dir)
+        mtime = to_filetime(os.path.getmtime(local))
+    except OSError:
+        return None, None, STATUS_ACCESS_DENIED
     fid = conn.alloc_fid()
     conn.files[fid] = of
     size = of.size
-    mtime = to_filetime(os.path.getmtime(local))
-    log("ntcreate", repr(name), "fid", fid, "dir" if is_dir else "size %d" % size)
+    log("ntcreate", repr(name), "fid", fid,
+        "dir" if is_dir else "size %d" % size, "action", action)
     params = struct.pack(
         "<BBHBHIqqqqIQQHHB",
-        SMB_COM_NONE, 0, 0,                 # AndX none
-        0,                                  # OplockLevel
-        fid,                                # FID
-        1,                                  # CreateAction = FILE_OPENED
-        mtime, mtime, mtime, mtime,         # Creation/Access/Write/Change times
-        ATTR_DIRECTORY if is_dir else ATTR_NORMAL,  # ExtFileAttributes
-        size, size,                         # AllocationSize, EndOfFile
-        0,                                  # FileType
-        0,                                  # IPCState
-        1 if is_dir else 0,                 # IsDirectory
+        SMB_COM_NONE, 0, 0,
+        0,
+        fid,
+        action,
+        mtime, mtime, mtime, mtime,
+        ATTR_DIRECTORY if is_dir else ATTR_NORMAL,
+        size, size,
+        0,
+        0,
+        1 if is_dir else 0,
     )
     return params, b"", STATUS_SUCCESS
-
 
 def h_read_andx(conn, r):
     # HOT PATH. Response struct ReadAndXResponse_t is 59 bytes; data starts at offset 59
@@ -749,6 +822,34 @@ def h_query_disk(conn, r):
     # All u16 to avoid overflow; smbman just needs non-zero free space.
     params = struct.pack("<HHHHH", 0xFFFF, 64, 512, 0xFFFF, 0)
     return params, b"", STATUS_SUCCESS
+
+
+def h_create_directory(conn, r):
+    # RiptOPL calls mkdir() for CFG/THM/LNG/ART/VMC/... on SMB connect.
+    # SMB_COM_CREATE_DIRECTORY carries BufferFormat=0x04 before the
+    # NUL-terminated share-relative directory name.
+    if conn.server.read_only:
+        return None, None, STATUS_ACCESS_DENIED
+    sh = _share_for_tid(conn, r)
+    if sh is None:
+        return None, None, STATUS_OBJECT_NAME_NOT_FOUND
+    raw = r.data[1:] if r.data[:1] == b"\x04" else r.data
+    name = raw.split(b"\x00", 1)[0].decode("ascii", "ignore")
+    local = sh.resolve(name)
+    if local is None:
+        return None, None, STATUS_ACCESS_DENIED
+    if os.path.exists(local):
+        return None, None, STATUS_OBJECT_NAME_COLLISION
+    if not os.path.isdir(os.path.dirname(local)):
+        return None, None, STATUS_OBJECT_NAME_NOT_FOUND
+    try:
+        os.mkdir(local)
+    except FileExistsError:
+        return None, None, STATUS_OBJECT_NAME_COLLISION
+    except OSError:
+        return None, None, STATUS_ACCESS_DENIED
+    log("mkdir", repr(name))
+    return b"", b"", STATUS_SUCCESS
 
 
 def h_check_directory(conn, r):
@@ -972,6 +1073,7 @@ def h_transaction(conn, r):
 # Dispatch
 # --------------------------------------------------------------------------------------------
 HANDLERS = {
+    SMB_COM_CREATE_DIRECTORY: h_create_directory,
     SMB_COM_NEGOTIATE: h_negotiate,
     SMB_COM_SESSION_SETUP_ANDX: h_session_setup,
     SMB_COM_TREE_CONNECT_ANDX: h_tree_connect,

--- a/tests/test_smb_wire_parity.py
+++ b/tests/test_smb_wire_parity.py
@@ -151,6 +151,7 @@ class SmbWireParity(unittest.TestCase):
         # A transposed opcode would send a valid-looking reply to the wrong
         # request, which is far harder to diagnose than a malformed one.
         pairs = [
+            ("ComCreateDirectory", "SMB_COM_CREATE_DIRECTORY"),
             ("ComClose", "SMB_COM_CLOSE"), ("ComCheckDirectory", "SMB_COM_CHECK_DIRECTORY"),
             ("ComTransaction", "SMB_COM_TRANSACTION"), ("ComEcho", "SMB_COM_ECHO"),
             ("ComOpenAndX", "SMB_COM_OPEN_ANDX"), ("ComReadAndX", "SMB_COM_READ_ANDX"),
@@ -167,6 +168,7 @@ class SmbWireParity(unittest.TestCase):
             ("StatusNotImplemented", "STATUS_NOT_IMPLEMENTED"),
             ("StatusAccessDenied", "STATUS_ACCESS_DENIED"),
             ("StatusObjectNameNotFound", "STATUS_OBJECT_NAME_NOT_FOUND"),
+            ("StatusObjectNameCollision", "STATUS_OBJECT_NAME_COLLISION"),
             ("Flags2", "FLAGS2"), ("Flags1Reply", "FLAGS1_REPLY"),
         ]
         body = "\n".join(

--- a/tests/test_smbv1_write_semantics.py
+++ b/tests/test_smbv1_write_semantics.py
@@ -1,0 +1,164 @@
+"""Regression coverage for writable SMBv1 operations used by OPL/RiptOPL.
+
+Issue #180 exposed a gap that read/boot tests could not see: the server could
+modify an existing file, but it could not create OPL's folders or create and
+truncate per-game CFG files on a fresh share.  These tests drive the same SMB1
+handlers with the create dispositions OPL can issue and verify the filesystem,
+not merely the reply header.
+"""
+
+import importlib.util
+import os
+import struct
+import sys
+import tempfile
+import types
+import unittest
+
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SERVER = os.path.join(_ROOT, "smbv1_server", "smbserver_opl.py")
+
+
+def _load_server():
+    spec = importlib.util.spec_from_file_location("smbv1_write_ref", _SERVER)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _request(*, tid=1, params=b"", data=b"", msg=b""):
+    return types.SimpleNamespace(tid=tid, params=params, data=data, msg=msg)
+
+
+def _ntcreate_request(server, name, disposition, create_options=0):
+    # SMB_COM_NT_CREATE_ANDX request parameters are 48 bytes.  The fields the
+    # server needs are NameLength at byte 5, CreateDisposition at byte 35 and
+    # CreateOptions at byte 39.  Unicode is not negotiated, so the pathname is
+    # single-byte and OPL may precede it with one alignment byte.
+    encoded = name.encode("ascii")
+    params = bytearray(48)
+    struct.pack_into("<H", params, 5, len(encoded))
+    struct.pack_into("<I", params, 35, disposition)
+    struct.pack_into("<I", params, 39, create_options)
+    return _request(params=bytes(params), data=b"\x00" + encoded)
+
+
+def _write_request(fid, payload, offset=0):
+    params = bytearray(28)
+    struct.pack_into("<H", params, 4, fid)
+    struct.pack_into("<I", params, 6, offset & 0xFFFFFFFF)
+    struct.pack_into("<H", params, 18, (len(payload) >> 16) & 0xFFFF)
+    struct.pack_into("<H", params, 20, len(payload) & 0xFFFF)
+    data_offset = 64
+    struct.pack_into("<H", params, 22, data_offset)
+    struct.pack_into("<I", params, 24, (offset >> 32) & 0xFFFFFFFF)
+    return _request(params=bytes(params), msg=(b"\x00" * data_offset) + payload)
+
+
+class SMBv1WriteSemantics(unittest.TestCase):
+    def setUp(self):
+        self.smb = _load_server()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = self.tmp.name
+        share = self.smb.Share("games", self.root)
+        server = self.smb.SmbServer({"games": share}, read_only=False)
+        self.conn = self.smb.Conn(server)
+        self.conn.trees[1] = share
+
+    def tearDown(self):
+        self.conn.cleanup()
+        self.tmp.cleanup()
+
+    def test_create_directory_on_fresh_share(self):
+        req = _request(data=b"\x04CFG\x00")
+        params, data, status = self.smb.h_create_directory(self.conn, req)
+        self.assertEqual(status, self.smb.STATUS_SUCCESS)
+        self.assertEqual(params, b"")
+        self.assertEqual(data, b"")
+        self.assertTrue(os.path.isdir(os.path.join(self.root, "CFG")))
+
+    def test_open_if_creates_new_cfg_then_write_commits(self):
+        os.mkdir(os.path.join(self.root, "CFG"))
+        req = _ntcreate_request(self.smb, r"CFG\SLUS_000.00.cfg", self.smb.FILE_OPEN_IF)
+        params, _data, status = self.smb.h_nt_create_andx(self.conn, req)
+        self.assertEqual(status, self.smb.STATUS_SUCCESS)
+        fid = struct.unpack_from("<H", params, 5)[0]
+        action = struct.unpack_from("<I", params, 7)[0]
+        self.assertEqual(action, self.smb.FILE_CREATED)
+
+        payload = b"compat=3\r\n"
+        _params, _data, status = self.smb.h_write_andx(
+            self.conn, _write_request(fid, payload)
+        )
+        self.assertEqual(status, self.smb.STATUS_SUCCESS)
+        self.smb.h_close(self.conn, _request(params=struct.pack("<H", fid)))
+
+        with open(os.path.join(self.root, "CFG", "SLUS_000.00.cfg"), "rb") as handle:
+            self.assertEqual(handle.read(), payload)
+
+    def test_overwrite_if_truncates_existing_cfg_before_shorter_write(self):
+        cfg_dir = os.path.join(self.root, "CFG")
+        os.mkdir(cfg_dir)
+        target = os.path.join(cfg_dir, "SLUS_000.00.cfg")
+        with open(target, "wb") as handle:
+            handle.write(b"compat=7\r\nvmc=old-long-value\r\n")
+
+        req = _ntcreate_request(self.smb, r"CFG\SLUS_000.00.cfg", self.smb.FILE_OVERWRITE_IF)
+        params, _data, status = self.smb.h_nt_create_andx(self.conn, req)
+        self.assertEqual(status, self.smb.STATUS_SUCCESS)
+        fid = struct.unpack_from("<H", params, 5)[0]
+        action = struct.unpack_from("<I", params, 7)[0]
+        self.assertEqual(action, self.smb.FILE_OVERWRITTEN)
+        self.assertEqual(os.path.getsize(target), 0, "overwrite must truncate before WRITE_ANDX")
+
+        payload = b"compat=1\r\n"
+        _params, _data, status = self.smb.h_write_andx(
+            self.conn, _write_request(fid, payload)
+        )
+        self.assertEqual(status, self.smb.STATUS_SUCCESS)
+        self.smb.h_close(self.conn, _request(params=struct.pack("<H", fid)))
+
+        with open(target, "rb") as handle:
+            self.assertEqual(handle.read(), payload, "old tail bytes must not survive O_TRUNC")
+
+    def test_open_if_existing_file_does_not_truncate(self):
+        cfg_dir = os.path.join(self.root, "CFG")
+        os.mkdir(cfg_dir)
+        target = os.path.join(cfg_dir, "SLUS_000.00.cfg")
+        original = b"keep-me"
+        with open(target, "wb") as handle:
+            handle.write(original)
+
+        req = _ntcreate_request(self.smb, r"CFG\SLUS_000.00.cfg", self.smb.FILE_OPEN_IF)
+        params, _data, status = self.smb.h_nt_create_andx(self.conn, req)
+        self.assertEqual(status, self.smb.STATUS_SUCCESS)
+        action = struct.unpack_from("<I", params, 7)[0]
+        self.assertEqual(action, self.smb.FILE_OPENED)
+        with open(target, "rb") as handle:
+            self.assertEqual(handle.read(), original)
+
+    def test_read_only_refuses_directory_create_and_new_file(self):
+        share = self.smb.Share("games", self.root)
+        ro = self.smb.Conn(self.smb.SmbServer({"games": share}, read_only=True))
+        ro.trees[1] = share
+        try:
+            _params, _data, status = self.smb.h_create_directory(
+                ro, _request(data=b"\x04CFG\x00")
+            )
+            self.assertEqual(status, self.smb.STATUS_ACCESS_DENIED)
+            self.assertFalse(os.path.exists(os.path.join(self.root, "CFG")))
+
+            _params, _data, status = self.smb.h_nt_create_andx(
+                ro,
+                _ntcreate_request(self.smb, "new.cfg", self.smb.FILE_OPEN_IF),
+            )
+            self.assertEqual(status, self.smb.STATUS_ACCESS_DENIED)
+            self.assertFalse(os.path.exists(os.path.join(self.root, "new.cfg")))
+        finally:
+            ro.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #180.

The SMBv1 server advertised writable shares but only supported modifying files that already existed. RiptOPL exposes this on a clean share because it:

- creates `CFG`, `THM`, `LNG`, `ART`, `VMC`, etc. with `mkdir()` on connection;
- creates new per-game CFG files with `O_CREAT`;
- rewrites CFG files with `O_TRUNC`.

Before this change, SMBv1 had no `SMB_COM_CREATE_DIRECTORY` handler and `NT_CREATE_ANDX` rejected every missing path. It also ignored the requested create disposition, so overwrite/truncate requests could leave stale bytes at the end of a shorter rewritten config.

## Changes

- implement `SMB_COM_CREATE_DIRECTORY` in the desktop Python SMBv1 server;
- implement `NT_CREATE_ANDX` create-disposition behavior for open/create/open-if/overwrite/overwrite-if/supersede;
- honor overwrite/truncate semantics before `WRITE_ANDX`;
- preserve `--read-only` behavior for every create/truncate path;
- return the correct create action (`OPENED`, `CREATED`, `OVERWRITTEN`, `SUPERSEDED`);
- mirror the same behavior in the Edge Go SMBv1 implementation;
- extend Python/Edge wire-parity checks with the new command/status;
- add permanent regression tests for clean-share folder creation, brand-new CFG creation/write, shorter overwrite truncation, existing-file OPEN_IF behavior, and read-only rejection;
- add Edge end-to-end socket tests for the same write lifecycle.

## Verification

A dedicated branch verification run compiled the patched Python and Go sources, then passed:

- `python -m unittest tests.test_smbv1_write_semantics tests.test_smb_wire_parity -v`
- `go test ./internal/smb`

The branch was then squashed to one focused commit; temporary verification tooling is not part of the PR diff.

Hardware confirmation with RiptOPL on a genuinely empty SMB share is still the final interoperability check, but the failure described in #180 is directly reproduced by the regression cases and is fixed at the server protocol layer rather than worked around in RiptOPL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating directories through SMB.
  * Added file creation, opening, overwriting, truncation, and superseding behaviors.
  * SMB responses now accurately report the action performed.

* **Bug Fixes**
  * Read-only shares now correctly reject file and directory creation.
  * Improved handling of invalid paths, missing parents, and name collisions.

* **Tests**
  * Added coverage for directory creation, file overwrite behavior, read-only restrictions, and protocol compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->