### PR TITLE
docs: answer whether NBD should work in both directions

### DIFF
--- a/docs/PLAN-NBD-AND-PS2CLIENT.md
+++ b/docs/PLAN-NBD-AND-PS2CLIENT.md
@@ -24,14 +24,15 @@ Evidence for NBD: OPL's tree carries `download_lwNBD.sh` (pinning
 describes users running `nbd-client`/`nbdfuse` on the PC against the PS2. OPL
 "currently only supports exporting the PS2's drive."
 
-**So "treat NBD like the others" needs revisiting before any code is written.**
-A PC-side NBD *server* would have no consumer — OPL ships the server. The thing
-with real value is a PC-side NBD **client**, and specifically a Windows-native
-one, because today Windows users need WSL or Ceph-for-Windows to reach their own
-PS2 drive. That is a genuinely good reason to build it here.
+**So "treat NBD like the others" does not apply.** A PC-side NBD *server* would
+have no consumer — OPL ships the server. The thing with real value is a PC-side
+NBD **client**, and specifically a Windows-native one, because today Windows
+users need WSL or Ceph-for-Windows to reach their own PS2 drive.
 
-This is a design question for Ripto, not something to decide in code. Flag it
-before starting.
+**DECIDED (Ripto, 2026-09-05): the target is a PC-side NBD client speaking to
+OPL's lwNBD export.** Not a server, and not a role toggle — see "Shouldn't NBD
+go both ways?" below for why, and for what to do so the server half stays cheap
+to add if that ever changes.
 
 ---
 
@@ -54,8 +55,29 @@ the PS2's internal drive from Windows without WSL.
 - Transmission: request magic `0x25609513`, simple reply magic `0x67446698`.
   Structured replies (`0x668e33ef`) exist in the header — check whether lwNBD
   actually negotiates them before assuming simple-only.
-- Use `NBD_OPT_LIST` to discover export names rather than hardcoding one. **We do
-  not know what lwNBD names its exports** — find out first.
+- Use `NBD_OPT_LIST` to discover export names, but we already know the default:
+  **`hdd0`**. From `loadLwnbdSvr()` in OPL's `src/opl.c` — the user can set one
+  via `CONFIG_NET_NBD_DEFAULT_EXPORT` (`gExportName`, max 32 chars), and when
+  it is blank OPL falls back to `strcpy(config.defaultexport, "hdd0")`. Prefill
+  the field with `hdd0` and let `NBD_OPT_LIST` correct it.
+
+### What OPL actually does when it serves (verified in `src/opl.c`)
+
+Three facts from `loadLwnbdSvr()` that shape the client:
+
+- **It exports the internal ATA drive.** OPL loads `ps2atad_irx` and then
+  `lwnbdsvr_irx`. That is the console's own HDD, not a mounted image.
+- **The export is read-only unless the user enabled writes ON THE CONSOLE.**
+  `config.readonly = !gEnableWrite;`, where `gEnableWrite` comes from
+  `CONFIG_OPL_ENABLE_WRITE` and **defaults to 0** (`src/opl.c:1744`). This is a
+  gate we get for free and must not paper over: if the server advertises
+  read-only, say plainly that OPL's "Enable write" is off, rather than reporting
+  a generic write failure.
+- **The console is fully occupied while serving.** OPL calls `audioEnd()`,
+  `ioBlockOps(1)`, `deinitAllSupport(...)` and `unloadPads()` before starting
+  the server. The PS2 is not usable for anything else, and nothing else on it is
+  listening — so do not expect to talk to any other PS2 Servers mode at the same
+  time, and expect the user to be sitting at a "NBD Server running..." screen.
 
 ### "Shouldn't NBD go both ways?" — two questions, one answer each
 
@@ -279,8 +301,8 @@ if you miss one:
 
 ## Phases
 
-1. Settle the direction question with Ripto (NBD client vs server), and confirm
-   the ps2link command/log port collision against `src/ps2link.c`.
+1. Confirm the ps2link command/log port collision against `src/ps2link.c`.
+   (The NBD direction is settled: client. See "Direction" above.)
 2. `role` on `ServerDef` + role-aware firewall guard. Small, unblocks both.
 3. ps2link: command sender + log listener + `host:` fileio server, contained.
 4. The interactive terminal UI, wired to the ps2link dispatcher.
@@ -311,12 +333,18 @@ if you miss one:
   with no filesystem and no undo. Read-only by default, **two separate
   confirmations** before any write reaches the wire, and write-enable never
   persisted across launches. See "Writing to the console's drive: two gates, not
-  one" above; that section is a requirement, not a suggestion. If the schedule
-  gets tight, ship the read path alone — a dump-only NBD client is genuinely
+  one" above; that section is a requirement, not a suggestion. Note OPL gates
+  this too — it exports read-only unless the user set `CONFIG_OPL_ENABLE_WRITE`
+  on the console — so a write reaching the drive takes THREE deliberate acts.
+  Do not treat OPL's gate as a substitute for ours; treat it as the reason a
+  failed write is usually "the console says no" rather than a bug. If the
+  schedule gets tight, ship the read path alone — a dump-only NBD client is genuinely
   useful, and a half-guarded write path is worse than none.
 - ps2client's protocol docs are from 2004 and mark several opcodes
   UNDOCUMENTED; treat `src/ps2netfs.c` and `src/ps2link.c` as the real spec, the
   way the HTTP work treated `src/ethsupport.c` over the fork's README.
-- lwNBD export naming is unknown — discover it, do not guess.
+- lwNBD's default export is `hdd0`, and OPL exports the internal ATA drive —
+  both read out of `loadLwnbdSvr()`. Still call `NBD_OPT_LIST` rather than
+  assuming the user kept the default.
 - ps2link has no authentication at all. Anyone on the network can run code on the
   console. Say so in the docs.

--- a/docs/PLAN-NBD-AND-PS2CLIENT.md
+++ b/docs/PLAN-NBD-AND-PS2CLIENT.md
@@ -57,6 +57,40 @@ the PS2's internal drive from Windows without WSL.
 - Use `NBD_OPT_LIST` to discover export names rather than hardcoding one. **We do
   not know what lwNBD names its exports** — find out first.
 
+### "Shouldn't NBD go both ways?" — two questions, one answer each
+
+Asked by Ripto 2026-09-05, and worth recording because the answer is not
+obvious.
+
+**Read vs write is bidirectional, and that IS a toggle.** One NBD connection
+carries both; the server advertises `NBD_FLAG_READ_ONLY` to say whether the
+client may write. That is the Read-only checkbox and the two gates below.
+
+**Server vs client is not a toggle.** It is which program you run, fixed for the
+life of a connection. NBD as a standard is perfectly happy either way — on Linux
+you run `nbd-server` or `nbd-client` as you please — but in the PS2 world it is
+currently one-directional:
+
+- lwNBD is a *server* framework. `include/lwnbd/lwnbd-server.h`,
+  `examples/lwnbd-server.c`, and plugins that **export** hardware (`atad` for
+  the console's ATA drive, `bdm`). Its README frames contribution as adding
+  "new Protocols (Servers) or Drivers (Plugins)". There is no client in it.
+- OPL's menu item is "Start NBD server", and it "currently only supports
+  exporting the PS2's drive".
+
+So a PC-side NBD server would have nothing to talk to today. A PS2-side NBD
+client would amount to UDPBD over TCP, and UDPBD/UDPFS already fill that niche
+with a UDP transport tuned for the console — which is likely why nobody has
+written one.
+
+**What to do about it:** do not build the server half, but do not design it out
+either. Put the wire protocol — handshake, option haggling, request/reply
+framing — in its own module with the role as a thin layer on top, the way
+`udpfs_server/compressed_iso/` sits under both UDPFS and HTTP. Client and server
+share nearly all of that code, so if a PS2 NBD client ever appears, the server
+half is a small addition rather than a rewrite. Note the trigger in the docs so
+the next person knows what would justify building it.
+
 ### The Windows problem, and the recommended answer
 
 Windows cannot present a block device without a kernel driver, so "mount the PS2

--- a/docs/PLAN-NBD-AND-PS2CLIENT.md
+++ b/docs/PLAN-NBD-AND-PS2CLIENT.md
@@ -85,8 +85,19 @@ Asked by Ripto 2026-09-05, and worth recording because the answer is not
 obvious.
 
 **Read vs write is bidirectional, and that IS a toggle.** One NBD connection
-carries both; the server advertises `NBD_FLAG_READ_ONLY` to say whether the
-client may write. That is the Read-only checkbox and the two gates below.
+carries both. But keep two separate things separate, because they are easy to
+collapse into one and this document did so in an earlier draft:
+
+- `NBD_FLAG_READ_ONLY` is the **server's capability** — whether the export will
+  accept writes at all. We read it; we cannot change it. For OPL it is driven by
+  `gEnableWrite` on the console.
+- The **Read-only checkbox is our client's policy** — whether we intend to send
+  writes. We own it; it defaults to on.
+
+A write needs both to line up, and the two failure modes read differently to a
+user: capability says "the console will not accept writes, turn on Enable write
+in OPL", policy says "you have not enabled writing here". Never derive one from
+the other, and never report one using the other's message.
 
 **Server vs client is not a toggle.** It is which program you run, fixed for the
 life of a connection. NBD as a standard is perfectly happy either way — on Linux
@@ -101,9 +112,10 @@ currently one-directional:
   exporting the PS2's drive".
 
 So a PC-side NBD server would have nothing to talk to today. A PS2-side NBD
-client would amount to UDPBD over TCP, and UDPBD/UDPFS already fill that niche
-with a UDP transport tuned for the console — which is likely why nobody has
-written one.
+client would give the console block-device access over NBD/TCP — a distinct
+protocol, but overlapping the use case UDPBD and UDPFS already cover over a UDP
+transport tuned for the console. That overlap, not any limitation of NBD, is
+likely why nobody has written one.
 
 **What to do about it:** do not build the server half, but do not design it out
 either. Put the wire protocol — handshake, option haggling, request/reply


### PR DESCRIPTION
Follow-up to #189, answering @NathanNeurotic's question about whether NBD should
be both-ways capable.

The question splits in two, and the plan only answered one half:

**Read vs write — bidirectional, and it IS a toggle.** One connection carries
both; the server advertises `NBD_FLAG_READ_ONLY` to say whether the client may
write. Already covered by the Read-only checkbox and the two write gates.

**Server vs client — not a toggle.** It's which program you run, fixed for the
life of a connection. NBD as a standard is happy either way, but the PS2 side is
currently one-directional:

- lwNBD is a *server* framework — `lwnbd-server.h`, `examples/lwnbd-server.c`,
  plugins that **export** hardware (`atad`, `bdm`), and a README framing
  contribution as adding "new Protocols (Servers) or Drivers (Plugins)". No
  client anywhere in it.
- OPL offers "Start NBD server" and "currently only supports exporting the PS2's
  drive".

So a PC-side NBD server has nothing to talk to today, and a PS2-side client
would be UDPBD over TCP — a niche UDPBD/UDPFS already fill with a transport
tuned for the console.

**Outcome:** don't build the server half, don't design it out. The wire protocol
goes in its own module with the role as a thin layer on top — the way
`compressed_iso/` sits under both UDPFS and HTTP — so if a PS2 NBD client ever
appears, the server half is an addition rather than a rewrite. The trigger that
would justify building it is now written down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance clarifying NBD read/write direction and fixed client/server roles.
  - Documented the current PS2-side server-only model and existing alternatives for client functionality.
  - Outlined criteria for considering future server- or client-side NBD support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->