### PR TITLE
fix(udpfs): make PC interface binding accessible in the launcher

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -465,11 +465,19 @@ class ServerCard(ttk.LabelFrame):
             var = tk.StringVar(value=str(f.default or ""))
             ttk.Entry(parent, textvariable=var).grid(
                 row=row, column=1, sticky="ew", padx=6, pady=2)
+            if self.server.key == "udpfs" and f.key == "bind":
+                ttk.Button(parent, text="Use LAN IP",
+                           command=self._use_lan_ip).grid(
+                    row=row, column=2, sticky="e", padx=4, pady=2)
         self.vars[f.key] = var
         row += 1
         if f.help:
             row = self._add_help(parent, f.help, row, 1, 6, HELP_RESERVE)
         return row
+
+    def _use_lan_ip(self):
+        self.vars["bind"].set(self.app.current_ip().strip())
+        self.app._save()
 
     def _toggle_advanced(self):
         self._advanced_shown = not self._advanced_shown

--- a/launcher/servers.py
+++ b/launcher/servers.py
@@ -437,8 +437,9 @@ UDPFS = ServerDef(
               help="UDP discovery port (default 0xF5F6)."),
         Field("data_port", "Data port", "port", default=0, advanced=True,
               help="Leave 0 (auto) unless a firewall/NAT requires a predictable data port."),
-        Field("bind", "Bind address", "text", default="", advanced=True,
-              help="Leave blank. Discovery already listens on every network interface; this only pins the data source address."),
+        Field("bind", "Bind address (PC)", "text", default="",
+              help="If games list but fail to launch, use the PC IP connected to your PS2. "
+                   "Blank = automatic. Stop/start UDPFS to apply changes."),
         Field("tx_delay_ms", "TX delay (ms)", "text", default="0",
               advanced=True,
               help="Optional pacing delay between UDP transmissions in milliseconds."),

--- a/tests/test_gui_layout.py
+++ b/tests/test_gui_layout.py
@@ -156,7 +156,9 @@ class LauncherLayout(unittest.TestCase):
         self.app.nb.select(self.app.terminal_tab)
         self.resize(1024, 640)
         short = self.app.terminal.winfo_height()
-        self.resize(1024, 1000)
+        # A new visible field can make the page taller than 1000px. Only height
+        # beyond its natural size is spare space that should grow the terminal.
+        self.resize(1024, max(1000, self.app.content.winfo_reqheight() + 100))
         self.assertGreater(self.app.terminal.winfo_height(), short + 50,
                            "spare height should go to the log, not to dead page")
 

--- a/tests/test_linux_parity.py
+++ b/tests/test_linux_parity.py
@@ -137,12 +137,12 @@ class ServerRecommendationTests(unittest.TestCase):
         # The classic; not badged either way so it doesn't read as second-class.
         self.assertEqual(servers.REGISTRY["smbv1"].recommendation, "")
 
-    def test_bind_help_says_you_need_not_set_it(self):
-        # The tester assumed he had to set 0.0.0.0; discovery is already all-iface.
+    def test_bind_help_explains_automatic_and_explicit_binding(self):
+        # Keep the automatic default clear while explaining the launch workaround.
         bind = next(f for f in servers.REGISTRY["udpfs"].fields if f.key == "bind")
-        self.assertIn("Leave blank", bind.help)
-        self.assertIn("every network interface", bind.help)
-        self.assertIn("source address", bind.help)
+        self.assertIn("Blank = automatic", bind.help)
+        self.assertIn("PC IP connected to your PS2", bind.help)
+        self.assertIn("Stop/start UDPFS", bind.help)
 
 
 class WindowsOnlyFieldTests(unittest.TestCase):

--- a/tests/test_udpfs_bind_control.py
+++ b/tests/test_udpfs_bind_control.py
@@ -1,0 +1,63 @@
+"""The visible UDPFS bind control must reach the existing --bind launch path."""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from launcher.servers import UDPFS
+
+
+class UdpfsBindControlTests(unittest.TestCase):
+    def setUp(self):
+        try:
+            import tkinter as tk
+        except ImportError:
+            self.skipTest("no tkinter")
+        try:
+            self.root = tk.Tk()
+        except tk.TclError:
+            self.skipTest("no display")
+        self.addCleanup(self.root.destroy)
+        self.root.withdraw()
+
+        from launcher.gui import ServerCard
+
+        self.ip = tk.StringVar(value="192.168.0.2")
+        self.saved = []
+        self.app = SimpleNamespace(
+            current_ip=self.ip.get,
+            _save=mock.Mock(side_effect=lambda: self.saved.append(self.card.values())),
+        )
+        self.card = ServerCard(self.root, self.app, UDPFS)
+        self.card.set_values({"root_dir": "/games", "bind": "192.168.0.3:41233"})
+
+    def test_visible_button_copies_current_selection_into_saved_launch_args(self):
+        # Direct children are on the main card, not in the hidden Advanced frame.
+        buttons = [w for w in self.card.winfo_children()
+                   if w.winfo_class() == "TButton" and w.cget("text") == "Use LAN IP"]
+        self.assertEqual(len(buttons), 1)
+        self.assertFalse(next(f for f in UDPFS.fields if f.key == "bind").advanced)
+
+        # Selecting another LAN IP does not silently replace a saved explicit bind.
+        self.ip.set(" 192.168.0.4 ")
+        self.assertEqual(self.card.values()["bind"], "192.168.0.3:41233")
+        buttons[0].invoke()
+        self.app._save.assert_called_once_with()
+        self.assertEqual(self.saved[0]["bind"], "192.168.0.4")
+        argv = UDPFS.build_argv(self.saved[0])
+        self.assertEqual(argv[argv.index("--bind") + 1], "192.168.0.4")
+
+        self.card.vars["bind"].set("")
+        self.card.set_values(self.saved[0])
+        self.assertEqual(self.card.values()["bind"], "192.168.0.4")
+
+    def test_manual_address_port_and_blank_keep_existing_behavior(self):
+        argv = UDPFS.build_argv(self.card.values())
+        self.assertEqual(argv[argv.index("--bind") + 1], "192.168.0.3:41233")
+        self.card.vars["bind"].set("")
+        self.assertNotIn("--bind", UDPFS.build_argv(self.card.values()))
+        self.app._save.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A reported UDPFS setup could browse games but failed at Neutrino launch until the user explicitly bound udpfsd's data connection. PS2-Servers already supports the equivalent `--bind`, but hid the control under Advanced and told users to leave it blank. The prominent LAN IP selector only supplies setup hints.

Show **Bind address (PC)** on the main UDPFS panel and add **Use LAN IP** to copy and save the selected PC address into the existing bind setting. Explain when to use it and that UDPFS must be stopped and started to apply the change. Manual address/port values and blank automatic binding retain their existing behavior.

This follows [udpfsd's documented interface-binding workaround](https://github.com/pcm720/udpfsd/blob/v0.1.7/README.md#troubleshooting). Production changes are limited to 11 added and 2 removed lines in the launcher. The layout test now requests height beyond the page's measured natural size, since the newly visible control can put that size above its previous fixed 1000px test target.

Validation:
- CI passed on commit `5f6008ab`: full Linux suite (615 tests, 25 display-dependent skips), protocol conformance/self-tests, bundled libchdr build, Edge/Core tests, all 16 Edge targets, and CodeQL.
- The full Windows suite ran 626 tests with five skips; its only failure was the existing POSIX-shell check passing a Windows temporary path to WSL Bash. That check passes in Linux CI.
- 86 focused configuration, packaging, protocol-selector and GUI tests ran successfully; four window-geometry checks skipped where the window manager did not honor the requested geometry.
- Actual Tk button -> saved values -> launch arguments -> bound data socket -> canonical INFORM source verified over local UDP sockets.
- Python compilation, release-compliance check and `git diff --check` passed.
- Hardware evidence is the user's successful explicit-bind test with udpfsd. The new PS2-Servers UI has not yet been retested on that console.

