### PR TITLE
fix(http): notice a game replaced in place, not just added or removed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Check release compliance posture
         run: python tools/check_release_compliance.py
 
+      - name: Run pinned OPL HTTP client conformance
+        run: python conformance/integration/opl_http/run.py
+
       - name: Run UDPBD protocol selftest
         run: python udpbd_server/selftest.py
 

--- a/conformance/integration/opl_http/csv.c.in
+++ b/conformance/integration/opl_http/csv.c.in
@@ -1,0 +1,54 @@
+/* PC parser scaffolding; upstream parsing block is injected by run.py. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#define strcasecmp _stricmp
+#else
+#include <strings.h>
+#endif
+
+/* include/supportbase.h */
+#define ISO_GAME_NAME_MAX      160
+#define ISO_GAME_EXTENSION_MAX 4
+#define GAME_STARTUP_MAX       12
+#define GAME_FORMAT_ISO        2
+
+typedef unsigned char u8;
+typedef unsigned int  u32;
+
+typedef struct
+{
+    char name[ISO_GAME_NAME_MAX + 1];
+    char startup[GAME_STARTUP_MAX + 1];
+    char extension[ISO_GAME_EXTENSION_MAX + 1];
+    u8 parts;
+    u8 media;
+    u8 format;
+    u32 sizeMB;
+} base_game_info_t;
+
+static base_game_info_t *ethGames = NULL;
+static int ethGameCount = 0;
+
+int main(void)
+{
+    static char csv_buf[65536];
+    int out_len = (int)fread(csv_buf, 1, sizeof(csv_buf) - 1, stdin);
+    if (out_len <= 0) { printf("FAIL  empty games.csv on stdin\n"); return 2; }
+    csv_buf[out_len] = '\0';
+
+    printf("games.csv: %d bytes (console buffer is 8192)\n", out_len);
+    if (out_len > 8192) return 2;
+
+@UPSTREAM_CSV@
+
+
+    for (int i = 0; i < ethGameCount; i++) {
+        base_game_info_t *g = &ethGames[i];
+        printf("ROW\t%s\t%s%s\t%u\n", g->startup, g->name, g->extension, g->media);
+    }
+    free(ethGames);
+    return ethGameCount > 0 ? 0 : 1;
+}

--- a/conformance/integration/opl_http/range.c.in
+++ b/conformance/integration/opl_http/range.c.in
@@ -1,0 +1,187 @@
+/* PC socket shims and assertions; upstream functions are injected by run.py. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#define poll_close closesocket
+
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#define poll_close close
+#endif
+
+typedef unsigned long long u64;
+typedef unsigned int u32;
+typedef unsigned char u8;
+typedef int s32;
+
+/* --- PS2SDK platform shims (the ONLY adaptation) ------------------------- */
+#ifdef _WIN32
+static SOCKET host_socket = INVALID_SOCKET;
+#else
+static int host_socket = -1;
+#endif
+static int sh_socket(int d, int t, int p) {
+    host_socket = socket(d, t, p);
+#ifdef _WIN32
+    return host_socket == INVALID_SOCKET ? -1 : 1;
+#else
+    return host_socket < 0 ? -1 : 1;
+#endif
+}
+static int sh_connect(int s, struct sockaddr *a, socklen_t l) { (void)s; return connect(host_socket, a, l); }
+static int sh_send(int s, void *b, int n, unsigned int f) { (void)s; return send(host_socket, (const char *)b, n, f); }
+static int sh_recv(int s, void *b, int n, unsigned int f) { (void)s; return recv(host_socket, (char *)b, n, f); }
+static int sh_close(int s) { (void)s; return poll_close(host_socket); }
+static u32 sh_inet_addr(const char *cp) { return inet_addr(cp); }
+
+static int (*plwip_close)(int) = sh_close;
+static int (*plwip_connect)(int, struct sockaddr *, socklen_t) = sh_connect;
+static int (*plwip_recv)(int, void *, int, unsigned int) = sh_recv;
+static int (*plwip_send)(int, void *, int, unsigned int) = sh_send;
+static int (*plwip_socket)(int, int, int) = sh_socket;
+static u32 (*pinet_addr)(const char *) = sh_inet_addr;
+
+static int main_socket = -1;
+static struct in_addr server_ip;
+static unsigned short server_port;
+static char base_path[64];
+static char ip_str[32];
+
+/* Generated from hash-verified upstream source; never edited here. */
+#define HTTP_MAX_CHUNK_SIZE 8192
+static int OpenTCPSession(struct in_addr ip, unsigned short port)
+{
+    int sock = plwip_socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+    struct sockaddr_in sa;
+    if (sock < 0) return -2;
+    memset(&sa, 0, sizeof(sa));
+    sa.sin_family = AF_INET;
+    sa.sin_addr = ip;
+    sa.sin_port = htons(port);
+    if (plwip_connect(sock, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+        plwip_close(sock);
+        return -3;
+    }
+    return sock;
+}
+@UPSTREAM_IO@
+@UPSTREAM_RANGE@
+
+/* --- the u64_to_str equivalence check (their math, our expectations) ----- */
+static int check_u64_to_str(void)
+{
+    u64 cases[] = {0ULL, 1ULL, 2047ULL, 2048ULL, 8191ULL, 65535ULL,
+                   999999999ULL, 1000000000ULL, 2147483647ULL, 2147483648ULL,
+                   4294967295ULL, 4294967296ULL, 4294967297ULL,
+                   4700372992ULL,          /* a DVD5 tail */
+                   8547991552ULL,          /* a DVD9 tail */
+                   9999999999ULL, 10000000000ULL, 123456789012ULL};
+    int n = (int)(sizeof(cases) / sizeof(cases[0])), i, bad = 0;
+    char buf[24], want[32];
+    for (i = 0; i < n; i++) {
+        u64_to_str(cases[i], buf);
+        sprintf(want, "%llu", cases[i]);
+        if (strcmp(buf, want) != 0) {
+            printf("FAIL  u64_to_str(%llu) = \"%s\", want \"%s\"\n", cases[i], buf, want);
+            bad++;
+        }
+    }
+    printf("%s  u64_to_str: %d/%d offsets formatted correctly (their 32-bit math)\n",
+           bad ? "FAIL" : "PASS", n - bad, n);
+    return bad;
+}
+
+int main(int argc, char **argv)
+{
+    const char *host = argc > 1 ? argv[1] : "127.0.0.1";
+    int port        = argc > 2 ? atoi(argv[2]) : 1100;
+    const char *fn  = argc > 3 ? argv[3] : "SLUS_201.74.Rumble Racing.iso";
+    int failures = 0, i;
+    static unsigned char buf[HTTP_MAX_CHUNK_SIZE];
+
+#ifdef _WIN32
+    WSADATA wsa; WSAStartup(MAKEWORD(2, 2), &wsa);
+#endif
+
+    printf("OPL's own client code vs the PS2 Servers HTTP server\n");
+    printf("host=%s port=%d file=\"%s\"\n\n", host, port, fn);
+
+    failures += check_u64_to_str();
+
+    strncpy(ip_str, host, sizeof(ip_str) - 1);
+    server_port = (unsigned short)port;
+    strcpy(base_path, "/");           /* hardcoded in src/ethsupport.c */
+    server_ip.s_addr = pinet_addr(ip_str);
+
+    main_socket = OpenTCPSession(server_ip, server_port);
+    if (main_socket < 0) { printf("FAIL  cannot connect\n"); return 2; }
+
+    /* Sequential 8 KB reads down ONE keep-alive socket, as the driver does. */
+    for (i = 0; i < 4; i++) {
+        u64 off = (u64)i * HTTP_MAX_CHUNK_SIZE;
+        int rc = http_ReadRangeInternal(fn, off, HTTP_MAX_CHUNK_SIZE, buf);
+        if (rc != HTTP_MAX_CHUNK_SIZE) {
+            printf("FAIL  read %d at offset %llu returned %d\n", i, off, rc);
+            failures++;
+            continue;
+        }
+        /* Server serves bytes(range(256)) repeated; verify byte-exactly. */
+        int j, wrong = 0;
+        for (j = 0; j < HTTP_MAX_CHUNK_SIZE; j++)
+            if (buf[j] != (unsigned char)((off + j) % 256)) { wrong = 1; break; }
+        if (wrong) {
+            printf("FAIL  read %d at offset %llu: wrong byte at %d\n", i, off, j);
+            failures++;
+        } else {
+            printf("PASS  read %d at offset %llu: 8192 bytes, byte-exact\n", i, off);
+        }
+    }
+
+    /* A read at a non-block-aligned offset, the way a game's seeks land. */
+    {
+        u64 off = 3000;
+        int rc = http_ReadRangeInternal(fn, off, 2048, buf);
+        if (rc != 2048) { printf("FAIL  unaligned read returned %d\n", rc); failures++; }
+        else {
+            int j, wrong = -1;
+            for (j = 0; j < 2048; j++)
+                if (buf[j] != (unsigned char)((off + j) % 256)) { wrong = j; break; }
+            if (wrong >= 0) { printf("FAIL  unaligned read wrong at %d\n", wrong); failures++; }
+            else printf("PASS  unaligned read at %llu: 2048 bytes, byte-exact\n", off);
+        }
+    }
+
+    /* Their client never drains a non-206 body, so a 416 desyncs the socket.
+     * http_ReadRange (their wrapper, verbatim above) is what saves it: it
+     * reconnects and retries once. This checks recovery in the PC-hosted client logic.
+     * Console timing and gameplay still require hardware validation. */
+    {
+        int rc = http_ReadRange(fn, 1000000000ULL, HTTP_MAX_CHUNK_SIZE, buf);
+        printf("%s  a range past EOF fails cleanly (rc=%d)\n",
+               rc == -5 ? "PASS" : "FAIL", rc);
+        if (rc != -5) failures++;
+        rc = http_ReadRange(fn, 0, HTTP_MAX_CHUNK_SIZE, buf);
+        if (rc != HTTP_MAX_CHUNK_SIZE) {
+            printf("FAIL  driver did NOT recover after the 416: %d\n", rc);
+            failures++;
+        } else {
+            int j, wrong = -1;
+            for (j = 0; j < HTTP_MAX_CHUNK_SIZE; j++)
+                if (buf[j] != (unsigned char)(j % 256)) { wrong = j; break; }
+            if (wrong >= 0) { printf("FAIL  recovered read wrong at %d\n", wrong); failures++; }
+            else printf("PASS  driver recovered after the 416, next read byte-exact\n");
+        }
+    }
+
+    plwip_close(main_socket);
+    printf("\n%s\n", failures ? "SMOKE TEST FAILED" : "all checks passed");
+    return failures ? 1 : 0;
+}

--- a/conformance/integration/opl_http/run.py
+++ b/conformance/integration/opl_http/run.py
@@ -37,11 +37,33 @@ def between(source, start, end):
     return source[a:b]
 
 
+class UpstreamUnavailable(Exception):
+    """The pinned upstream source could not be retrieved at all.
+
+    Distinct from every other failure here on purpose. This check gates CI on a
+    repository nobody in this project controls -- three days old and described
+    by its own author as a proof of concept. If it is deleted, renamed or made
+    private, every pull request would go red for a reason unrelated to the
+    change being tested. Not being able to REACH the source is an availability
+    problem and skips loudly; anything after the bytes arrive (a hash mismatch,
+    drifted extraction anchors, a build failure, a failed assertion) is a real
+    signal and still fails hard.
+    """
+
+
 def generate(work):
     sources = {}
     for path, digest in HASHES.items():
-        with urllib.request.urlopen(BASE + path, timeout=30) as response:
-            data = response.read()
+        try:
+            with urllib.request.urlopen(BASE + path, timeout=30) as response:
+                data = response.read()
+        except OSError as exc:
+            # urllib's HTTPError and URLError are both OSError subclasses, so
+            # this covers a deleted or private repo (404/403) as well as DNS,
+            # TLS and timeout failures. A pinned commit's bytes cannot change
+            # underneath us, so a 404 here means the source is gone, not that
+            # it was edited -- that case is the hash check below.
+            raise UpstreamUnavailable("{}: {}".format(path, exc)) from exc
         if hashlib.sha256(data).hexdigest() != digest:
             raise ValueError("Upstream SHA256 mismatch: " + path)
         (work / Path(path).name).write_bytes(data)
@@ -146,6 +168,10 @@ def exercise(work, binaries):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--cc", default="gcc", help="C compiler executable (default: gcc)")
+    parser.add_argument("--require-upstream", action="store_true",
+                        help="Fail instead of skipping when the pinned upstream "
+                             "source cannot be fetched. For a release gate, "
+                             "where 'we could not check' is not good enough.")
     args = parser.parse_args()
     compiler = shutil.which(args.cc)
     if not compiler:
@@ -153,11 +179,24 @@ def main():
     print("Upstream OPL commit: " + COMMIT, flush=True)
     with tempfile.TemporaryDirectory(prefix="ps2-http-conformance-") as directory:
         work = Path(directory)
-        generate(work)
+        try:
+            generate(work)
+        except UpstreamUnavailable as exc:
+            if args.require_upstream:
+                print("FAIL  pinned upstream source unreachable: " + str(exc))
+                return 1
+            print("SKIP  pinned upstream source unreachable: " + str(exc))
+            print("SKIP  the OPL client conformance check did NOT run. This says "
+                  "nothing about whether the server is correct -- only that the "
+                  "upstream repository could not be reached.")
+            return 0
         binaries = build(work, compiler)
         exercise(work, binaries)
     print("PASS  all PC-hosted upstream client checks (not PS2 hardware validation)")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    # main() returns the exit code now that a skip is distinct from a pass;
+    # dropping it would make --require-upstream silently succeed.
+    sys.exit(main())

--- a/conformance/integration/opl_http/run.py
+++ b/conformance/integration/opl_http/run.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Build and exercise pinned OPL client logic on loopback (Python 3 + GCC).
+
+No upstream implementation is vendored. Downloads, generated C, executables and
+fixtures live in a fresh temporary directory and are removed on exit.
+"""
+import argparse
+import hashlib
+import http.client
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.request
+
+COMMIT = "6fced11a6afafe20c52b8d1a090067e3e1889b99"
+BASE = "https://raw.githubusercontent.com/Docmine17/Open-PS2-Loader-HTTP/" + COMMIT + "/"
+HASHES = {
+    "modules/iopcore/cdvdman/http.c": "59e52f5456ff86ce024d7af647286f29ff0b6303a9db13c4560b97923e5925e8",
+    "src/ethsupport.c": "a882cab07b646a1a978628bfe96bf2459b56e99ed598e00980613aa54bb0c881",
+}
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[2]
+
+
+def between(source, start, end):
+    """Fail closed if pinned extraction anchors are missing or ambiguous."""
+    if source.count(start) != 1 or source.count(end) != 1:
+        raise ValueError("Upstream extraction anchor changed: " + start)
+    a, b = source.index(start), source.index(end)
+    if a >= b:
+        raise ValueError("Upstream extraction anchors are out of order")
+    return source[a:b]
+
+
+def generate(work):
+    sources = {}
+    for path, digest in HASHES.items():
+        with urllib.request.urlopen(BASE + path, timeout=30) as response:
+            data = response.read()
+        if hashlib.sha256(data).hexdigest() != digest:
+            raise ValueError("Upstream SHA256 mismatch: " + path)
+        (work / Path(path).name).write_bytes(data)
+        sources[path] = data.decode("utf-8")
+    http = sources["modules/iopcore/cdvdman/http.c"]
+    eth = between(sources["src/ethsupport.c"], "static int ethUpdateGameListHTTP(void)\n{",
+                  "static int ethUpdateGameList(item_list_t *itemList)\n{")
+    replacements = {
+        "@UPSTREAM_IO@": between(http, "static int SendData(", "int http_Connect("),
+        "@UPSTREAM_RANGE@": between(http, "static void url_encode(", "int http_ReadFile("),
+        "@UPSTREAM_CSV@": between(eth, "    int count = 0;",
+                                 "    free(csv_buf);\n    return ethGameCount;"),
+    }
+    for name in ("range", "csv"):
+        template = (HERE / (name + ".c.in")).read_text(encoding="utf-8")
+        for marker, code in replacements.items():
+            if marker in template:
+                if template.count(marker) != 1:
+                    raise ValueError("Duplicate template marker: " + marker)
+                template = template.replace(marker, code)
+        if "@UPSTREAM_" in template:
+            raise ValueError("Unexpanded upstream template marker")
+        (work / (name + ".c")).write_text(template, encoding="utf-8", newline="\n")
+
+
+def build(work, compiler):
+    binaries = {}
+    for name in ("range", "csv"):
+        exe = work / (name + (".exe" if os.name == "nt" else ""))
+        # A unique temporary build directory plus check=True prevents stale runs.
+        command = [compiler, "-std=c99", "-O0", "-Wall", "-Wextra",
+                   str(work / (name + ".c")), "-o", str(exe)]
+        if os.name == "nt" and name == "range":
+            command.append("-lws2_32")
+        subprocess.run(command, check=True, timeout=60)
+        binaries[name] = exe
+    return binaries
+
+
+def exercise(work, binaries):
+    sys.path[:0] = [str(ROOT / "http_server"), str(ROOT / "udpfs_server")]
+    import http_server as hs
+    from compression_selftest import make_cso
+
+    root = work / "games"
+    (root / "DVD").mkdir(parents=True)
+    (root / "CD").mkdir()
+    plain = bytes(range(256)) * 512
+    iso = "SLUS_201.74.Rumble Racing.iso"
+    amp = "SCUS_971.24.Ratchet & Clank.iso"
+    cso = "SLUS_209.99.Compressed Game.iso"
+    (root / "DVD" / iso).write_bytes(plain)
+    (root / "CD" / amp).write_bytes(plain)
+    make_cso(str(root / "DVD" / cso.replace(".iso", ".cso")), plain)
+    index = hs.GameIndex(str(root), enable_compression=True)
+    server = hs.Ps2HTTPServer(("127.0.0.1", 0), index)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.server_address[1]
+
+    def get(path, headers=None):
+        connection = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+        try:
+            connection.request("GET", path, headers=headers or {})
+            response = connection.getresponse()
+            return response.status, dict(response.getheaders()), response.read()
+        finally:
+            connection.close()
+
+    try:
+        status, _, csv = get("/games.csv")
+        if status != 200:
+            raise AssertionError("games.csv status: " + str(status))
+        parsed = subprocess.run([str(binaries["csv"])], input=csv,
+                                capture_output=True, check=True, timeout=30)
+        rows = [line.split("\t")[1:] for line in parsed.stdout.decode().splitlines()
+                if line.startswith("ROW\t")]
+        expected = sorted([["SLUS_201.74", iso, "20"], ["SCUS_971.24", amp, "18"],
+                           ["SLUS_209.99", cso, "20"]])
+        if sorted(rows) != expected:
+            raise AssertionError("OPL parsed rows differ: " + repr(rows))
+        print("PASS  upstream CSV parser: exact startup, filename and media", flush=True)
+        for _, filename, _ in rows:
+            subprocess.run([str(binaries["range"]), "127.0.0.1", str(port), filename],
+                           check=True, timeout=30)
+        # Exercise the committed stale-size fix through its public list-fetch path.
+        (root / "DVD" / iso).write_bytes(plain[:32768])
+        time.sleep(index.RESCAN_INTERVAL + 0.1)
+        get("/games.csv")
+        status, headers, body = get("/" + iso.replace(" ", "%20"),
+                                    {"Range": "bytes=0-8191"})
+        if (status != 206 or headers.get("Content-Range") != "bytes 0-8191/32768"
+                or body != plain[:8192]):
+            raise AssertionError("In-place replacement retained stale size or bytes")
+        print("PASS  in-place replacement noticed after game-list refresh", flush=True)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=10)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cc", default="gcc", help="C compiler executable (default: gcc)")
+    args = parser.parse_args()
+    compiler = shutil.which(args.cc)
+    if not compiler:
+        parser.error("C compiler not found: " + args.cc)
+    print("Upstream OPL commit: " + COMMIT, flush=True)
+    with tempfile.TemporaryDirectory(prefix="ps2-http-conformance-") as directory:
+        work = Path(directory)
+        generate(work)
+        binaries = build(work, compiler)
+        exercise(work, binaries)
+    print("PASS  all PC-hosted upstream client checks (not PS2 hardware validation)")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/HTTP.md
+++ b/docs/HTTP.md
@@ -159,6 +159,17 @@ Use `--cc /path/to/gcc` to select a compiler. Windows GCC must support Winsock;
 Linux uses the system socket library. Internet access to GitHub is required.
 CI runs the same command on Linux.
 
+**If the upstream source cannot be fetched, the runner skips loudly and exits
+0.** That check gates CI on a repository nobody here controls — three days old
+when this was written, and a proof of concept by its author's own description.
+If it were deleted, renamed or made private, a hard failure would redden every
+pull request for a reason unrelated to the change being tested. Only being
+unable to *reach* the source is tolerated: a SHA256 mismatch, drifted
+extraction anchors, a build failure or a failed assertion all still fail hard,
+because those are real signals. Pass `--require-upstream` to turn the skip back
+into a failure where "we could not check" is not good enough, such as a release
+gate.
+
 The runner fetches source from `Docmine17/Open-PS2-Loader-HTTP` at
 `6fced11a6afafe20c52b8d1a090067e3e1889b99` and verifies each file's SHA256.
 It injects unchanged upstream `SendData`, `RecvData`, `url_encode`, `u64_to_str`,

--- a/docs/HTTP.md
+++ b/docs/HTTP.md
@@ -6,8 +6,9 @@ an OPL fork that streams ISOs with HTTP Range requests instead of SMB. There are
 shares, no logins, and no SMB dialects to negotiate.
 
 > **Status: experimental.** The OPL fork is young and prototype-stage, and nothing
-> here has been validated against a real console yet. Everything below is derived
-> from reading the client's source. If you test it on hardware, please report back.
+> here has been validated against a real console yet. The pinned client's range-read
+> functions and CSV parser are tested on a PC; PS2 networking, timing and gameplay
+> still need hardware testing. If you test it on hardware, please report back.
 
 ## Setting it up
 
@@ -145,3 +146,59 @@ else DVD. Blank lines and `#` comments are skipped.
 An out-of-range request is answered `416` rather than clamped, deliberately: a short
 body would leave the driver blocked waiting for bytes that never arrive, whereas a
 416 fails a read it can retry.
+
+## Reproduce the upstream-client test
+
+From the repository root, with Python 3 and GCC on PATH:
+
+```
+python conformance/integration/opl_http/run.py
+```
+
+Use `--cc /path/to/gcc` to select a compiler. Windows GCC must support Winsock;
+Linux uses the system socket library. Internet access to GitHub is required.
+CI runs the same command on Linux.
+
+The runner fetches source from `Docmine17/Open-PS2-Loader-HTTP` at
+`6fced11a6afafe20c52b8d1a090067e3e1889b99` and verifies each file's SHA256.
+It injects unchanged upstream `SendData`, `RecvData`, `url_encode`, `u64_to_str`,
+`http_ReadRangeInternal`, `http_ReadRange`, and the CSV parsing block into PC
+scaffolding. Socket creation/connection and the PS2 data types are host shims;
+the CSV arrives on stdin after Python fetches it over HTTP. This does not exercise
+the console's game-list HTTP client, IOP semaphores or connection retry timing.
+
+Every run creates fresh temporary sources, binaries and deterministic fixtures.
+A download, hash, extraction, compilation, timeout or assertion failure exits
+nonzero. No previously built executable can be used after a failed compilation.
+Generated upstream source is not committed or packaged with PS2 Servers.
+
+Checks cover exact parsed startup IDs, filenames and CD/DVD media; sequential and
+unaligned reads of ISO, an ampersand filename and CSO served as virtual ISO;
+the expected `-5` result for a range beyond EOF followed by byte-exact recovery;
+and a rewritten ISO's size after a game-list refresh. The high-offset check tests
+decimal formatting above 4 GB, not actual reads from a DVD9 image. CHD is not
+covered by this harness.
+
+Replacing an image is detected on the next game-list fetch after the five-second
+rescan interval. Finish copying before refreshing the list; this is not support
+for replacing an image while the console is playing it.
+
+## PS2 hardware handoff
+
+1. Record the tested PS2 Servers commit (for a packaged build, verify its build
+   identity), the OPL ELF's source commit and hash, PS2 model, and network topology.
+   The PC test above is pinned to OPL commit
+   `6fced11a6afafe20c52b8d1a090067e3e1889b99`; other client revisions need separate
+   verification. Run the server from the checkout with `python ps2servers.py`.
+2. Start HTTP with a known-good plain ISO in `DVD/`. Set the console's HTTP port
+   explicitly to the displayed server port. Reload the list, confirm the startup
+   ID/title, boot, and exercise gameplay and loading transitions. Record the
+   deepest successful stage and server errors if it stops.
+3. Repeat with a filename containing `&`, then a CSO of a known-good game.
+   Treat CHD and ZSO as additional hardware cases, not as established by this test.
+4. With gameplay stopped, replace an ISO under the same name with a completed,
+   known-good image of a different size. Wait at least five seconds, reload the
+   game list, and launch again without restarting the server.
+
+Passing the PC test is a prerequisite for this handoff, not evidence that a game
+has booted on a PS2. Keep HTTP experimental until hardware results are recorded.

--- a/http_server/http_server.py
+++ b/http_server/http_server.py
@@ -208,19 +208,32 @@ class GameIndex(object):
         return result
 
     def _signature_of(self, scan_dirs):
-        """Cheap change token: each scanned directory's mtime and entry count.
+        """Change token covering each scanned file's identity, size and mtime.
 
-        Enough to notice a game being added or removed without re-stat'ing
-        every file on every games.csv request.
+        Directory mtime and entry count are NOT enough. Replacing a game's
+        contents in place -- re-dumping an ISO under the same name, which people
+        do -- changes neither on Windows, so the index kept serving the old size
+        forever: Content-Range advertised a total that no longer existed, and
+        every read past it came back 416 with the game simply refusing to load.
+
+        scandir carries the stat data from the directory read, so this costs
+        little, and it only runs on a games.csv fetch (throttled) -- never on the
+        read path.
         """
         parts = []
         for path, _media in scan_dirs:
+            entries = []
             try:
-                stat = os.stat(path)
-                count = len(os.listdir(path))
+                with os.scandir(path) as it:
+                    for entry in it:
+                        try:
+                            st = entry.stat()
+                        except OSError:
+                            continue
+                        entries.append((entry.name, st.st_mtime_ns, st.st_size))
             except OSError:
                 continue
-            parts.append((path, int(stat.st_mtime), count))
+            parts.append((path, tuple(sorted(entries))))
         return tuple(parts)
 
     def _media_for(self, implied, size):

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -291,6 +291,31 @@ class IndexTests(_ServerFixture):
         head, _body = self.simple_get("/OUTSIDE.iso", "Range: bytes=0-10\r\n")
         self.assertTrue(head.startswith(b"HTTP/1.1 404"))
 
+    def test_replacing_a_game_in_place_is_noticed(self):
+        """Re-dumping an ISO under the same name must not serve the old size.
+
+        Found by running OPL's own client code against the server: the index
+        keyed staleness on directory mtime and entry count, and rewriting a
+        file's CONTENTS changes neither on Windows. The cached size then stuck
+        forever -- Content-Range advertised a total that no longer existed, and
+        every read past it came back 416, which on a console is a game that
+        simply refuses to load.
+        """
+        path = os.path.join(self.work, "DVD", "SLUS_201.74.Rumble Racing.iso")
+        with open(path, "wb") as handle:          # same name, different length
+            handle.write(bytes([0x11]) * 4096)
+        self.index._last_scan = time.monotonic() - self.index.RESCAN_INTERVAL
+        self.simple_get("/games.csv")             # the fetch that rescans
+
+        sock = self.connect()
+        head, body = self.driver_request(
+            sock, "SLUS_201.74.Rumble%20Racing.iso", 0, 2047)
+        self.assertTrue(head.startswith(b"HTTP/1.1 206"), head[:40])
+        self.assertIn(b"/4096", head,
+                      "Content-Range still advertises the old total: " +
+                      head[:60].decode(errors="replace"))
+        self.assertEqual(body, bytes([0x11]) * 2048)
+
     def test_new_games_appear_without_a_restart(self):
         self._write(os.path.join("DVD", "SLES_502.10.Added Later.iso"),
                     b"\xDD" * 2048)

--- a/tests/test_opl_http_runner.py
+++ b/tests/test_opl_http_runner.py
@@ -29,6 +29,46 @@ class RunnerFailureTests(unittest.TestCase):
             self.assertEqual(run.call_count, 1)
             exercise.assert_not_called()
 
+    def test_unreachable_upstream_skips_rather_than_failing_ci(self):
+        """A deleted or unreachable upstream must not redden every pull request.
+
+        This check gates CI on a repository nobody here controls. Losing the
+        ability to REACH it is an availability problem, not a defect in this
+        server, so it exits 0 -- loudly, and without pretending the check ran.
+        """
+        with mock.patch.object(runner.sys, "argv", [str(PATH)]), \
+                mock.patch.object(runner.shutil, "which", return_value="gcc"), \
+                mock.patch.object(runner, "generate",
+                                  side_effect=runner.UpstreamUnavailable("404")), \
+                mock.patch.object(runner, "build") as build, \
+                mock.patch.object(runner, "exercise") as exercise, \
+                mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            self.assertEqual(runner.main(), 0)
+        build.assert_not_called()
+        exercise.assert_not_called()
+        self.assertIn("SKIP", out.getvalue())
+        self.assertNotIn("PASS", out.getvalue())
+
+    def test_require_upstream_turns_the_skip_back_into_a_failure(self):
+        """A release gate cannot accept 'we could not check' as a pass."""
+        with mock.patch.object(runner.sys, "argv", [str(PATH), "--require-upstream"]), \
+                mock.patch.object(runner.shutil, "which", return_value="gcc"), \
+                mock.patch.object(runner, "generate",
+                                  side_effect=runner.UpstreamUnavailable("404")), \
+                mock.patch.object(runner, "exercise") as exercise, \
+                mock.patch("sys.stdout", new_callable=io.StringIO) as out:
+            self.assertEqual(runner.main(), 1)
+        exercise.assert_not_called()
+        self.assertIn("FAIL", out.getvalue())
+
+    def test_a_hash_mismatch_still_fails_hard_and_is_not_a_skip(self):
+        """Only unreachability is tolerated. Changed content is a real signal."""
+        with tempfile.TemporaryDirectory() as directory, \
+                mock.patch.object(runner.urllib.request, "urlopen",
+                                  return_value=io.BytesIO(b"unexpected source")):
+            with self.assertRaises(ValueError):
+                runner.generate(Path(directory))
+
     def test_changed_upstream_bytes_are_rejected_before_source_generation(self):
         with tempfile.TemporaryDirectory() as directory, \
                 mock.patch.object(runner.urllib.request, "urlopen",

--- a/tests/test_opl_http_runner.py
+++ b/tests/test_opl_http_runner.py
@@ -1,0 +1,39 @@
+"""The fetched-client runner must fail closed, especially after build failures."""
+import importlib.util
+import io
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+
+PATH = (Path(__file__).resolve().parents[1] / "conformance" / "integration" /
+        "opl_http" / "run.py")
+SPEC = importlib.util.spec_from_file_location("opl_http_runner", PATH)
+runner = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(runner)
+
+
+class RunnerFailureTests(unittest.TestCase):
+    def test_compilation_failure_never_reaches_exercise(self):
+        failure = subprocess.CalledProcessError(1, ["gcc"])
+        with mock.patch.object(runner.sys, "argv", [str(PATH)]), \
+                mock.patch.object(runner.shutil, "which", return_value="gcc"), \
+                mock.patch.object(runner, "generate"), \
+                mock.patch.object(runner.subprocess, "run", side_effect=failure) as run, \
+                mock.patch.object(runner, "exercise") as exercise:
+            with self.assertRaises(subprocess.CalledProcessError):
+                runner.main()
+            self.assertTrue(run.call_args.kwargs["check"])
+            self.assertEqual(run.call_count, 1)
+            exercise.assert_not_called()
+
+    def test_changed_upstream_bytes_are_rejected_before_source_generation(self):
+        with tempfile.TemporaryDirectory() as directory, \
+                mock.patch.object(runner.urllib.request, "urlopen",
+                                  return_value=io.BytesIO(b"unexpected source")):
+            work = Path(directory)
+            with self.assertRaisesRegex(ValueError, "SHA256 mismatch"):
+                runner.generate(work)
+            self.assertEqual(list(work.iterdir()), [])


### PR DESCRIPTION
## How this was found

I compiled **OPL's own client code** and pointed it at our server.

`url_encode`, `u64_to_str` and `http_ReadRangeInternal` copied verbatim from
`modules/iopcore/cdvdman/http.c` (@ `6fced11a`), with only the `ps2ip` function
pointers shimmed to real sockets. Plus the `games.csv` parsing loop from
`src/ethsupport.c`, fed our generated list.

This matters because every test until now spoke the client's bytes *as I
reconstructed them from reading their C* — so the server and its tests shared a
single source of truth. If I'd misread something, both would agree and both
would be wrong. This harness doesn't share that reading.

## The bug it found

A game rewritten under the same name kept serving its **old size**.

The index keyed staleness on directory mtime + entry count. Replacing a file's
*contents* changes neither on Windows, so the cached size stuck forever:
`Content-Range` advertised a total that no longer existed, and every read past
it returned 416. On a console that's a game that refuses to load, with nothing
in any log to explain why. People re-dump ISOs and the server is meant to be
left running, so this was reachable.

The signature now covers each file's name/size/mtime via `scandir` (which
carries stat data from the directory read). Still only on a `games.csv` fetch,
throttled — never on the read path, so the hot-path fix that made us 3x the
reference stays intact. Regression test included; verified it fails against the
old signature.

## What else the harness confirmed

- byte-exact reads across plain ISO, **a CSO decompressed on the fly**, and a
  filename containing `&` (which their `url_encode` passes through raw)
- their `games.csv` parser produces the right STARTUP/name/extension/media from
  our list, and reconstructs exactly the URLs our index serves
- their `u64_to_str` formats offsets correctly past 4 GB
- **their reconnect wrapper recovers from our 416** — confirming that answering
  416 rather than clamping a short read is safe on the real driver, which until
  now was a reasoned choice with nothing behind it

619 tests pass.

## Still not hardware

This is OPL's client *logic* on a PC. The IOP, its network stack, timing, and
the game actually booting are all still untested. It closes the "did I misread
their C" gap, not the "does it work on a PS2" gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated game indexing to detect in-place file replacements and serve current file sizes and contents.
  * Added coverage for refreshed range responses after game files change.

* **Testing**
  * Added automated conformance checks for HTTP range requests, CSV parsing, stale-size handling, and upstream source integrity.
  * Added CI execution for the pinned HTTP client conformance test.

* **Documentation**
  * Expanded HTTP testing guidance, including PC conformance testing and PS2 hardware validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->