### PR TITLE
fix(udpfs): restore canonical INFORM routing

### DIFF
--- a/launcher/directlink.py
+++ b/launcher/directlink.py
@@ -173,6 +173,40 @@ def _validate_topology(server_ip, client_ip, prefixlen):
     return server_ip, client_ip, prefixlen
 
 
+def static_client_settings(server_ip, dhcp_client_ip, prefixlen):
+    """Return (address, netmask, gateway) for a non-DHCP PS2 client.
+
+    The address is deliberately distinct from the responder's one DHCP lease,
+    so a second network stack (for example POPStarter) has an unambiguous
+    static configuration. No reservation is needed: the responder offers only
+    dhcp_client_ip.
+    """
+    server_ip, dhcp_client_ip, prefixlen = _validate_topology(
+        server_ip, dhcp_client_ip, prefixlen)
+    network = ipaddress.IPv4Network(
+        "{}/{}".format(server_ip, prefixlen), strict=False)
+    server = ipaddress.IPv4Address(server_ip)
+    dhcp_client = ipaddress.IPv4Address(dhcp_client_ip)
+    avoided = {network.network_address, network.broadcast_address,
+               server, dhcp_client}
+
+    # Prefer the address immediately after the DHCP lease (normally .11).
+    candidate = int(dhcp_client) + 1
+    for _ in range(3):
+        if candidate > int(network.broadcast_address):
+            break
+        address = ipaddress.IPv4Address(candidate)
+        if address in network and address not in avoided:
+            return str(address), str(network.netmask), server_ip
+        candidate += 1
+
+    # Handles a DHCP lease at the end of the subnet and very small subnets.
+    for address in network.hosts():
+        if address not in avoided:
+            return str(address), str(network.netmask), server_ip
+    return None
+
+
 def _ip_to_int(ip):
     return struct.unpack("!I", socket.inet_aton(ip))[0]
 

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -1265,11 +1265,23 @@ class LauncherApp:
             self._direct_check.config(state="disabled" if busy else "normal")
 
     def _direct_ready_status(self, cfg):
-        return ("Ready on '{adapter}': this PC is {server}, the PS2 gets "
-                "{client} by itself. Use {server} wherever an app asks for "
-                "the server IP.".format(adapter=cfg.get("adapter", "?"),
-                                        server=cfg.get("server_ip", "?"),
-                                        client=cfg.get("client_ip", "?")))
+        server = cfg.get("server_ip", "?")
+        client = cfg.get("client_ip", "?")
+        prefix = cfg.get("prefix", directlink.PREFIX_LENGTH)
+        try:
+            static = directlink.static_client_settings(server, client, prefix)
+        except (ValueError, windows_setup.WindowsSetupError):
+            static = None
+        text = ("Ready on '{adapter}'. Server: {server}. "
+                "DHCP PS2: {client}.".format(
+                    adapter=cfg.get("adapter", "?"), server=server,
+                    client=client))
+        if static is not None:
+            static_ip, mask, gateway = static
+            text += (" Static PS2/POPStarter: IP {ip}, mask {mask}, gateway "
+                     "{gateway}.".format(ip=static_ip, mask=mask,
+                                         gateway=gateway))
+        return text + " Use the server address wherever an app asks for it."
 
     def _on_direct_link_toggle(self):
         if self._direct_busy:

--- a/tests/test_directlink.py
+++ b/tests/test_directlink.py
@@ -18,6 +18,7 @@ from launcher.directlink import (
     build_reply, choose_subnet, classify_adapter, networks_overlap,
     parse_packet, plan_rehome, taken_networks, _BOOTP, _free_host, _ip_to_int,
     _build_discover, _foreign_offer_server_id, _synthetic_probe_mac,
+    static_client_settings,
 )
 from launcher.gui import LauncherApp
 from launcher.windows_setup import WindowsSetupError
@@ -250,6 +251,16 @@ class RehomeTests(unittest.TestCase):
     def test_no_neighbors_no_move(self):
         self.assertIsNone(plan_rehome("192.168.137.1", "192.168.137.10", 24,
                                       [], our_ip_present=True))
+
+    def test_static_client_uses_distinct_address_after_dhcp_lease(self):
+        self.assertEqual(
+            static_client_settings(SERVER, CLIENT, 24),
+            ("192.168.137.11", "255.255.255.0", SERVER))
+
+    def test_static_client_wraps_at_end_of_subnet(self):
+        self.assertEqual(
+            static_client_settings("192.168.137.1", "192.168.137.254", 24),
+            ("192.168.137.2", "255.255.255.0", "192.168.137.1"))
 
     def test_neighbor_in_subnet_not_contesting_no_move(self):
         # A console at .10 (not our address) with our address still present:
@@ -781,6 +792,15 @@ class LauncherLifecycleTests(unittest.TestCase):
         app._set_direct_status = mock.Mock()
         app._shutting_down = False  # real __init__ sets this; _poll_status reads it
         return app
+
+    def test_ready_status_lists_dhcp_and_static_client_settings(self):
+        status = LauncherApp._direct_ready_status(
+            self.app(), self.app().saved["direct_link"])
+        self.assertIn("Server: 192.168.137.1", status)
+        self.assertIn("DHCP PS2: 192.168.137.10", status)
+        self.assertIn("Static PS2/POPStarter: IP 192.168.137.11", status)
+        self.assertIn("mask 255.255.255.0", status)
+        self.assertIn("gateway 192.168.137.1", status)
 
     def test_enable_is_not_saved_when_helper_fails_to_start(self):
         app = self.app()

--- a/tests/test_udpfs_protocol_negotiation.py
+++ b/tests/test_udpfs_protocol_negotiation.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import pathlib
+import struct
 import sys
 import unittest
 
@@ -43,6 +44,25 @@ class NegotiationTests(unittest.TestCase):
         parser = CORE.build_parser()
         args = parser.parse_args(["--root-dir", str(ROOT)])
         self.assertEqual(args.protocol_mode, "auto")
+
+    def test_canonical_inform_uses_data_socket_and_zero_reserved_word(self):
+        data_socket = object()
+        discovery_socket = object()
+        destination = ("192.0.2.10", 0xF5F6)
+        sent = []
+        server = CORE.AutoUdpfsServer.__new__(CORE.AutoUdpfsServer)
+        server.dsock = data_socket
+        server.sock = discovery_socket
+        server._send_specific = lambda sock, packet, addr: sent.append(
+            (sock, packet, addr))
+
+        server._canonical_inform(destination)
+
+        self.assertEqual(sent, [(
+            data_socket,
+            struct.pack("<HHH", 0x0011, CORE.UDPRDMA_SVC_UDPFS, 0),
+            destination,
+        )])
 
 
 if __name__ == "__main__":

--- a/udpfs_server/ps2servers_core.py
+++ b/udpfs_server/ps2servers_core.py
@@ -174,8 +174,8 @@ class AutoUdpfsServer(UdpfsServer):
         hdr = Header(packet_type=PacketType.INFORM, seq_nr=1)
         disc = DiscHeader(
             service_id=UDPRDMA_SVC_UDPFS,
-            port=self.dsock.getsockname()[1])
-        self._send_specific(self.sock, hdr.pack() + disc.pack(), addr)
+            port=0)
+        self._send_specific(self.dsock, hdr.pack() + disc.pack(), addr)
 
     def _compatibility_inform(self, sess):
         hdr = Header(packet_type=PacketType.INFORM, seq_nr=sess.tx_seq_nr)


### PR DESCRIPTION
## Summary

- send the standards-compatible UDPFS INFORM from the data socket
- keep the Discovery/Inform reserved word zero
- add byte-exact coverage for the response socket, packet bytes, and destination tuple

## Cause

Neutrino learns the server data port from the INFORM datagram's UDP source port. The current Core path sent the canonical INFORM from the discovery socket while placing the ephemeral data port in the reserved body word, so a reset/reconnecting client selected the wrong endpoint.

## Verification

- `python -m unittest tests.test_udpfs_protocol_negotiation -v` — 8 passed
- `python -m unittest tests.test_server_override_contract -v` — 3 passed
- full discovery: 565 tests, 7 unrelated existing/environment failures, 4 skipped (Tk layout assertions, POSIX init parse check, and unavailable/broken Go stdlib parity checks)

Hardware validation remains required against the reported RiptOPL → Neutrino reset/reconnect path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UDPFS service discovery responses by advertising the correct port.
  * Discovery packets are now sent through the appropriate data connection.
  * Ensured responses include the expected service identifier and reserved field values.
* **Tests**
  * Added regression coverage to verify UDPFS discovery packet contents and destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->